### PR TITLE
Reintroduce buildinfo computation parallelism

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -27,12 +27,32 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskState;
-import org.jfrog.build.api.*;
-import org.jfrog.build.api.builder.*;
+import org.gradle.util.SingleMessageLogger;
+import org.jfrog.build.api.Agent;
+import org.jfrog.build.api.Artifact;
+import org.jfrog.build.api.BlackDuckProperties;
+import org.jfrog.build.api.Build;
+import org.jfrog.build.api.BuildAgent;
+import org.jfrog.build.api.BuildType;
+import org.jfrog.build.api.Dependency;
+import org.jfrog.build.api.Governance;
+import org.jfrog.build.api.Issue;
+import org.jfrog.build.api.IssueTracker;
+import org.jfrog.build.api.Issues;
+import org.jfrog.build.api.LicenseControl;
+import org.jfrog.build.api.MatrixParameter;
+import org.jfrog.build.api.Module;
+import org.jfrog.build.api.Vcs;
+import org.jfrog.build.api.builder.ArtifactBuilder;
+import org.jfrog.build.api.builder.BuildInfoBuilder;
+import org.jfrog.build.api.builder.DependencyBuilder;
+import org.jfrog.build.api.builder.ModuleBuilder;
+import org.jfrog.build.api.builder.PromotionStatusBuilder;
 import org.jfrog.build.api.release.Promotion;
 import org.jfrog.build.api.util.FileChecksumCalculator;
 import org.jfrog.build.extractor.BuildInfoExtractor;
@@ -49,7 +69,17 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Lists.newArrayList;
@@ -69,11 +99,13 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
     private static final String MD5 = "md5";
     private final ArtifactoryClientConfiguration clientConf;
     private final Set<GradleDeployDetails> gradleDeployDetails;
+    private int publishForkCount;
 
     public GradleBuildInfoExtractor(ArtifactoryClientConfiguration clientConf,
-                                    Set<GradleDeployDetails> gradleDeployDetails) {
+                                    Set<GradleDeployDetails> gradleDeployDetails, int publishForkCount) {
         this.clientConf = clientConf;
         this.gradleDeployDetails = gradleDeployDetails;
+        this.publishForkCount = publishForkCount;
     }
 
     @Override
@@ -113,12 +145,17 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         bib.durationMillis(durationMillis);
 
         Set<Project> allProjects = rootProject.getAllprojects();
-        for (Project project : allProjects) {
-            if (project.getState().getExecuted()) {
-                ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
-                if (buildInfoTask != null && buildInfoTask.hasModules()) {
-                    bib.addModule(extractModule(project));
-                }
+        if (publishForkCount <= 1) {
+            allProjects.forEach(p -> addModule(bib, p));
+        } else {
+            try {
+                ExecutorService executor = Executors.newFixedThreadPool(publishForkCount);
+                CompletableFuture<Void> allModules = CompletableFuture.allOf(allProjects.stream()
+                        .map(project -> CompletableFuture.runAsync(() -> addModule(bib, project), executor))
+                        .toArray(CompletableFuture[]::new));
+                allModules.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
             }
         }
         String parentName = clientConf.info.getParentBuildName();
@@ -234,6 +271,15 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         return build;
     }
 
+    private void addModule(BuildInfoBuilder bib, Project project) {
+        if (project.getState().getExecuted()) {
+            ArtifactoryTask buildInfoTask = getBuildInfoTask(project);
+            if (buildInfoTask != null && buildInfoTask.hasModules()) {
+                bib.addModule(extractModule(project));
+            }
+        }
+    }
+
     private ArtifactoryTask getBuildInfoTask(Project project) {
         Set<Task> tasks = project.getTasksByName(ArtifactoryTask.ARTIFACTORY_PUBLISH_TASK_NAME, false);
         if (tasks.isEmpty()) {
@@ -324,11 +370,12 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         Set<Configuration> configurationSet = project.getConfigurations();
         List<Dependency> dependencies = newArrayList();
         for (Configuration configuration : configurationSet) {
-            if (configuration.getState() != Configuration.State.RESOLVED) {
+            DefaultConfiguration defaultConfiguration = (DefaultConfiguration) configuration;
+            if (defaultConfiguration.getResolvedState() != ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED) {
                 log.info("Artifacts for configuration '{}' were not all resolved, skipping", configuration.getName());
                 continue;
             }
-            ResolvedConfiguration resolvedConfiguration = getResolvedConfiguration(project, configuration);
+            ResolvedConfiguration resolvedConfiguration = SingleMessageLogger.whileDisabled(() -> configuration.getResolvedConfiguration());
             Set<ResolvedArtifact> resolvedArtifactSet = resolvedConfiguration.getResolvedArtifacts();
             for (final ResolvedArtifact artifact : resolvedArtifactSet) {
                 File file = artifact.getFile();
@@ -364,16 +411,6 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
             }
         }
         return dependencies;
-    }
-
-    private ResolvedConfiguration getResolvedConfiguration(Project project, Configuration configuration) {
-        try {
-            // Gradle 5.0 and above:
-            return ((ProjectInternal) project).getMutationState().withMutableState(configuration::getResolvedConfiguration);
-        } catch (NoSuchMethodError error) {
-            // Compatibility with older versions of Gradle:
-            return configuration.getResolvedConfiguration();
-        }
     }
 
     private class ProjectPredicate implements Predicate<GradleDeployDetails> {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -122,7 +122,7 @@ public class DeployTask extends DefaultTask {
                 configureProxy(accRoot, client);
                 configConnectionTimeout(accRoot, client);
                 configRetriesParams(accRoot, client);
-                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails);
+                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails, publishForkCount);
                 Build build = gbie.extract(getProject().getRootProject());
                 exportBuildInfo(build, getExportFile(accRoot));
                 if (isPublishBuildInfo(accRoot)) {


### PR DESCRIPTION
Discussing it internally within Gradle, this PR reintroduces parallel computation of the build infos.

  Doing so in non-Gradle-managed threads is in theory unsafe, and Gradle logs a warning about that.
  To work around this:
    - use internal Gradle APIs to query only configuration in state ARTIFACTS_RESOLVED
    - Silence Gradle's warning, as what we do is actually read-only, and safe without locking the project state

This effectively replaces https://github.com/jfrog/build-info/pull/270