### PR TITLE
Allow parallel upload of artifacts

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
@@ -60,6 +60,7 @@ public class BuildDeploymentHelper {
         Set<DeployDetails> deployableArtifacts = prepareDeployableArtifacts(build, deployableArtifactBuilders);
 
         logger.debug("Build Info Recorder: deploy artifacts: " + clientConf.publisher.isPublishArtifacts());
+        logger.debug("Build Info Recorder: publication fork count: " + clientConf.publisher.getPublishForkCount());
         logger.debug("Build Info Recorder: publish build info: " + clientConf.publisher.isPublishBuildInfo());
 
         File aggregateDirectory;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -367,6 +367,14 @@ public class ArtifactoryClientConfiguration {
             return getBooleanValue(PUBLISH_BUILD_INFO, true);
         }
 
+        public void setPublishForkCount(int value) {
+            setIntegerValue(PUBLISH_FORK_COUNT, value);
+        }
+
+        public Integer getPublishForkCount() {
+            return getIntegerValue(PUBLISH_FORK_COUNT, 8);
+        }
+
         public boolean isRecordAllDependencies() {
             return getBooleanValue(RECORD_ALL_DEPENDENCIES, false);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -39,6 +39,7 @@ public interface ClientConfigurationFields {
     String COPY_AGGREGATED_ARTIFACTS = "copy.aggregated"; // Boolean - whether or not aggregated artifacts should be published
     String PUBLISH_ARTIFACTS = "artifacts";
     String PUBLISH_BUILD_INFO = "buildInfo";
+    String PUBLISH_FORK_COUNT = "forkCount";
     String RECORD_ALL_DEPENDENCIES = "record.all.dependencies";
     String SNAPSHOT_REPO_KEY = "snapshot.repoKey";
     String MATRIX = "matrix";


### PR DESCRIPTION
While helping customers and OSS projects to optimize the performance of their build, we (Gradle, Inc.) noticed that the `artifactoryDeploy` task was very long to execute.
This is because uploads are executing serially.

This PR allows to upload artifacts in parallel.
The number of forked threads defaults to 8, but can be customized using the `publishForkCount` in the `artifactory{}` DSL extension.

See for instance the net results in the https://github.com/spring-projects/spring-framework OSS project:

- before this PR:
  - https://ge.spring.io/s/ju7kyr3p4m62c/timeline?task=jb2ueukhvhszg
  - `artifactoryDeploy` needs 1 minute to perform 89 uploads

- with this PR:
  - https://ge.spring.io/s/e65kj475jjspk/timeline?task=jb2ueukhvhszg
  - `artifactoryDeploy` needs 7 seconds to perform 89 uploads