### PR TITLE
[BI-445] Support standard Maven settings to retrieve publisher credentials

### DIFF
--- a/build-info-extractor-maven3-plugin/src/main/groovy/org/jfrog/build/extractor/maven/plugin/PublishMojo.groovy
+++ b/build-info-extractor-maven3-plugin/src/main/groovy/org/jfrog/build/extractor/maven/plugin/PublishMojo.groovy
@@ -12,6 +12,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.project.MavenProject
+import org.apache.maven.settings.Settings
 import org.codehaus.gmaven.mojo.GroovyMojo
 import org.gcontracts.annotations.Requires
 import org.jfrog.build.api.BuildInfoProperties
@@ -135,9 +136,20 @@ class PublishMojo extends GroovyMojo
      * Completes various configuration settings.
      */
     @SuppressWarnings([ 'GroovyAccessibility' ])
-    @Requires({ buildInfo && artifactory && session && project })
+    @Requires({ publisher && buildInfo && artifactory && session && project })
     private void completeConfig ()
     {
+        String serverId = publisher.serverId;
+        Settings settings = session.settings;
+        if (serverId != null && settings.getServer(serverId) != null) {
+            if (publisher.getUsername() == null) {
+                publisher.setUsername(settings.getServer(serverId).getUsername())
+            }
+            if (publisher.getPassword() == null) {
+                publisher.setPassword(settings.getServer(serverId).getPassword())
+            }
+        }
+        
         final format                = { Date d  -> new SimpleDateFormat( 'yyyy-MM-dd\'T\'HH:mm:ss.SSSZ' ).format( d ) } // 2013-06-23T18\:38\:37.597+0200
         buildInfo.buildTimestamp    = session.startTime.time as String
         buildInfo.buildStarted      = format( session.startTime )

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -319,6 +319,14 @@ public class ArtifactoryClientConfiguration {
             setStringValue(CONTEXT_URL, contextUrl);
         }
 
+        public String getServerId() {
+            return getStringValue(SERVER_ID);
+        }
+
+        public void setServerId(String serverId) {
+            setStringValue(SERVER_ID, serverId);
+        }
+
         public String getSnapshotRepoKey() {
             return getStringValue(SNAPSHOT_REPO_KEY);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -48,4 +48,5 @@ public interface ClientConfigurationFields {
     String FILTER_EXCLUDED_ARTIFACTS_FROM_BUILD = "filterExcludedArtifactsFromBuild";
     String EVEN_UNSTABLE = "unstable";
     String CONTEXT_URL = "contextUrl";
+    String SERVER_ID = "serverId";
 }


### PR DESCRIPTION
Add a serverId parameter used to lookup credentials in maven settings if not specified by the user in pom.xml

I've already accept the JFrog CLA (adobe sign)