### PR TITLE
Wire module info files without using dependencies

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -16,21 +16,19 @@
 
 package org.jfrog.gradle.plugin.artifactory
 
-import org.gradle.api.Named
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.FileCollection
 import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
 import org.jfrog.gradle.plugin.artifactory.extractor.listener.ProjectsEvaluatedBuildListener
 import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 import org.jfrog.gradle.plugin.artifactory.task.DistributeBuildTask
 import org.jfrog.gradle.plugin.artifactory.task.DeployTask
 import org.jfrog.gradle.plugin.artifactory.task.ExtractModuleTask
+import org.jfrog.gradle.plugin.artifactory.extractor.ModuleInfoFileProducer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import static org.jfrog.gradle.plugin.artifactory.extractor.GradleBuildInfoExtractor.ALL_MODULES_CONFIGURATION
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.ARTIFACTORY_PUBLISH_TASK_NAME
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.DEPLOY_TASK_NAME
 import static org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask.EXTRACT_MODULE_TASK_NAME
@@ -39,7 +37,6 @@ import static org.jfrog.gradle.plugin.artifactory.task.DistributeBuildTask.DISTR
 abstract class ArtifactoryPluginBase implements Plugin<Project> {
     private static final Logger log = LoggerFactory.getLogger(ArtifactoryPluginBase.class)
     public static final String PUBLISH_TASK_GROUP = "publishing"
-    public static final String MODULES_CONFIGURATION = "moduleInfo"
 
     void apply(Project project) {
         if ("buildSrc".equals(project.name)) {
@@ -49,15 +46,11 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         // Add an Artifactory plugin convention to all the project modules
         ArtifactoryPluginConvention conv = getArtifactoryPluginConvention(project)
         // Then add the artifactory publish task
-        addArtifactoryPublishTask(project)
-        // Add the module info configuration to each project
-        addModuleInfoConfiguration(project)
+        ArtifactoryTask artifactoryTask = addArtifactoryPublishTask(project)
         // Add the module info producer task
-        addModuleInfoTask(project)
+        addModuleInfoTask(artifactoryTask)
 
         if (isRootProject(project)) {
-            // Add the aggregate module info configuration to the root project
-            addAllModulesConfiguration(project)
             addDeployTask(project)
             addDistributeBuildTask(project)
         } else {
@@ -109,19 +102,6 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         artifactoryTask
     }
 
-    private void addAllModulesConfiguration(Project project) {
-        Configuration allModules = project.getConfigurations().create(ALL_MODULES_CONFIGURATION)
-        allModules.canBeConsumed = false
-        allModules.canBeResolved = true
-        Named moduleInfoType = project.getObjects().named(BuildInfoType.class, BuildInfoType.MODULE_INFO)
-        allModules.attributes.attribute(BuildInfoType.BUILD_INFO_ATTRIBUTE, moduleInfoType)
-        project.allprojects { subproject ->
-            subproject.pluginManager.withPlugin('com.jfrog.artifactory') {
-                project.dependencies.add(ALL_MODULES_CONFIGURATION, subproject)
-            }
-        }
-    }
-
     /**
      * Add the "artifactoryDistribute" gradle task (under "publishing" task group)
      */
@@ -135,16 +115,8 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         distributeBuildTask
     }
 
-    private void addModuleInfoConfiguration(Project project) {
-        Configuration moduleInfo = project.getConfigurations().create(MODULES_CONFIGURATION)
-        moduleInfo.canBeConsumed = true
-        moduleInfo.canBeResolved = false
-        moduleInfo.visible = false
-        Named moduleInfoType = project.getObjects().named(BuildInfoType.class, BuildInfoType.MODULE_INFO)
-        moduleInfo.attributes.attribute(BuildInfoType.BUILD_INFO_ATTRIBUTE, moduleInfoType)
-    }
-
-    private ExtractModuleTask addModuleInfoTask(Project project) {
+    private ExtractModuleTask addModuleInfoTask(ArtifactoryTask artifactoryTask) {
+        Project project = artifactoryTask.project
         ExtractModuleTask extractModuleTask = project.tasks.findByName(EXTRACT_MODULE_TASK_NAME)
         if (extractModuleTask == null) {
             log.debug("Configuring extractModuleInfo task for project ${project.path}")
@@ -153,9 +125,10 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         extractModuleTask.moduleFile.set(project.layout.buildDirectory.file("moduleInfo.json"))
         extractModuleTask.mustRunAfter(project.tasks.withType(ArtifactoryTask.class))
 
-        project.getArtifacts().add(MODULES_CONFIGURATION, extractModuleTask.moduleFile) {
-            builtBy(extractModuleTask)
+        project.rootProject.tasks.withType(DeployTask).configureEach { deployTask ->
+            deployTask.registerModuleInfoProducer(new DefaultModuleInfoFileProducer(artifactoryTask, extractModuleTask))
         }
+
         return extractModuleTask
     }
 
@@ -165,14 +138,31 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
             log.debug("Configuring deployTask task for project ${project.path}")
             deployTask = createArtifactoryDeployTask(project)
             deployTask.setGroup(PUBLISH_TASK_GROUP)
-            deployTask.inputs.files(project.getConfigurations().findByName(ALL_MODULES_CONFIGURATION))
         }
         deployTask
     }
 
-    interface BuildInfoType extends Named {
-        Attribute<BuildInfoType> BUILD_INFO_ATTRIBUTE = Attribute.of("org.jfrog.build-info", BuildInfoType.class)
+    private static class DefaultModuleInfoFileProducer implements ModuleInfoFileProducer {
+        private final ArtifactoryTask artifactoryTask
+        private final ExtractModuleTask extractModuleTask
 
-        static final String MODULE_INFO = "moduleInfo"
+        DefaultModuleInfoFileProducer(ArtifactoryTask artifactoryTask, ExtractModuleTask extractModuleTask) {
+            this.artifactoryTask = artifactoryTask
+            this.extractModuleTask = extractModuleTask
+        }
+
+        @Override
+        boolean hasModules() {
+            if (artifactoryTask.project.getState().getExecuted()) {
+                return artifactoryTask != null && artifactoryTask.hasModules();
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        FileCollection getModuleInfoFiles() {
+            return extractModuleTask.outputs.files
+        }
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -155,9 +155,8 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         boolean hasModules() {
             if (artifactoryTask.project.getState().getExecuted()) {
                 return artifactoryTask != null && artifactoryTask.hasModules();
-            } else {
-                return false;
             }
+            return false;
         }
 
         @Override

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ModuleInfoFileProducer.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ModuleInfoFileProducer.java
@@ -1,0 +1,24 @@
+package org.jfrog.gradle.plugin.artifactory.extractor;
+
+import org.gradle.api.file.FileCollection;
+
+import java.io.File;
+
+/**
+ * Represents a producer of ModuleInfo files
+ */
+public interface ModuleInfoFileProducer {
+    /**
+     * Whether the module info file will actually contain modules or not.
+     *
+     * @return true if the module info file will contain modules
+     */
+    boolean hasModules();
+
+    /**
+     * Get the module info file.
+     *
+     * @return the module info file
+     */
+    FileCollection getModuleInfoFiles();
+}

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ModuleInfoFileProducer.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/ModuleInfoFileProducer.java
@@ -2,7 +2,6 @@ package org.jfrog.gradle.plugin.artifactory.extractor;
 
 import org.gradle.api.file.FileCollection;
 
-import java.io.File;
 
 /**
  * Represents a producer of ModuleInfo files


### PR DESCRIPTION
#334 describes a problem whereby when the root project does not produce publishable artifacts, but has the same coordinates as a subproject, the subproject will not be published.  This happens because the inter-project dependencies are wired together via artifacts and when two projects have matching coordinates, they appear as the same module so conflict resolution kicks in and resolves to one project or the other.  If this were two subprojects, there would be no reason to apply the artifactory plugin to both projects (otherwise they would both publish the same module).  But in the case where the root project does not publish any artifacts, it is entirely feasible to apply the plugin to both the root project and the subproject event though the coordinates are the same.

These changes fix the issue by wiring the module info files to the deploy task without using dependencies.  This is generally undesirable because we would like to have all inter-project dependencies modeled as project dependencies, but Gradle currently can't handle the peculiarities of this use case.  Once this is fixed in Gradle, we can change this back to using dependency-based relationship between projects.

Fixes #334