### PR TITLE
conf to record immediate deps only, no transitive

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -429,7 +429,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             return;
         }
 
-        mergeProjectDependencies(project.getArtifacts());
+        mergeProjectDependencies(conf.publisher.isRecordImmediateDependencies() ? project.getDependencyArtifacts() : project.getArtifacts());
     }
 
     /**

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -379,6 +379,14 @@ public class ArtifactoryClientConfiguration {
             setBooleanValue(RECORD_ALL_DEPENDENCIES, enabled);
         }
 
+        public boolean isRecordImmediateDependencies() {
+            return getBooleanValue(RECORD_IMMEDIATE_DEPENDENCIES, false);
+        }
+
+        public void setRecordImmediateDependencies(Boolean enabled) {
+            setBooleanValue(RECORD_IMMEDIATE_DEPENDENCIES, enabled);
+        }
+
         public String getIncludePatterns() {
             return getStringValue(INCLUDE_PATTERNS);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -40,6 +40,7 @@ public interface ClientConfigurationFields {
     String PUBLISH_ARTIFACTS = "artifacts";
     String PUBLISH_BUILD_INFO = "buildInfo";
     String RECORD_ALL_DEPENDENCIES = "record.all.dependencies";
+    String RECORD_IMMEDIATE_DEPENDENCIES = "record.immediate.dependencies";
     String SNAPSHOT_REPO_KEY = "snapshot.repoKey";
     String MATRIX = "matrix";
     String ARTIFACT_SPECS = "artifactSpecs";


### PR DESCRIPTION
We need this in our company b/c we use artifactory to capture "builds" of a particular pom that enumerates versions of various other internal projects as dependencies. We need to be able to grab this list from the artifactory builds API without the transitive dependencies of those projects being included.