### PR TITLE
checksum-retry

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
@@ -131,8 +131,7 @@ public class PreemptiveHttpClient {
         // Add as the first request interceptor
         builder.addInterceptorFirst(new PreemptiveAuth());
 
-        int retryCount = connectionRetries < 0 ? ArtifactoryHttpClient.DEFAULT_CONNECTION_RETRY : connectionRetries;
-        builder.setRetryHandler(new PreemptiveRetryHandler(retryCount));
+        builder.disableAutomaticRetries();
         builder.setServiceUnavailableRetryStrategy(new PreemptiveRetryStrategy());
         builder.setRedirectStrategy(new PreemptiveRedirectStrategy());
 


### PR DESCRIPTION
These two patches make upload a bit more resilient against networking issues:

* We see uploads failing with a 404, but eventually they succeed with the patch
* we also upload files that are symlinks, and without the 2nd patch this plugin will try to do a full upload of all the files, without retrying the checksum deploy in case of network issues

This is probably not the best way to solve this, open for better suggestions :-)