### PR TITLE
Add publishing of metadata (.module file) to the plugin - Gradle 4 fix

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperPublications.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperPublications.java
@@ -248,13 +248,21 @@ public class TaskHelperPublications extends TaskHelper {
                     addMavenArtifactToDeployDetails(deployDetails, publicationName, builder, artifactInfo, mavenPublication);
                 }
             }
-            // Second adding the main artifact of the publication, if present
-            if (mavenNormalizedPublication.getMainArtifact() != null) {
-                createPublishArtifactInfoAndAddToDeployDetails(mavenNormalizedPublication.getMainArtifact(), deployDetails, mavenPublication, publicationName);
+
+            Set<MavenArtifact> artifacts;
+            try {
+                // Gradle 5.0 and above:
+                artifacts = mavenNormalizedPublication.getAdditionalArtifacts();
+                // Second adding the main artifact of the publication, if present
+                if (mavenNormalizedPublication.getMainArtifact() != null) {
+                    createPublishArtifactInfoAndAddToDeployDetails(mavenNormalizedPublication.getMainArtifact(), deployDetails, mavenPublication, publicationName);
+                }
+            } catch (NoSuchMethodError error) {
+                // Compatibility with older versions of Gradle:
+                artifacts = mavenNormalizedPublication.getAllArtifacts();
             }
 
             // Third adding all additional artifacts - includes Gradle Module Metadata when produced
-            Set<MavenArtifact> artifacts = mavenNormalizedPublication.getAdditionalArtifacts();
             for (MavenArtifact artifact : artifacts) {
                 createPublishArtifactInfoAndAddToDeployDetails(artifact, deployDetails, mavenPublication, publicationName);
             }


### PR DESCRIPTION
Fix the following exception in Gradle 4:
> Caused by: java.lang.NoSuchMethodError: org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication.getAdditionalArtifacts()Ljava/util/Set;
        at org.jfrog.gradle.plugin.artifactory.task.helper.TaskHelperPublications.getArtifactDeployDetails(TaskHelperPublications.java:257)

@ljacomet the exception introduced by the following change:  https://github.com/jfrog/build-info/pull/265/commits/04e8afd9ae4550ef2b04d8f89a3e91c0f1bd49b5#diff-dd7b7a4cca93e9ac769933a1811d39dcR255. 
Can you please take a look on this pull request? Thanks!