### PR TITLE
Improve module info extraction to gather info safely in parallel (only)

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPlugin.groovy
@@ -4,9 +4,11 @@ import org.gradle.api.Project
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 import org.jfrog.gradle.plugin.artifactory.task.DeployTask
+import org.jfrog.gradle.plugin.artifactory.task.ExtractModuleTask
 
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.ARTIFACTORY_PUBLISH_TASK_NAME
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.DEPLOY_TASK_NAME
+import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.EXTRACT_MODULE_TASK_NAME
 
 /**
  * @author Lior Hasson
@@ -28,6 +30,13 @@ class ArtifactoryPlugin extends ArtifactoryPluginBase {
     protected DeployTask createArtifactoryDeployTask(Project project) {
         def result = project.getTasks().create(DEPLOY_TASK_NAME, DeployTask.class)
         result.setDescription('''Deploys artifacts and build-info to Artifactory''')
+        return result
+    }
+
+    @Override
+    protected ExtractModuleTask createExtractModuleTask(Project project) {
+        def result = project.getTasks().create(EXTRACT_MODULE_TASK_NAME, ExtractModuleTask.class)
+        result.setDescription('''Extracts module info to an intermediate file''')
         return result
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -16,32 +16,47 @@
 
 package org.jfrog.gradle.plugin.artifactory
 
+import org.gradle.api.Named
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Usage
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.extractor.listener.ProjectsEvaluatedBuildListener
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 import org.jfrog.gradle.plugin.artifactory.task.DeployTask
+import org.jfrog.gradle.plugin.artifactory.task.ExtractModuleTask
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import static org.jfrog.gradle.plugin.artifactory.extractor.GradleBuildInfoExtractor.ALL_MODULES_CONFIGURATION
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.ARTIFACTORY_PUBLISH_TASK_NAME
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.DEPLOY_TASK_NAME
+import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.EXTRACT_MODULE_TASK_NAME
 
 abstract class ArtifactoryPluginBase implements Plugin<Project> {
     private static final Logger log = LoggerFactory.getLogger(ArtifactoryPluginBase.class)
     public static final String PUBLISH_TASK_GROUP = "publishing"
+    public static final String MODULES_CONFIGURATION = "moduleInfo"
+    public static final String MODULE_INFO_USAGE = "moduleInfo"
 
-    def void apply(Project project) {
+    void apply(Project project) {
         if ("buildSrc".equals(project.name)) {
             log.debug("Artifactory Plugin disabled for ${project.path}")
             return
         }
         // Add an Artifactory plugin convention to all the project modules
         ArtifactoryPluginConvention conv = getArtifactoryPluginConvention(project)
-        // Then add the build info task
+        // Then add the artifactory publish task
         addArtifactoryPublishTask(project)
+        // Add the module info configuration to each project
+        addModuleInfoConfiguration(project)
+        // Add the module info producer task
+        addModuleInfoTask(project)
+
         if (isRootProject(project)) {
+            // Add the aggregate module info configuration to the root project
+            addAllModulesConfiguration(project)
             addDeployTask(project)
         } else {
             // Makes sure the plugin is applied in the root project
@@ -59,6 +74,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
     protected abstract ArtifactoryTask createArtifactoryPublishTask(Project project)
     protected abstract ArtifactoryPluginConvention createArtifactoryPluginConvention(Project project)
     protected abstract DeployTask createArtifactoryDeployTask(Project project);
+    protected abstract ExtractModuleTask createExtractModuleTask(Project project);
 
     /**
      *  Set the plugin convention closure object
@@ -90,12 +106,49 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         artifactoryTask
     }
 
+    private void addAllModulesConfiguration(Project project) {
+        Configuration allModules = project.getConfigurations().create(ALL_MODULES_CONFIGURATION)
+        allModules.canBeConsumed = false
+        allModules.canBeResolved = true
+        Named moduleInfoUsage = project.getObjects().named(Usage.class, MODULE_INFO_USAGE)
+        allModules.attributes.attribute(Usage.USAGE_ATTRIBUTE, moduleInfoUsage)
+        project.allprojects { subproject ->
+            subproject.pluginManager.withPlugin('com.jfrog.artifactory') {
+                project.dependencies.add(ALL_MODULES_CONFIGURATION, subproject)
+            }
+        }
+    }
+
+    private void addModuleInfoConfiguration(Project project) {
+        Configuration moduleInfo = project.getConfigurations().create(MODULES_CONFIGURATION)
+        moduleInfo.canBeConsumed = true
+        moduleInfo.canBeResolved = false
+        Named moduleInfoUsage = project.getObjects().named(Usage.class, MODULE_INFO_USAGE)
+        moduleInfo.attributes.attribute(Usage.USAGE_ATTRIBUTE, moduleInfoUsage)
+    }
+
+    private ExtractModuleTask addModuleInfoTask(Project project) {
+        ExtractModuleTask extractModuleTask = project.tasks.findByName(EXTRACT_MODULE_TASK_NAME)
+        if (extractModuleTask == null) {
+            log.debug("Configuring extractModuleInfo task for project ${project.path}")
+            extractModuleTask = createExtractModuleTask(project)
+        }
+        extractModuleTask.moduleFile.set(project.layout.buildDirectory.file("moduleInfo.json"))
+        extractModuleTask.mustRunAfter(project.tasks.withType(ArtifactoryTask.class))
+
+        project.getArtifacts().add(MODULES_CONFIGURATION, extractModuleTask.moduleFile) {
+            builtBy(extractModuleTask)
+        }
+        return extractModuleTask
+    }
+
     private DeployTask addDeployTask(Project project) {
         DeployTask deployTask = project.tasks.findByName(DEPLOY_TASK_NAME)
         if (deployTask == null) {
             log.debug("Configuring deployTask task for project ${project.path}")
             deployTask = createArtifactoryDeployTask(project)
             deployTask.setGroup(PUBLISH_TASK_GROUP)
+            deployTask.inputs.files(project.getConfigurations().findByName(ALL_MODULES_CONFIGURATION))
         }
         deployTask
     }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -122,6 +122,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         Configuration moduleInfo = project.getConfigurations().create(MODULES_CONFIGURATION)
         moduleInfo.canBeConsumed = true
         moduleInfo.canBeResolved = false
+        moduleInfo.visible = false
         Named moduleInfoType = project.getObjects().named(BuildInfoType.class, BuildInfoType.MODULE_INFO)
         moduleInfo.attributes.attribute(BuildInfoType.BUILD_INFO_ATTRIBUTE, moduleInfoType)
     }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.attributes.Usage
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.extractor.listener.ProjectsEvaluatedBuildListener
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -63,14 +63,9 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
     public static final String ALL_MODULES_CONFIGURATION = "allModules";
 
     private final ArtifactoryClientConfiguration clientConf;
-    private final Set<GradleDeployDetails> gradleDeployDetails;
-    private int publishForkCount;
 
-    public GradleBuildInfoExtractor(ArtifactoryClientConfiguration clientConf,
-                                    Set<GradleDeployDetails> gradleDeployDetails, int publishForkCount) {
+    public GradleBuildInfoExtractor(ArtifactoryClientConfiguration clientConf) {
         this.clientConf = clientConf;
-        this.gradleDeployDetails = gradleDeployDetails;
-        this.publishForkCount = publishForkCount;
     }
 
     @Override

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
@@ -48,13 +48,16 @@ public class GradleDeployDetails implements Comparable<GradleDeployDetails> {
     public PublishArtifactInfo getPublishArtifact() {
         return publishArtifact;
     }
-    
+
     public int compareTo(GradleDeployDetails that) {
         if (this.publishArtifact == null) {
             return -1;
         }
         if (that.publishArtifact == null) {
             return 1;
+        }
+        if (this.deployDetails.compareTo(that.deployDetails) == 0) {
+            return 0;
         }
         String thisExtension = this.publishArtifact.getExtension();
         String thatExtension = that.publishArtifact.getExtension();

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleDeployDetails.java
@@ -56,9 +56,12 @@ public class GradleDeployDetails implements Comparable<GradleDeployDetails> {
         if (that.publishArtifact == null) {
             return 1;
         }
-        if (this.deployDetails.compareTo(that.deployDetails) == 0) {
+
+        int compareDeployDetails = this.deployDetails.compareTo(that.deployDetails);
+        if (compareDeployDetails == 0) {
             return 0;
         }
+
         String thisExtension = this.publishArtifact.getExtension();
         String thatExtension = that.publishArtifact.getExtension();
         if (thisExtension == null) {
@@ -75,7 +78,7 @@ public class GradleDeployDetails implements Comparable<GradleDeployDetails> {
         if ("xml".equals(thatExtension) || "pom".equals(thatExtension)) {
             return -1;
         }
-        return this.deployDetails.compareTo(that.deployDetails);
+        return compareDeployDetails;
     }
 
     @Override

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -1,0 +1,186 @@
+package org.jfrog.gradle.plugin.artifactory.extractor;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.jfrog.build.api.Artifact;
+import org.jfrog.build.api.Dependency;
+import org.jfrog.build.api.Module;
+import org.jfrog.build.api.builder.ArtifactBuilder;
+import org.jfrog.build.api.builder.DependencyBuilder;
+import org.jfrog.build.api.builder.ModuleBuilder;
+import org.jfrog.build.api.util.FileChecksumCalculator;
+import org.jfrog.build.extractor.ModuleExtractor;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
+import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
+import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
+import org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginUtil;
+import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.*;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
+
+public class GradleModuleExtractor implements ModuleExtractor<Project> {
+    private static final Logger log = Logging.getLogger(GradleModuleExtractor.class);
+
+    private static final String SHA1 = "sha1";
+    private static final String MD5 = "md5";
+
+    @Override
+    public Module extractModule(Project project) {
+        Set<GradleDeployDetails> gradleDeployDetails = Sets.newHashSet();
+        String artifactName = project.getName();
+        ArtifactoryTask artifactoryTask = ProjectUtils.getBuildInfoTask(project);
+        if (artifactoryTask != null) {
+            artifactName = project.getName();
+            try {
+                artifactoryTask.collectDescriptorsAndArtifactsForUpload();
+            } catch (IOException e) {
+                throw new RuntimeException("Cannot collect deploy details for " + artifactoryTask.getPath(), e);
+            }
+            gradleDeployDetails = artifactoryTask.deployDetails;
+        }
+        ModuleBuilder builder = new ModuleBuilder()
+                .id(getModuleIdString(project.getGroup().toString(),
+                        artifactName, project.getVersion().toString()));
+        try {
+            ArtifactoryClientConfiguration.PublisherHandler publisher = ArtifactoryPluginUtil.getPublisherHandler(project);
+            if (publisher != null) {
+                boolean excludeArtifactsFromBuild = publisher.isFilterExcludedArtifactsFromBuild();
+                IncludeExcludePatterns patterns = new IncludeExcludePatterns(
+                        publisher.getIncludePatterns(),
+                        publisher.getExcludePatterns());
+                Iterable<GradleDeployDetails> deployExcludeDetails = null;
+                Iterable<GradleDeployDetails> deployIncludeDetails = null;
+                if (excludeArtifactsFromBuild) {
+                    deployIncludeDetails = Iterables.filter(gradleDeployDetails, new IncludeExcludePredicate(project, patterns, true));
+                    deployExcludeDetails = Iterables.filter(gradleDeployDetails, new IncludeExcludePredicate(project, patterns, false));
+                } else {
+                    deployIncludeDetails = Iterables.filter(gradleDeployDetails, new ProjectPredicate(project));
+                    deployExcludeDetails = new ArrayList<GradleDeployDetails>();
+                }
+                builder.artifacts(calculateArtifacts(deployIncludeDetails))
+                        .excludedArtifacts(calculateArtifacts(deployExcludeDetails))
+                        .dependencies(calculateDependencies(project));
+            } else {
+                log.warn("No publisher config found for project: " + project.getName());
+            }
+        } catch (Exception e) {
+            log.error("Error during extraction: ", e);
+        }
+        return builder.build();
+    }
+
+    private List<Artifact> calculateArtifacts(Iterable<GradleDeployDetails> deployDetails) throws Exception {
+        List<Artifact> artifacts = newArrayList(transform(deployDetails, new Function<GradleDeployDetails, Artifact>() {
+            public Artifact apply(GradleDeployDetails from) {
+                PublishArtifactInfo publishArtifact = from.getPublishArtifact();
+                DeployDetails deployDetails = from.getDeployDetails();
+                String artifactPath = deployDetails.getArtifactPath();
+                int index = artifactPath.lastIndexOf('/');
+                return new ArtifactBuilder(artifactPath.substring(index + 1))
+                        .type(getTypeString(publishArtifact.getType(),
+                                publishArtifact.getClassifier(), publishArtifact.getExtension()))
+                        .md5(deployDetails.getMd5()).sha1(deployDetails.getSha1()).build();
+            }
+        }));
+        return artifacts;
+    }
+
+    private List<Dependency> calculateDependencies(Project project) throws Exception {
+        Set<Configuration> configurationSet = project.getConfigurations();
+        List<Dependency> dependencies = newArrayList();
+        for (Configuration configuration : configurationSet) {
+            if (configuration.getState() != Configuration.State.RESOLVED) {
+                log.info("Artifacts for configuration '{}' were not all resolved, skipping", configuration.getName());
+                continue;
+            }
+            ResolvedConfiguration resolvedConfiguration = configuration.getResolvedConfiguration();
+            Set<ResolvedArtifact> resolvedArtifactSet = resolvedConfiguration.getResolvedArtifacts();
+            for (final ResolvedArtifact artifact : resolvedArtifactSet) {
+                File file = artifact.getFile();
+                if (file != null && file.exists()) {
+                    ModuleVersionIdentifier id = artifact.getModuleVersion().getId();
+                    final String depId = getModuleIdString(id.getGroup(),
+                            id.getName(), id.getVersion());
+                    Predicate<Dependency> idEqualsPredicate = new Predicate<Dependency>() {
+                        public boolean apply(@Nullable Dependency input) {
+                            return input.getId().equals(depId);
+                        }
+                    };
+                    // if it's already in the dependencies list just add the current scope
+                    if (any(dependencies, idEqualsPredicate)) {
+                        Dependency existingDependency = find(dependencies, idEqualsPredicate);
+                        Set<String> existingScopes = existingDependency.getScopes();
+                        existingScopes.add(configuration.getName());
+                        existingDependency.setScopes(existingScopes);
+                    } else {
+                        DependencyBuilder dependencyBuilder = new DependencyBuilder()
+                                .type(getTypeString(artifact.getType(),
+                                        artifact.getClassifier(), artifact.getExtension()))
+                                .id(depId)
+                                .scopes(Sets.newHashSet(configuration.getName()));
+                        if (file.isFile()) {
+                            // In recent gradle builds (3.4+) subproject dependencies are represented by a dir not jar.
+                            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(file, MD5, SHA1);
+                            dependencyBuilder.md5(checksums.get(MD5)).sha1(checksums.get(SHA1));
+                        }
+                        dependencies.add(dependencyBuilder.build());
+                    }
+                }
+            }
+        }
+        return dependencies;
+    }
+
+    private class ProjectPredicate implements Predicate<GradleDeployDetails> {
+        private final Project project;
+
+        private ProjectPredicate(Project project) {
+            this.project = project;
+        }
+
+        public boolean apply(@Nullable GradleDeployDetails input) {
+            return input.getProject().equals(project);
+        }
+    }
+
+    private class IncludeExcludePredicate implements Predicate<GradleDeployDetails> {
+        private Project project;
+        private IncludeExcludePatterns patterns;
+        private boolean include;
+
+        public IncludeExcludePredicate(Project project, IncludeExcludePatterns patterns, boolean isInclude) {
+            this.project = project;
+            this.patterns = patterns;
+            include = isInclude;
+        }
+
+        public boolean apply(@Nullable GradleDeployDetails input) {
+            if (include) {
+                return input.getProject().equals(project) && !PatternMatcher.pathConflicts(input.getDeployDetails().getArtifactPath(), patterns);
+            } else {
+                return input.getProject().equals(project) && PatternMatcher.pathConflicts(input.getDeployDetails().getArtifactPath(), patterns);
+            }
+        }
+    }
+}

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -1,6 +1,5 @@
 package org.jfrog.gradle.plugin.artifactory.extractor;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Lists.newArrayList;
@@ -90,20 +92,17 @@ public class GradleModuleExtractor implements ModuleExtractor<Project> {
         return builder.build();
     }
 
-    private List<Artifact> calculateArtifacts(Iterable<GradleDeployDetails> deployDetails) throws Exception {
-        List<Artifact> artifacts = newArrayList(transform(deployDetails, new Function<GradleDeployDetails, Artifact>() {
-            public Artifact apply(GradleDeployDetails from) {
-                PublishArtifactInfo publishArtifact = from.getPublishArtifact();
-                DeployDetails deployDetails = from.getDeployDetails();
-                String artifactPath = deployDetails.getArtifactPath();
-                int index = artifactPath.lastIndexOf('/');
-                return new ArtifactBuilder(artifactPath.substring(index + 1))
-                        .type(getTypeString(publishArtifact.getType(),
-                                publishArtifact.getClassifier(), publishArtifact.getExtension()))
-                        .md5(deployDetails.getMd5()).sha1(deployDetails.getSha1()).build();
-            }
-        }));
-        return artifacts;
+    private List<Artifact> calculateArtifacts(Iterable<GradleDeployDetails> deployDetails) {
+        return newArrayList(StreamSupport.stream(deployDetails.spliterator(), false).map(from -> {
+            PublishArtifactInfo publishArtifact = from.getPublishArtifact();
+            DeployDetails deployDetails1 = from.getDeployDetails();
+            String artifactPath = deployDetails1.getArtifactPath();
+            int index = artifactPath.lastIndexOf('/');
+            return new ArtifactBuilder(artifactPath.substring(index + 1))
+                .type(getTypeString(publishArtifact.getType(),
+                    publishArtifact.getClassifier(), publishArtifact.getExtension()))
+                .md5(deployDetails1.getMd5()).sha1(deployDetails1.getSha1()).build();
+        }).collect(Collectors.toList()));
     }
 
     private List<Dependency> calculateDependencies(Project project) throws Exception {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ProjectUtils.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ProjectUtils.java
@@ -2,10 +2,8 @@ package org.jfrog.gradle.plugin.artifactory.extractor;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.tasks.TaskState;
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
 
-import java.lang.reflect.Method;
 import java.util.Set;
 
 public class ProjectUtils {
@@ -18,31 +16,6 @@ public class ProjectUtils {
             return null;
         }
         ArtifactoryTask artifactoryTask = (ArtifactoryTask)tasks.iterator().next();
-        if (ProjectUtils.taskDidWork(artifactoryTask)) {
-            return artifactoryTask;
-        }
-        return null;
-    }
-
-    /**
-     * Determines if the task actually did any work.
-     * This methods wraps Gradle's task.getState().getDidWork().
-     *
-     * @param task The ArtifactoryTask
-     * @return true if the task actually did any work.
-     */
-    static boolean taskDidWork(ArtifactoryTask task) {
-        try {
-            return task.getState().getDidWork();
-        } catch (NoSuchMethodError error) {
-            // Compatibility with older versions of Gradle:
-            try {
-                Method m = task.getClass().getMethod("getState");
-                TaskState state = (TaskState) m.invoke(task);
-                return state.getDidWork();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
+        return artifactoryTask.getState().getDidWork() ? artifactoryTask : null;
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ProjectUtils.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ProjectUtils.java
@@ -1,0 +1,48 @@
+package org.jfrog.gradle.plugin.artifactory.extractor;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskState;
+import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public class ProjectUtils {
+    /**
+     * Finds the ArtifactoryTask in the project if it has executed.
+     */
+    static ArtifactoryTask getBuildInfoTask(Project project) {
+        Set<Task> tasks = project.getTasksByName(ArtifactoryTask.ARTIFACTORY_PUBLISH_TASK_NAME, false);
+        if (tasks.isEmpty()) {
+            return null;
+        }
+        ArtifactoryTask artifactoryTask = (ArtifactoryTask)tasks.iterator().next();
+        if (ProjectUtils.taskDidWork(artifactoryTask)) {
+            return artifactoryTask;
+        }
+        return null;
+    }
+
+    /**
+     * Determines if the task actually did any work.
+     * This methods wraps Gradle's task.getState().getDidWork().
+     *
+     * @param task The ArtifactoryTask
+     * @return true if the task actually did any work.
+     */
+    static boolean taskDidWork(ArtifactoryTask task) {
+        try {
+            return task.getState().getDidWork();
+        } catch (NoSuchMethodError error) {
+            // Compatibility with older versions of Gradle:
+            try {
+                Method m = task.getClass().getMethod("getState");
+                TaskState state = (TaskState) m.invoke(task);
+                return state.getDidWork();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -74,11 +74,14 @@ public class ArtifactoryTask extends DefaultTask {
     }
 
     public void collectDescriptorsAndArtifactsForUpload() throws IOException {
-        if (helperConfigurations.hasConfigurations()) {
-            helperConfigurations.collectDescriptorsAndArtifactsForUpload();
-        }
-        if (helperPublications.hasPublications()) {
-            helperPublications.collectDescriptorsAndArtifactsForUpload();
+        // Only collect descriptors and artifacts once
+        if (deployDetails.isEmpty()) {
+            if (helperConfigurations.hasConfigurations()) {
+                helperConfigurations.collectDescriptorsAndArtifactsForUpload();
+            }
+            if (helperPublications.hasPublications()) {
+                helperPublications.collectDescriptorsAndArtifactsForUpload();
+            }
         }
     }
 

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -74,14 +74,11 @@ public class ArtifactoryTask extends DefaultTask {
     }
 
     public void collectDescriptorsAndArtifactsForUpload() throws IOException {
-        // Only collect descriptors and artifacts once
-        if (deployDetails.isEmpty()) {
-            if (helperConfigurations.hasConfigurations()) {
-                helperConfigurations.collectDescriptorsAndArtifactsForUpload();
-            }
-            if (helperPublications.hasPublications()) {
-                helperPublications.collectDescriptorsAndArtifactsForUpload();
-            }
+        if (helperConfigurations.hasConfigurations()) {
+            helperConfigurations.collectDescriptorsAndArtifactsForUpload();
+        }
+        if (helperPublications.hasPublications()) {
+            helperPublications.collectDescriptorsAndArtifactsForUpload();
         }
     }
 

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -40,6 +40,7 @@ import java.util.Set;
 public class ArtifactoryTask extends DefaultTask {
     public static final String DEPLOY_TASK_NAME = "artifactoryDeploy";
     public static final String ARTIFACTORY_PUBLISH_TASK_NAME = "artifactoryPublish";
+    public static final String EXTRACT_MODULE_TASK_NAME = "extractModuleInfo";
     public static final String PUBLISH_ARTIFACTS = "publishArtifacts";
     public static final String PUBLISH_IVY = "publishIvy";
     public static final String PUBLISH_POM = "publishPom";

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -122,7 +122,7 @@ public class DeployTask extends DefaultTask {
                 configureProxy(accRoot, client);
                 configConnectionTimeout(accRoot, client);
                 configRetriesParams(accRoot, client);
-                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot, allDeployDetails, publishForkCount);
+                GradleBuildInfoExtractor gbie = new GradleBuildInfoExtractor(accRoot);
                 Build build = gbie.extract(getProject().getRootProject());
                 exportBuildInfo(build, getExportFile(accRoot));
                 if (isPublishBuildInfo(accRoot)) {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -180,7 +180,6 @@ public class DeployTask extends DefaultTask {
                         password = "";
                     }
 
-                    artifactoryTask.collectDescriptorsAndArtifactsForUpload();
                     if (publisher.isPublishArtifacts()) {
                         ArtifactoryBuildInfoClient client = null;
                         try {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ExtractModuleTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ExtractModuleTask.java
@@ -1,0 +1,35 @@
+package org.jfrog.gradle.plugin.artifactory.task;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.jfrog.build.api.Module;
+import org.jfrog.build.extractor.ModuleExtractorUtils;
+import org.jfrog.gradle.plugin.artifactory.extractor.GradleModuleExtractor;
+
+import java.io.IOException;
+
+public class ExtractModuleTask extends DefaultTask {
+    @OutputFile
+    public RegularFileProperty moduleFile;
+
+    public ExtractModuleTask() {
+        try {
+            this.moduleFile = getProject().getObjects().fileProperty();
+        } catch(NoSuchMethodError e) {
+            // Gradle 4.x
+            this.moduleFile = getProject().getLayout().fileProperty();
+        }
+    }
+
+    @TaskAction
+    void extractModuleFile() {
+        Module module = new GradleModuleExtractor().extractModule(getProject());
+        try {
+            ModuleExtractorUtils.saveModuleToFile(module, moduleFile.getAsFile().get());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not extract module file", e);
+        }
+    }
+}

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ExtractModuleTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ExtractModuleTask.java
@@ -9,6 +9,7 @@ import org.jfrog.build.extractor.ModuleExtractorUtils;
 import org.jfrog.gradle.plugin.artifactory.extractor.GradleModuleExtractor;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 public class ExtractModuleTask extends DefaultTask {
     @OutputFile
@@ -19,7 +20,7 @@ public class ExtractModuleTask extends DefaultTask {
             this.moduleFile = getProject().getObjects().fileProperty();
         } catch (NoSuchMethodError e) {
             // Gradle 4.x
-            this.moduleFile = getProject().getLayout().fileProperty();
+            this.moduleFile = invokeMethod(getProject().getLayout(), "fileProperty");
         }
     }
 
@@ -30,6 +31,14 @@ public class ExtractModuleTask extends DefaultTask {
             ModuleExtractorUtils.saveModuleToFile(module, moduleFile.getAsFile().get());
         } catch (IOException e) {
             throw new RuntimeException("Could not extract module file", e);
+        }
+    }
+
+    <T> T invokeMethod(Object source, String methodName) {
+        try {
+            return (T) source.getClass().getMethod(methodName).invoke(source);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ExtractModuleTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ExtractModuleTask.java
@@ -17,7 +17,7 @@ public class ExtractModuleTask extends DefaultTask {
     public ExtractModuleTask() {
         try {
             this.moduleFile = getProject().getObjects().fileProperty();
-        } catch(NoSuchMethodError e) {
+        } catch (NoSuchMethodError e) {
             // Gradle 4.x
             this.moduleFile = getProject().getLayout().fileProperty();
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractor.java
@@ -1,0 +1,17 @@
+package org.jfrog.build.extractor;
+
+import org.jfrog.build.api.Module;
+
+/**
+ * Extracts a single module from the underlying build technology.
+ * @param <C> the source object from the underlying build
+ */
+public interface ModuleExtractor<C> {
+    /**
+     * Extract a module from the source object.
+     *
+     * @param source the source object
+     * @return A handle for the exported module
+     */
+    Module extractModule(C source);
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -35,8 +35,7 @@ public class ModuleExtractorUtils {
         jsonGenerator.useDefaultPrettyPrinter();
 
         jsonGenerator.writeObject(module);
-        String result = writer.getBuffer().toString();
-        return result;
+        return writer.getBuffer().toString();
     }
 
     public static Module jsonStringToModule(String json) throws IOException {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -16,6 +16,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+/**
+ * Utilities for serializing/deserializing Module info as json
+ */
 public class ModuleExtractorUtils {
     private static JsonFactory createJsonFactory() {
         JsonFactory jsonFactory = new JsonFactory();
@@ -27,6 +30,13 @@ public class ModuleExtractorUtils {
         return jsonFactory;
     }
 
+    /**
+     * Given a Module object, serialize it as a json string.
+     *
+     * @param module The module to serialize
+     * @return The json string representing the serialized module
+     * @throws IOException
+     */
     public static String moduleToJsonString(Module module) throws IOException {
         JsonFactory jsonFactory = createJsonFactory();
 
@@ -38,12 +48,26 @@ public class ModuleExtractorUtils {
         return writer.getBuffer().toString();
     }
 
+    /**
+     * Given a serialized json module string, deserialize it into a Module object.
+     *
+     * @param json The serialized json module string
+     * @return A Module object deserialized from the provided string
+     * @throws IOException
+     */
     public static Module jsonStringToModule(String json) throws IOException {
         JsonFactory jsonFactory = createJsonFactory();
         JsonParser parser = jsonFactory.createParser(new StringReader(json));
         return jsonFactory.getCodec().readValue(parser, Module.class);
     }
 
+    /**
+     * Given a Module object, serialize it to a json string and write it to the provided file.
+     *
+     * @param module The module object
+     * @param toFile The file to write the serialized module to
+     * @throws IOException
+     */
     public static void saveModuleToFile(Module module, File toFile) throws IOException {
         String moduleInfoJson = moduleToJsonString(module);
         if (!toFile.getParentFile().exists()) {
@@ -55,6 +79,13 @@ public class ModuleExtractorUtils {
         Files.asCharSink(toFile, Charsets.UTF_8).write(moduleInfoJson);
     }
 
+    /**
+     * Given a file, read its contents as a json string and deserialize it as a Module object.
+     *
+     * @param fromFile The file containing a serialized json string
+     * @return The Module object deserialized from the content of the file
+     * @throws IOException
+     */
     public static Module readModuleFromFile(File fromFile) throws IOException {
         String moduleInfoJson = Files.asCharSource(fromFile, Charsets.UTF_8).read();
         return jsonStringToModule(moduleInfoJson);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
-import org.jfrog.build.api.Build;
 import org.jfrog.build.api.Module;
 
 import java.io.File;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -52,7 +52,7 @@ public class ModuleExtractorUtils {
         if (!toFile.exists()) {
             toFile.createNewFile();
         }
-        Files.write(moduleInfoJson, toFile, Charsets.UTF_8);
+        Files.asCharSink(toFile, Charsets.UTF_8).write(moduleInfoJson);
     }
 
     public static Module readModuleFromFile(File fromFile) throws IOException {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -1,0 +1,64 @@
+package org.jfrog.build.extractor;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.jfrog.build.api.Build;
+import org.jfrog.build.api.Module;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+public class ModuleExtractorUtils {
+    private static JsonFactory createJsonFactory() {
+        JsonFactory jsonFactory = new JsonFactory();
+        ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        jsonFactory.setCodec(mapper);
+        return jsonFactory;
+    }
+
+    public static String moduleToJsonString(Module module) throws IOException {
+        JsonFactory jsonFactory = createJsonFactory();
+
+        StringWriter writer = new StringWriter();
+        JsonGenerator jsonGenerator = jsonFactory.createJsonGenerator(writer);
+        jsonGenerator.useDefaultPrettyPrinter();
+
+        jsonGenerator.writeObject(module);
+        String result = writer.getBuffer().toString();
+        return result;
+    }
+
+    public static Module jsonStringToModule(String json) throws IOException {
+        JsonFactory jsonFactory = createJsonFactory();
+        JsonParser parser = jsonFactory.createParser(new StringReader(json));
+        return jsonFactory.getCodec().readValue(parser, Module.class);
+    }
+
+    public static void saveModuleToFile(Module module, File toFile) throws IOException {
+        String moduleInfoJson = moduleToJsonString(module);
+        if (!toFile.getParentFile().exists()) {
+            toFile.getParentFile().mkdirs();
+        }
+        if (!toFile.exists()) {
+            toFile.createNewFile();
+        }
+        Files.write(moduleInfoJson, toFile, Charsets.UTF_8);
+    }
+
+    public static Module readModuleFromFile(File fromFile) throws IOException {
+        String moduleInfoJson = Files.asCharSource(fromFile, Charsets.UTF_8).read();
+        return jsonStringToModule(moduleInfoJson);
+    }
+}


### PR DESCRIPTION
This is a followup from #293.  Given the difficulties with incorporating the integration tests I included there, I'm carving off the functional change that I made in that PR so that it can be tested as normal and we can resolve the issues with the integration tests I added as a separate PR.

This refactors the module info extraction to make it safer. With #287 this was parallelized in a fairly unsafe manner using some Gradle internal APIs. This breaks up the module info extraction so that instead of a single task in the root project reaching across and resolving configurations in other projects, each project has its own extraction task that produces a module info artifact by resolving only the configurations in its project. Then the root project has a configuration that aggregates all of the module info artifacts and adds them to the build info object. Since this is done in a more "standard" way from a Gradle perspective, it allows us to remove the internal Gradle API usages. Since those module info tasks run in different projects, they can safely execute in parallel prior to the deploy task in the root project starting. This allows us to push some of this work earlier in the build and run it in parallel to other stuff that might be blocking the main deploy task. YMMV, but in certain cases this could provide a fair performance improvement.

We've learned that some of the unsafe things we did in #287 can lead to a deadlock condition in some scenarios.  The changes in this PR should avoid the potential deadlock.

cc @ljacomet 