### PR TITLE
Better logging of what went wrong.

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
@@ -245,10 +245,16 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient {
      */
     public void sendBuildInfo(Build buildInfo) throws IOException {
         log.debug("Sending build info: " + buildInfo);
-        try {
-            sendBuildInfo(buildInfoToJsonString(buildInfo));
+		try {
+            String buildInfoJsonString = buildInfoToJsonString(buildInfo);
         } catch (Exception e) {
             log.error("Could not build the build-info object.", e);
+            throw new IOException("Could not build the build-info object: " + e.getMessage());
+        }
+        try {
+            sendBuildInfo(buildInfoJsonString);
+        } catch (Exception e) {
+            log.error("Could not publish the build-info object.", e);
             throw new IOException("Could not publish build-info: " + e.getMessage());
         }
         String url = artifactoryUrl +


### PR DESCRIPTION
Every now and then I get the "Could not build the build-info object" error in my Jenkins pipeline. However I actually suspect that it is not the building-part that is the problem but rather the publishing. I have no way of telling because the logging will default to "Could not build the build-info object" even if an exception occurs in sendBuildInfo.