### PR TITLE
GradleBuildInfoExtractor: only add modules with artifacts to build info

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -107,7 +107,10 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
 
         moduleFilesWithModules.forEach(moduleFile -> {
             try {
-                bib.addModule(ModuleExtractorUtils.readModuleFromFile(moduleFile));
+                Module module = ModuleExtractorUtils.readModuleFromFile(moduleFile);
+                if(!module.getArtifacts().isEmpty()) {
+                    bib.addModule(module);
+                }
             } catch (IOException e) {
                 throw new RuntimeException("Cannot load module info from file: " + moduleFile.getAbsolutePath(), e);
             }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -108,7 +108,7 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         moduleFilesWithModules.forEach(moduleFile -> {
             try {
                 Module module = ModuleExtractorUtils.readModuleFromFile(moduleFile);
-                if(!module.getArtifacts().isEmpty()) {
+                if(!module.getArtifacts().isEmpty() || !module.getDependencies().isEmpty()) {
                     bib.addModule(module);
                 }
             } catch (IOException e) {


### PR DESCRIPTION
This addresses "Gradle Build Info Extractor should not add modules without artifacts" https://github.com/jfrog/build-info/issues/342 