### PR TITLE
Plugin does not publish all artifacts

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -151,7 +151,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
             extractModuleTask = createExtractModuleTask(project)
         }
         extractModuleTask.moduleFile.set(project.layout.buildDirectory.file("moduleInfo.json"))
-        extractModuleTask.mustRunAfter(project.tasks.withType(ArtifactoryTask.class))
+        project.tasks.findByName(ARTIFACTORY_PUBLISH_TASK_NAME).finalizedBy(extractModuleTask)
 
         project.getArtifacts().add(MODULES_CONFIGURATION, extractModuleTask.moduleFile) {
             builtBy(extractModuleTask)


### PR DESCRIPTION
**The Issue**
Using same submodule name as the root project causes the extractModuleInfo task of the submodule to not being triggered.
Reproducer here - https://github.com/yahavi/gradle-deploying-issue

**Deeper Analysis**
It looks like [mustRunAfter](https://github.com/gradle/gradle/blob/v6.3.0/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L793) does not happen when it already been called once for a project with the same GAV.

**Workaround**
Instead of: 
`TaskA` [mustRunAfter](https://github.com/gradle/gradle/blob/v6.3.0/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L793) `TaskB`
Do: 
`TaskB` [finalizedBy](https://github.com/gradle/gradle/blob/v6.3.0/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L819) `TaskA`

Obviously, this is a workaround.

@ghale