### PR TITLE
Remove wrapper task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -536,7 +536,3 @@ idea {
         }
     }
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
-}


### PR DESCRIPTION
With newer versions of gradle, that task is already available. This causes errors in building.

Also, the wrapper currently uses 4.8 whereas this task tried to use 2.4