### PR TITLE
Gradle - Remove 'The configuration was resolved without accessing the project in a safe manner' warning

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -372,7 +372,7 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
                 log.info("Artifacts for configuration '{}' were not all resolved, skipping", configuration.getName());
                 continue;
             }
-            ResolvedConfiguration resolvedConfiguration = configuration.getResolvedConfiguration();
+            ResolvedConfiguration resolvedConfiguration = getResolvedConfiguration(project, configuration);
             Set<ResolvedArtifact> resolvedArtifactSet = resolvedConfiguration.getResolvedArtifacts();
             for (final ResolvedArtifact artifact : resolvedArtifactSet) {
                 File file = artifact.getFile();
@@ -408,6 +408,16 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
             }
         }
         return dependencies;
+    }
+
+    private ResolvedConfiguration getResolvedConfiguration(Project project, Configuration configuration) {
+        try {
+            // Gradle 5.0 and above:
+            return ((ProjectInternal) project).getMutationState().withMutableState(configuration::getResolvedConfiguration);
+        } catch (NoSuchMethodError error) {
+            // Compatibility with older versions of Gradle:
+            return configuration.getResolvedConfiguration();
+        }
     }
 
     private class ProjectPredicate implements Predicate<GradleDeployDetails> {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -31,26 +31,8 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskState;
-import org.jfrog.build.api.Agent;
-import org.jfrog.build.api.Artifact;
-import org.jfrog.build.api.BlackDuckProperties;
-import org.jfrog.build.api.Build;
-import org.jfrog.build.api.BuildAgent;
-import org.jfrog.build.api.BuildType;
-import org.jfrog.build.api.Dependency;
-import org.jfrog.build.api.Governance;
-import org.jfrog.build.api.Issue;
-import org.jfrog.build.api.IssueTracker;
-import org.jfrog.build.api.Issues;
-import org.jfrog.build.api.LicenseControl;
-import org.jfrog.build.api.MatrixParameter;
-import org.jfrog.build.api.Module;
-import org.jfrog.build.api.Vcs;
-import org.jfrog.build.api.builder.ArtifactBuilder;
-import org.jfrog.build.api.builder.BuildInfoBuilder;
-import org.jfrog.build.api.builder.DependencyBuilder;
-import org.jfrog.build.api.builder.ModuleBuilder;
-import org.jfrog.build.api.builder.PromotionStatusBuilder;
+import org.jfrog.build.api.*;
+import org.jfrog.build.api.builder.*;
 import org.jfrog.build.api.release.Promotion;
 import org.jfrog.build.api.util.FileChecksumCalculator;
 import org.jfrog.build.extractor.BuildInfoExtractor;
@@ -67,17 +49,7 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.*;
 
 import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Lists.newArrayList;
@@ -97,13 +69,11 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
     private static final String MD5 = "md5";
     private final ArtifactoryClientConfiguration clientConf;
     private final Set<GradleDeployDetails> gradleDeployDetails;
-    private int publishForkCount;
 
     public GradleBuildInfoExtractor(ArtifactoryClientConfiguration clientConf,
-                                    Set<GradleDeployDetails> gradleDeployDetails, int publishForkCount) {
+                                    Set<GradleDeployDetails> gradleDeployDetails) {
         this.clientConf = clientConf;
         this.gradleDeployDetails = gradleDeployDetails;
-        this.publishForkCount = publishForkCount;
     }
 
     @Override
@@ -143,17 +113,12 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         bib.durationMillis(durationMillis);
 
         Set<Project> allProjects = rootProject.getAllprojects();
-        if (publishForkCount <= 1) {
-            allProjects.forEach(p -> addModule(bib, p));
-        } else {
-            try {
-                ExecutorService executor = Executors.newFixedThreadPool(publishForkCount);
-                CompletableFuture<Void> allModules = CompletableFuture.allOf(allProjects.stream()
-                        .map(project -> CompletableFuture.runAsync(() -> addModule(bib, project), executor))
-                        .toArray(CompletableFuture[]::new));
-                allModules.get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
+        for (Project project : allProjects) {
+            if(project.getState().getExecuted()) {
+                ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
+                if (buildInfoTask != null && buildInfoTask.hasModules()) {
+                    bib.addModule(extractModule(project));
+                }
             }
         }
         String parentName = clientConf.info.getParentBuildName();
@@ -267,15 +232,6 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
             build.setParentBuildId(parentName);
         }
         return build;
-    }
-
-    private void addModule(BuildInfoBuilder bib, Project project) {
-        if (project.getState().getExecuted()) {
-            ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
-            if (buildInfoTask != null && buildInfoTask.hasModules()) {
-                bib.addModule(extractModule(project));
-            }
-        }
     }
 
     private ArtifactoryTask getBuildInfoTask(Project project) {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -114,7 +114,7 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
 
         Set<Project> allProjects = rootProject.getAllprojects();
         for (Project project : allProjects) {
-            if(project.getState().getExecuted()) {
+            if (project.getState().getExecuted()) {
                 ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
                 if (buildInfoTask != null && buildInfoTask.hasModules()) {
                     bib.addModule(extractModule(project));

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -122,7 +122,7 @@ public class DeployTask extends DefaultTask {
                 configureProxy(accRoot, client);
                 configConnectionTimeout(accRoot, client);
                 configRetriesParams(accRoot, client);
-                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails, publishForkCount);
+                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails);
                 Build build = gbie.extract(getProject().getRootProject());
                 exportBuildInfo(build, getExportFile(accRoot));
                 if (isPublishBuildInfo(accRoot)) {


### PR DESCRIPTION
Handle this kind of warnings by using Gradle's Mutex mechanism:

> The configuration :services:webservice:annotationProcessor was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a thread not managed by Gradle or from a different project.  See https://docs.gradle.org/5.6.3/userguide/troubleshooting_dependency_resolution.html#sub:configuration_resolution_constraints for more details. This behaviour has been deprecated and is scheduled to be removed in Gradle 6.0.

Resolves also: https://github.com/jfrog/build-info/issues/255

Guard `configuration.getResolvedConfiguration()` and remove parallelism when populating the build info object.
Uploads still occur in parallel, as contributed in https://github.com/jfrog/build-info/pull/261.

@facewindu
Thanks a lot for making the uploads parallel.
`getMutationState().withMutableState()` freezes when running in non-Gradle threads. To avoid it, we removed parallelism when populating the build info object. As mentioned previously, uploads to Artifactory will still be in parallel.
Can you please take a look? It will be highly appreciated!