### PR TITLE
Fixed compilation errors in build-info-client integration tests; added tests

### DIFF
--- a/build-info-client/src/it/java/org/jfrog/build/api/dependency/BuildPatternArtifactsSerializationTest.java
+++ b/build-info-client/src/it/java/org/jfrog/build/api/dependency/BuildPatternArtifactsSerializationTest.java
@@ -34,12 +34,12 @@ public class BuildPatternArtifactsSerializationTest {
     public void testBuildOutputsSerialisation() throws Exception {
 
         PatternResult bobZips = new PatternResult();
-        bobZips.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").url("lib-releases-local:bob/aaa.zip").size(4354354).lastModifiedDate(new Date()).sha1("sha1").build());
-        bobZips.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").url("lib-releases-local:bob/yyy/bbb.zip").size(78654).lastModifiedDate(new Date()).sha1("sha1").build());
+        bobZips.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").uri("lib-releases-local:bob/aaa.zip").size(4354354).lastModifiedDate(new Date()).sha1("sha1").build());
+        bobZips.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").uri("lib-releases-local:bob/yyy/bbb.zip").size(78654).lastModifiedDate(new Date()).sha1("sha1").build());
 
         PatternResult prod = new PatternResult();
-        prod.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").url("lib-releases-local:mmm.jar").size(345654).lastModifiedDate(new Date()).sha1("sha1").build());
-        prod.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").url("lib-releases-local:kkk/lll.war").size(456546743).lastModifiedDate(new Date()).sha1("sha1").build());
+        prod.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").uri("lib-releases-local:mmm.jar").size(345654).lastModifiedDate(new Date()).sha1("sha1").build());
+        prod.addArtifact(new PatternArtifactBuilder().artifactoryUrl("http://localhost:8080/artifactory").uri("lib-releases-local:kkk/lll.war").size(456546743).lastModifiedDate(new Date()).sha1("sha1").build());
 
 
         BuildPatternArtifacts buildPatternArtifacts = new BuildPatternArtifactsBuilder().buildName("foo").buildNumber("123")

--- a/build.gradle
+++ b/build.gradle
@@ -269,12 +269,23 @@ project('build-info-client') {
         }
         compile "org.codehaus.jackson:jackson-mapper-asl:1.9.12"
         compile "commons-codec:commons-codec:1.8"
+        testCompile "com.thoughtworks:web-stub:1.1.0"
     }
     sourceSets {
         main {
             resources {
                 srcDir 'src/main/filtered-resources'
             }
+        }
+
+        test {
+           java {
+              srcDir 'src/it/java'
+           }
+
+           resources {
+              srcDir 'src/it/resources'
+           }
         }
     }
     processResources {//???
@@ -284,6 +295,9 @@ project('build-info-client') {
         }
     }
 
+    repositories {
+        mavenCentral()
+    }
 }
 
 project('build-info-extractor') {


### PR DESCRIPTION
I noticed that integration tests in `build-info-client` are not getting compiled and run, as part of the usual build. I need to run those tests, since I would like to change the `ArtifactoryBuildInfoClient.deployArtifact(DeployDetails)` to return the metadata sent in the Artifactory REST response.

This is related to https://github.com/JFrogDev/build-info/issues/31 
