### PR TITLE
Fix #138 delay resolving of publication artifacts.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip


### PR DESCRIPTION
The artifacts, dependency and other metadata was previously resolved
when the publication was specified to artifactory.
This can cause missing and/or incomplete pom files being uploaded to
artifactory.