### PR TITLE
Building with Install -U Fails Build - Fix

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipseRepositoryListener.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipseRepositoryListener.java
@@ -184,9 +184,6 @@ public class ArtifactoryEclipseRepositoryListener extends AbstractRepositoryList
         Field url = RemoteRepository.class.getDeclaredField("url");
         url.setAccessible(true);
         url.set(toRepo, fromRepo.getUrl());
-        Field id = RemoteRepository.class.getDeclaredField("id");
-        id.setAccessible(true);
-        id.set(toRepo, fromRepo.getId());
         if (fromRepo.getAuthentication() != null) {
             Field authentication = RemoteRepository.class.getDeclaredField("authentication");
             authentication.setAccessible(true);


### PR DESCRIPTION
Allow plugin without version resolution. Fix this error:
> [main] ERROR org.apache.maven.cli.MavenCli - Error resolving version for plugin 'org.sonarsource.scanner.maven:sonar-maven-plugin' from the repositories [local (/Users/yahavi/.m2/repository), artifactory-release (http://127.0.0.1:8081/artifactory/libs-release)]: Plugin not found in any plugin repository

Caused by previous commit: https://github.com/jfrog/build-info/commit/e6c67cd5ae6819382a99825ef504337d19164841#diff-6b303c85142da9302de6e07eb769c56cR195-R197.