### PR TITLE
BI-522 - Reduce default deployment threads for Gradle and Maven

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleParallelDeployHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleParallelDeployHelper.java
@@ -17,6 +17,8 @@ import java.util.concurrent.Executors;
  * The deployment of every module will always be serial, with maven / gradle descriptors deployed last. This is done to prevent conflicts in Artifactory.
  */
 public class ModuleParallelDeployHelper {
+    public static final int DEFAULT_DEPLOYMENT_THREADS = 3;
+
     public void deployArtifacts(ArtifactoryBuildInfoClient client,
                                 Map<String, Set<DeployDetails>> deployableArtifactsByModule, int publishForkCount) {
         if (publishForkCount <= 1) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -42,6 +42,7 @@ import static org.jfrog.build.api.BuildInfoProperties.*;
 import static org.jfrog.build.api.IssuesTrackerFields.*;
 import static org.jfrog.build.api.LicenseControlFields.AUTO_DISCOVER;
 import static org.jfrog.build.api.LicenseControlFields.VIOLATION_RECIPIENTS;
+import static org.jfrog.build.extractor.ModuleParallelDeployHelper.DEFAULT_DEPLOYMENT_THREADS;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.*;
 import static org.jfrog.build.extractor.clientConfiguration.ClientProperties.*;
 
@@ -365,7 +366,7 @@ public class ArtifactoryClientConfiguration {
         }
 
         public Integer getPublishForkCount() {
-            return getIntegerValue(PUBLISH_FORK_COUNT, 8);
+            return getIntegerValue(PUBLISH_FORK_COUNT, DEFAULT_DEPLOYMENT_THREADS);
         }
 
         public boolean isRecordAllDependencies() {


### PR DESCRIPTION
Following #304 , reducing to 3.