### PR TITLE
BI-525 - Add artifact's path field to Build-Info in Maven and Gradle

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/BaseBuildFileBean.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/BaseBuildFileBean.java
@@ -16,6 +16,8 @@
 
 package org.jfrog.build.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 /**
@@ -30,6 +32,8 @@ public abstract class BaseBuildFileBean extends BaseBuildBean implements BuildFi
     protected String sha256;
     protected String md5;
     protected String localPath;
+
+    @JsonProperty("path")
     protected String remotePath;
 
     public String getType() {

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -100,7 +100,7 @@ public class GradleModuleExtractor implements ModuleExtractor<Project> {
             return new ArtifactBuilder(artifactPath.substring(index + 1))
                 .type(getTypeString(publishArtifact.getType(),
                     publishArtifact.getClassifier(), publishArtifact.getExtension()))
-                .md5(deployDetails1.getMd5()).sha1(deployDetails1.getSha1()).build();
+                .md5(deployDetails1.getMd5()).sha1(deployDetails1.getSha1()).remotePath(deployDetails1.getTargetRepository() + "/" + artifactPath).build();
         }).collect(Collectors.toList()));
     }
 

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
@@ -158,6 +158,7 @@ public class BuildDeploymentHelper {
                     if (deployable != null) {
                         File file = deployable.getFile();
                         setArtifactChecksums(file, artifact);
+                        artifact.setRemotePath(deployable.getTargetRepository() + "/" + deployable.getArtifactPath());
                         moduleDeployableArtifacts.add(new DeployDetails.Builder().
                                 artifactPath(deployable.getArtifactPath()).
                                 file(file).


### PR DESCRIPTION
- [ ] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
