### PR TITLE
ArtifactoryTask: Add proper gradle annotations to avoid 6.x warnings

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -48,37 +48,19 @@ public class ArtifactoryTask extends DefaultTask {
     private static final Logger log = Logging.getLogger(ArtifactoryTask.class);
     private final Map<String, Boolean> flags = Maps.newHashMap();
 
-    @InputFile
-    @Optional
     public File ivyDescriptor;
 
-    @InputFile
-    @Optional
     public File mavenDescriptor;
 
-    @InputFiles
-    @Optional
     public Set<Configuration> publishConfigs = Sets.newHashSet();
 
-    @Input
-    @Optional
     public Set<IvyPublication> ivyPublications = Sets.newHashSet();
 
-    @Input
-    @Optional
     public Set<MavenPublication> mavenPublications = Sets.newHashSet();
 
     private boolean addArchivesConfigToTask = false;
     public TaskHelperConfigurations helperConfigurations = new TaskHelperConfigurations(this);
     public TaskHelperPublications helperPublications = new TaskHelperPublications(this);
-
-    @Input
-    Set<Publication> getPublications() {
-        Set<Publication> publications = new HashSet<Publication>();
-        publications.addAll(ivyPublications);
-        publications.addAll(mavenPublications);
-        return publications;
-    }
 
     @TaskAction
     public void taskAction() throws IOException {
@@ -128,15 +110,40 @@ public class ArtifactoryTask extends DefaultTask {
     }
 
     /** Getters **/
+    @Input
+    Set<Publication> getPublications() {
+        Set<Publication> publications = new HashSet<Publication>();
+        publications.addAll(ivyPublications);
+        publications.addAll(mavenPublications);
+        return publications;
+    }
 
+    @InputFiles
+    @Optional
+    public Set<Configuration> getPublishConfigs() {
+        return publishConfigs;
+    }
+
+    @Input
+    @Optional
     public Set<IvyPublication> getIvyPublications() {
         return ivyPublications;
     }
 
+    @Input
+    @Optional
+    public Set<MavenPublication> getMavenPublications() {
+        return mavenPublications;
+    }
+
+    @InputFile
+    @Optional
     public File getIvyDescriptor() {
         return ivyDescriptor;
     }
 
+    @InputFile
+    @Optional
     public File getMavenDescriptor() {
         return mavenDescriptor;
     }
@@ -235,6 +242,7 @@ public class ArtifactoryTask extends DefaultTask {
         finalizedBy(deployTask);
     }
 
+    @Internal
     public boolean isEvaluated() {
         return evaluated;
     }
@@ -263,6 +271,8 @@ public class ArtifactoryTask extends DefaultTask {
         }
     }
 
+    @Input
+    @Optional
     public Set<GradleDeployDetails> getDeployDetails() {
         return deployDetails;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -334,6 +334,7 @@ project('build-info-extractor-ivy') {
 
 project('build-info-extractor-gradle') {
     apply plugin: 'groovy'
+    apply plugin: 'java-gradle-plugin'
     description = 'JFrog Build-Info Gradle Extractor'
 
     println description


### PR DESCRIPTION
Hi

This pull request fixes the following warnings when using Gradle 6.x:

```
> Task :build-info-extractor-gradle:validatePlugins FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':build-info-extractor-gradle:validatePlugins'.
> Plugin validation failed. See https://docs.gradle.org/6.1-20191004133052+0000/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Type 'ArtifactoryTask': field 'mavenPublications' without corresponding getter has been annotated with @Input, @Optional.
   > Warning: Type 'ArtifactoryTask': field 'publishConfigs' without corresponding getter has been annotated with @InputFiles, @Optional.
   > Warning: Type 'ArtifactoryTask': property 'deployDetails' is not annotated with an input or output annotation.
   > Warning: Type 'ArtifactoryTask': property 'evaluated' is not annotated with an input or output annotation.

``` 

It would be great if we could get this one merged soon :)

cc / @ljacomet 