### PR TITLE
BuildInfoRecorder can upload "stale" POM when using maven-shade plugin

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -440,11 +440,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             if (!isPomProject(moduleArtifact)) {
                 for (ArtifactMetadata metadata : moduleArtifact.getMetadataList()) {
                     if (metadata instanceof ProjectArtifactMetadata) {
-                        Model model = project.getModel();
-                        File pomFile = null;
-                        if (model != null) {
-                            pomFile = model.getPomFile();
-                        }
+                        File pomFile = ((ProjectArtifactMetadata) metadata).getFile();
                         artifactBuilder.type("pom");
                         String pomFileName = StringUtils.removeEnd(artifactName, artifactExtension) + "pom";
                         artifactBuilder.name(pomFileName);
@@ -455,6 +451,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
                                     artifactId, artifactVersion,
                                     artifactClassifier, "pom");
                         }
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
When using maven-shade plugin, the plugin tends to create a dependency-reduced-pom.xml, which basically contains a slightly modified version of the original POM (dependencies removed, or modified to have provided scope).
When using Jenkins in conjuction with artifactory-plugin suddenly the dependency-reduced-pom.xml starts to get ignored, and always the original POM gets deployed to Artifactory.

After _hours_ of debugging I think I've nailed it down to BuildInfoRecorder#addArtifactsToCurrentModule where the deployable artifact would refer to an incorrect POM (rather than using the correct POM from the ProjectArtifactMetadata), changing that seems to resolve the problem for me. I've ran tests with single module and multi module project and the uploaded POMs looked okay as far as I could see.
