### PR TITLE
BI-437 - Fix download artifacts with build in file spec

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/search/AqlSearchResult.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/search/AqlSearchResult.java
@@ -1,9 +1,12 @@
 package org.jfrog.build.api.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class AqlSearchResult {
@@ -24,7 +27,7 @@ public class AqlSearchResult {
         private String actualSha1;
         private String actualMd5;
         private String[] virtualRepos = new String[]{};
-
+        private HashMap<String,String> properties = new HashMap<>();
 
         public void setRepo(String repo) {
             this.repo = repo;
@@ -51,6 +54,15 @@ public class AqlSearchResult {
         @JsonProperty("virtual_repos")
         public void setVirtualRepos(String[] virtualRepos) {
             this.virtualRepos = virtualRepos;
+        }
+
+        @JsonProperty("properties")
+        public void setProperties(List<Property> propertiesList) {
+            for (Property property : propertiesList) {
+                if (StringUtils.isNotEmpty(property.key)) {
+                    properties.put(property.key,property.value);
+                }
+            }
         }
 
         public String getRepo() {
@@ -80,5 +92,42 @@ public class AqlSearchResult {
             return virtualRepos;
         }
 
+        @JsonProperty("properties")
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public String getBuildName() {
+            return properties.get("build.name");
+        }
+
+        public String getBuildNumber() {
+            return properties.get("build.number");
+        }
+    }
+
+    public static class Property {
+        private String key;
+        private String value;
+
+        @JsonProperty("key")
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        @JsonProperty("key")
+        public String getkey() {
+            return key;
+        }
+
+        @JsonProperty("value")
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @JsonProperty("value")
+        public String getValue() {
+            return value;
+        }
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/AqlDependenciesHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/AqlDependenciesHelper.java
@@ -1,6 +1,8 @@
 package org.jfrog.build.extractor.clientConfiguration.util;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.dependency.DownloadableArtifact;
@@ -9,9 +11,7 @@ import org.jfrog.build.api.search.AqlSearchResult;
 import org.jfrog.build.api.util.Log;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Created by Tamirh on 25/04/2016.
@@ -41,7 +41,30 @@ public class AqlDependenciesHelper implements DependenciesHelper {
         return downloadDependencies(downloadableArtifacts);
     }
 
-    public List<Dependency> downloadDependencies(Set<DownloadableArtifact> downloadableArtifacts) throws IOException {
+    Set<DownloadableArtifact> collectArtifactsToDownload(String aqlBody, boolean explode) throws IOException {
+        String aql = buildQuery(aqlBody);
+        List<AqlSearchResult.SearchEntry> searchResults = aqlSearch(aql);
+        if (StringUtils.isNotBlank(buildName) && searchResults.size()>0) {
+            searchResults=filterAqlSearchResultsByBuild(searchResults);
+        }
+        return fetchDownloadableArtifactsFromResult(searchResults,explode);
+    }
+
+    public List<Dependency> retrievePublishedDependenciesByBuildOnly(boolean explode) throws IOException {
+        Set<DownloadableArtifact> downloadableArtifacts = collectArtifactsToDownloadByBuildOnly(explode);
+        return downloadDependencies(downloadableArtifacts);
+    }
+
+    private Set<DownloadableArtifact> collectArtifactsToDownloadByBuildOnly(boolean explode) throws IOException {
+        String aql = createAqlBodyForBuild();
+        aql = buildQuery(aql);
+        List<AqlSearchResult.SearchEntry> searchResults = aqlSearch(aql);
+        Map<String,Boolean> buildSha1Map = extractSha1FromAqlResponse(searchResults);
+        searchResults = filterBuildAqlSearchResults(searchResults,buildSha1Map);
+        return fetchDownloadableArtifactsFromResult(searchResults,explode);
+    }
+
+    List<Dependency> downloadDependencies(Set<DownloadableArtifact> downloadableArtifacts) throws IOException {
         log.info("Beginning to resolve Build Info published dependencies.");
         List<Dependency> dependencies = downloader.download(downloadableArtifacts);
         log.info("Finished resolving Build Info published dependencies.");
@@ -53,14 +76,112 @@ public class AqlDependenciesHelper implements DependenciesHelper {
         this.downloader.setFlatDownload(flat);
     }
 
-    public Set<DownloadableArtifact> collectArtifactsToDownload(String aql, boolean explode) throws IOException {
-        Set<DownloadableArtifact> downloadableArtifacts = Sets.newHashSet();
-        if (StringUtils.isNotBlank(buildName)) {
-            aql = addBuildToQuery(aql);
+    private List<AqlSearchResult.SearchEntry> filterAqlSearchResultsByBuild(List<AqlSearchResult.SearchEntry> searchResults) throws IOException {
+        Map<String,Boolean> buildArtifactsSha1 = fetchBuildArtifactsSha1();
+        return filterBuildAqlSearchResults(searchResults,buildArtifactsSha1);
+    }
+
+    /**
+     * Filter search results by the following priorities:
+     * 1st priority: Match {Sha1, build name, build number}
+     * 2nd priority: Match {Sha1, build name}
+     * 3rd priority: Match {Sha1}
+     */
+    private List<AqlSearchResult.SearchEntry> filterBuildAqlSearchResults(List<AqlSearchResult.SearchEntry> itemsToFilter, Map<String,Boolean> buildArtifactsSha1){
+        List<AqlSearchResult.SearchEntry> filteredResults = new ArrayList<>();
+        Map<String,List<AqlSearchResult.SearchEntry>> firstPriority = new HashMap<>();
+        Map<String,List<AqlSearchResult.SearchEntry>> secondPriority = new HashMap<>();
+        Map<String,List<AqlSearchResult.SearchEntry>> thirdPriority = new HashMap<>();
+        boolean isBuildNameMatch;
+        boolean isBuildNumberMatch;
+
+        // Step 1 - Populate 3 priorities mappings.
+        for (AqlSearchResult.SearchEntry item:itemsToFilter) {
+            if(!buildArtifactsSha1.containsKey(item.getActualSha1())){
+                continue;
+            }
+
+            isBuildNameMatch = item.getBuildName().equals(this.buildName);
+            isBuildNumberMatch = item.getBuildNumber().equals(this.buildNumber);
+            if (isBuildNameMatch && isBuildNumberMatch) {
+                firstPriority = addToListInMap(firstPriority,item);
+                continue;
+            }
+            if (isBuildNameMatch) {
+                secondPriority = addToListInMap(secondPriority,item);
+                continue;
+            }
+            thirdPriority = addToListInMap(thirdPriority,item);
         }
-        aql = "items.find(" + aql + ")";
+
+        // Step 2 - Append mappings to the final results, respectively.
+        for (Map.Entry<String,Boolean> entry : buildArtifactsSha1.entrySet()) {
+            String shaToMatch = entry.getKey();
+            if (firstPriority.containsKey(shaToMatch)) {
+                filteredResults.addAll(firstPriority.get(shaToMatch));
+            } else if (secondPriority.containsKey(shaToMatch)) {
+                filteredResults.addAll(secondPriority.get(shaToMatch));
+            }  else if (thirdPriority.containsKey(shaToMatch)) {
+                filteredResults.addAll(thirdPriority.get(shaToMatch));
+            }
+        }
+        return filteredResults;
+    }
+
+    private Map<String,List<AqlSearchResult.SearchEntry>> addToListInMap(
+            Map<String,List<AqlSearchResult.SearchEntry>> map, AqlSearchResult.SearchEntry item) {
+        List<AqlSearchResult.SearchEntry> curList=map.get(item.getActualSha1());
+        if (curList==null) curList = new ArrayList<>();
+        curList.add(item);
+        map.put(item.getActualSha1(),curList);
+        return map;
+    }
+
+    private Map<String,Boolean> extractSha1FromAqlResponse(List<AqlSearchResult.SearchEntry> searchResults) {
+        Map<String,Boolean> resultsMap = new HashMap<>();
+        searchResults.forEach((result)-> resultsMap.put(result.getActualSha1(),true));
+        return resultsMap;
+    }
+
+    private Map<String,Boolean> fetchBuildArtifactsSha1() throws  IOException {
+        String buildQuery = createAqlQueryForBuild(buildIncludeQueryPart(Arrays.asList("name", "repo", "path", "actual_sha1")));
+        return extractSha1FromAqlResponse(aqlSearch(buildQuery));
+    }
+
+    private String createAqlQueryForBuild(String includeQueryPart) {
+        return String.format("items.find(%s)%s",createAqlBodyForBuild(),includeQueryPart);
+    }
+
+    private String createAqlBodyForBuild() {
+        return String.format("{\"artifact.module.build.name\": \"%s\",\"artifact.module.build.number\": \"%s\"}",buildName,buildNumber);
+    }
+
+    private List<AqlSearchResult.SearchEntry> aqlSearch(String aql) throws IOException {
         AqlSearchResult aqlSearchResult = downloader.getClient().searchArtifactsByAql(aql);
-        List<AqlSearchResult.SearchEntry> searchResults = aqlSearchResult.getResults();
+        return aqlSearchResult.getResults();
+    }
+
+    private String buildQuery(String aql){
+        aql = "items.find(" + aql + ")";
+        aql += buildIncludeQueryPart(getQueryReturnFields());
+        return aql;
+    }
+
+    private String buildIncludeQueryPart(List<String> fieldsToInclude) {
+        return ".include(" + StringUtils.join(prepareFieldsForQuery(fieldsToInclude),',') + ")";
+    }
+
+    private List<String> prepareFieldsForQuery(List<String> fields) {
+        fields.forEach( (field) -> fields.set(fields.indexOf(field),'"' + field + '"'));
+        return fields;
+    }
+
+    private List<String> getQueryReturnFields() {
+        return Arrays.asList("name", "repo", "path", "actual_md5", "actual_sha1", "size", "type", "property");
+    }
+
+    private Set<DownloadableArtifact> fetchDownloadableArtifactsFromResult(List<AqlSearchResult.SearchEntry> searchResults, boolean explode) {
+        Set<DownloadableArtifact> downloadableArtifacts = Sets.newHashSet();
         for (AqlSearchResult.SearchEntry searchEntry : searchResults) {
             String path = searchEntry.getPath().equals(".") ? "" : searchEntry.getPath() + "/";
             DownloadableArtifact downloadableArtifact = new DownloadableArtifact(StringUtils.stripEnd(artifactoryUrl, "/") + "/" +
@@ -69,24 +190,6 @@ public class AqlDependenciesHelper implements DependenciesHelper {
             downloadableArtifacts.add(downloadableArtifact);
         }
         return downloadableArtifacts;
-    }
-
-    private String addBuildToQuery(String aql) {
-        return "{" +
-                "\"$and\": [" +
-                    aql + "," +
-                    "{" +
-                        "\"artifact.module.build.name\": {" +
-                            "\"$eq\": \"" + buildName + "\"" +
-                        "}" +
-                "}," +
-                "{" +
-                        "\"artifact.module.build.number\": {" +
-                            "\"$eq\": \"" + buildNumber + "\"" +
-                        "}" +
-                    "}" +
-                    "]" +
-                "}";
     }
 
     public void setArtifactoryUrl(String artifactoryUrl) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/BuildDependenciesHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/BuildDependenciesHelper.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 /**
  * Helper class for parsing build dependencies property.
- *
+ * Used only for legacy patterns in jenkins and bamboo.
  * @author Evgeny Goldin
  */
 public class BuildDependenciesHelper {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/FileSpec.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/FileSpec.java
@@ -1,5 +1,7 @@
 package org.jfrog.build.extractor.clientConfiguration.util.spec;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -17,6 +19,10 @@ public class FileSpec {
     private String build;
     private String explode;
     private String[] excludePatterns;
+    public static final String SPEC_TYPE_BUILD = "build";
+    public static final String SPEC_TYPE_PATTERN = "pattern";
+    public static final String SPEC_TYPE_AQL = "aql";
+
 
     public String getAql() throws IOException {
         if (aql != null) {
@@ -123,5 +129,16 @@ public class FileSpec {
                 ", explode='" + explode + '\'' +
                 ", excludePatterns='" + Arrays.toString(excludePatterns) + '\'' +
                 '}';
+    }
+
+    public String getSpecType() throws IOException {
+        if (StringUtils.isNotEmpty(this.build) && StringUtils.isEmpty(getAql()) && (StringUtils.isEmpty(this.pattern) || this.pattern.equals("*"))) {
+            return SPEC_TYPE_BUILD;
+        } else if (StringUtils.isNotEmpty(this.pattern)) {
+            return SPEC_TYPE_PATTERN;
+        } else if (StringUtils.isNotEmpty(getAql())) {
+            return SPEC_TYPE_AQL;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
1. When downloading artifacts with "build" in file spec, only artifacts from that build will be downloaded (Added filtering by build name, build number and sha1).
2. Added an option to use a file spec with only "build", without "aql" and "pattern".