### PR TITLE
ExtractorMojoHelper - {a} expression is also resolved, default is null i...

### DIFF
--- a/build-info-extractor-maven3-plugin/src/main/groovy/org/jfrog/build/extractor/maven/plugin/ExtractorMojoHelper.groovy
+++ b/build-info-extractor-maven3-plugin/src/main/groovy/org/jfrog/build/extractor/maven/plugin/ExtractorMojoHelper.groovy
@@ -186,7 +186,7 @@ class ExtractorMojoHelper
      */
     String updateValue( String value )
     {
-        if ( ! value?.contains( '{' )){ return value?.trim() }
+        if ( ! value?.with{ contains( '{' ) && contains( '}' ) }){ return value?.trim() }
 
         value.trim().replaceAll( /(\$?\{)([^}]+)(\})/ ){
 


### PR DESCRIPTION
...n this case. If expression isn't resolved it is returned as-is.
