### PR TITLE
BI-518 - java.lang.NullPointerException with rtNpm install in Container

### DIFF
--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmCommand.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmCommand.java
@@ -43,7 +43,7 @@ abstract class NpmCommand implements Serializable {
     NpmCommand(ArtifactoryClientBuilderBase clientBuilder, String executablePath, String repo, Log logger, Path path, Map<String, String> env) {
         this.clientBuilder = clientBuilder;
         this.npmDriver = new NpmDriver(executablePath, env);
-        this.workingDir = Files.isDirectory(path) ? path : path.getParent();
+        this.workingDir = Files.isDirectory(path) ? path : path.toAbsolutePath().getParent();
         this.repo = repo;
         this.logger = logger;
         this.path = path;


### PR DESCRIPTION
https://github.com/jfrog/build-info/issues/315

This fix handle relative paths better. Specifically it fix these cases:

**Before the fix:**
|Path|Abs|Working Dir
|:----:|:----:|:------------:|
|.|abs current dir path|null
|package.json|abs current dir path|null
|path to dir|abs path to dir|path to dir
|path to package.json|abs path to package.json|path to dir containing package.json

**After the fix:**
|Path|Abs|Working Dir
|:----:|:----:|:------------:|
|.|abs current dir path|parent of abs path
|package.json|abs current dir path|parent of abs path
|path to dir|abs path to dir|path to dir
|path to package.json|abs path to package.json|path to dir containing package.json