### PR TITLE
The IvyArtifactRepository.layout(String, Closure) method has been deprecated

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -102,7 +102,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
         return project.repositories.ivy {
             name = 'artifactory-ivy-resolver'
             url = resolverConf.urlWithMatrixParams(pUrl)
-            layout 'pattern', {
+            patternLayout {
                 artifact resolverConf.getIvyArtifactPattern()
                 ivy resolverConf.getIvyPattern()
             }


### PR DESCRIPTION
https://github.com/jfrog/build-info/issues/203