### PR TITLE
Remove unneeded maven callbacks

### DIFF
--- a/build-info-extractor-maven3-plugin/src/main/groovy/org/jfrog/build/extractor/maven/plugin/PublishMojo.groovy
+++ b/build-info-extractor-maven3-plugin/src/main/groovy/org/jfrog/build/extractor/maven/plugin/PublishMojo.groovy
@@ -1,10 +1,7 @@
 package org.jfrog.build.extractor.maven.plugin
 
 import org.apache.maven.AbstractMavenLifecycleParticipant
-import org.apache.maven.execution.ExecutionEvent
 import org.apache.maven.execution.MavenSession
-import org.apache.maven.lifecycle.internal.DefaultExecutionEventCatapult
-import org.apache.maven.lifecycle.internal.ExecutionEventCatapult
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugin.MojoFailureException
 import org.apache.maven.plugins.annotations.Component
@@ -40,9 +37,6 @@ class PublishMojo extends GroovyMojo
 
     @Component( role = AbstractMavenLifecycleParticipant )
     private BuildInfoRecorderLifecycleParticipant listener
-
-    @Component( role = ExecutionEventCatapult )
-    private DefaultExecutionEventCatapult eventCatapult
 
     /**
      * ----------------
@@ -158,7 +152,7 @@ class PublishMojo extends GroovyMojo
     /**
      * Adds original Maven listener to the lifecycle so that it records and publishes build info, together with build artifacts.
      */
-    @Requires({ session && deployGoals && session.goals && listener && eventCatapult })
+    @Requires({ session && deployGoals && session.goals && listener })
     private void recordBuildInfo()
     {
         final isDeployGoal = deployGoals.tokenize( ',' )*.trim().any {
@@ -169,10 +163,8 @@ class PublishMojo extends GroovyMojo
 
         if ( isDeployGoal )
         {
-            listener.afterSessionStart( session )
             listener.afterProjectsRead( session )
-            eventCatapult.fire( ExecutionEvent.Type.SessionStarted, session, null )
-            eventCatapult.fire( ExecutionEvent.Type.ProjectStarted, session, null )
+            listener.afterSessionStart( session )
         }
     }
 }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoModelPropertyResolver.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoModelPropertyResolver.java
@@ -3,7 +3,7 @@ package org.jfrog.build.extractor.maven;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.Maven;
-import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -31,10 +31,9 @@ public class BuildInfoModelPropertyResolver {
     @Requirement
     private Logger logger;
 
-
-    public BuildInfoMavenBuilder resolveProperties(ExecutionEvent event, ArtifactoryClientConfiguration clientConf) {
-        BuildInfoMavenBuilder builder = resolveCoreProperties(event, clientConf).
-                artifactoryPrincipal(clientConf.publisher.getName()).artifactoryPluginVersion(clientConf.info.getArtifactoryPluginVersion()).
+    public BuildInfoMavenBuilder resolveProperties(MavenSession session, ArtifactoryClientConfiguration clientConf) {
+        BuildInfoMavenBuilder builder = resolveCoreProperties(session, clientConf).
+                artifactoryPrincipal(clientConf.publisher.getName()).
                 principal(clientConf.info.getPrincipal()).type(BuildType.MAVEN).parentName(
                 clientConf.info.getParentBuildName()).
                 parentNumber(clientConf.info.getParentBuildNumber());
@@ -137,17 +136,16 @@ public class BuildInfoModelPropertyResolver {
         }
     }
 
-    private BuildInfoMavenBuilder resolveCoreProperties(ExecutionEvent event,
-                                                        ArtifactoryClientConfiguration clientConf) {
+    private BuildInfoMavenBuilder resolveCoreProperties(MavenSession session, ArtifactoryClientConfiguration clientConf) {
         String buildName = clientConf.info.getBuildName();
         if (StringUtils.isBlank(buildName)) {
-            buildName = event.getSession().getTopLevelProject().getName();
+            buildName = session.getTopLevelProject().getName();
         }
         String buildNumber = clientConf.info.getBuildNumber();
         if (StringUtils.isBlank(buildNumber)) {
             buildNumber = Long.toString(System.currentTimeMillis());
         }
-        Date buildStartedDate = event.getSession().getRequest().getStartTime();
+        Date buildStartedDate = session.getRequest().getStartTime();
         String buildStarted = clientConf.info.getBuildStarted();
         if (StringUtils.isBlank(buildStarted)) {
             buildStarted = new SimpleDateFormat(Build.STARTED_FORMAT).format(buildStartedDate);

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -140,11 +140,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         }
     }
 
-    @Override
-    public void sessionStarted(ExecutionEvent event) {
+    public void init(MavenSession session) {
         try {
             logger.info("Initializing Artifactory Build-Info Recording");
-            buildInfoBuilder = buildInfoModelPropertyResolver.resolveProperties(event, conf);
+            buildInfoBuilder = buildInfoModelPropertyResolver.resolveProperties(session, conf);
             deployableArtifactBuilderMap = Maps.newConcurrentMap();
             matrixParams = Maps.newConcurrentMap();
             Map<String, String> matrixParamProps = conf.publisher.getMatrixParams();
@@ -153,12 +152,8 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
                 key = StringUtils.removeStartIgnoreCase(key, ClientProperties.PROP_DEPLOY_PARAM_PROP_PREFIX);
                 matrixParams.put(key, matrixParamProp.getValue());
             }
-
-            if (wrappedListener != null) {
-                wrappedListener.sessionStarted(event);
-            }
         } catch (Throwable t) {
-            String message = getClass().getName() + ".sessionStarted() listener has failed: ";
+            String message = getClass().getName() + ".init() listener has failed: ";
             logger.error(message, t);
             throw new RuntimeException(message, t);
         }
@@ -206,12 +201,14 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
 
     @Override
     public void projectStarted(ExecutionEvent event) {
-        MavenProject project = event.getProject();
-        initModule(project);
-
+        projectStarted(event.getProject());
         if (wrappedListener != null) {
             wrappedListener.projectStarted(event);
         }
+    }
+
+    public void projectStarted(MavenProject project) {
+        initModule(project);
     }
 
     @Override

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorderLifecycleParticipant.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorderLifecycleParticipant.java
@@ -64,6 +64,12 @@ public class BuildInfoRecorderLifecycleParticipant extends AbstractMavenLifecycl
         session.getRequest().setExecutionListener(recorder);
     }
 
+    @Override
+    public void afterSessionStart(MavenSession session) {
+        recorder.init(session);
+        recorder.projectStarted(session.getCurrentProject());
+    }
+
     private ArtifactoryClientConfiguration getConfiguration(MavenSession session) {
         if (internalConfiguration != null) {
             return internalConfiguration;


### PR DESCRIPTION
This breaks assumptions that a single ProjectStarted event should be fired for a given project.

Fixes https://github.com/jfrog/build-info/issues/299