### PR TITLE
Remove groovy from compile classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,6 @@ project('build-info-extractor-gradle') {
     println description
     dependencies {
         compile gradleApi()
-        compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.12'
         compile fileTree(dir: "${gradle.gradleHomeDir}/lib/plugins", include: '**/*.jar') //workaround for GRADLE-1699
         provided "org.codehaus.plexus:plexus-component-annotations:1.5.5",
                 "com.google.code.findbugs:jsr305:1.3.9"


### PR DESCRIPTION
There already is

```
compile gradleApi()
```

That makes the presence of `groovy-all` in the compile classpath
redundant.

Also it causes module version conflicts in newer versions of gradle
since gradle brings in a newer version of groovy.

Fixes #180 