### PR TITLE
Default MavenJava and IvyJava publications added in non Java projects

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -109,7 +109,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
             if (resolver != null) {
                 defineResolvers(artifactoryTask.project, resolver)
             }
-            if (artifactoryTask.isCiServerBuild() && isJava(artifactoryTask)) {
+            if (artifactoryTask.isCiServerBuild() && isJava(artifactoryTask.project)) {
                 addDefaultPublicationsOrConfigurations(artifactoryTask);
             }
             artifactoryTask.projectEvaluated()
@@ -118,11 +118,11 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
 
     /**
      * Return true if the 'java' or 'java-library' plugins are applied.
-     * @param artifactoryTask - The artifactory task
+     * @param project - The Gradle project of the task
      * @return true if the 'java' or 'java-library' plugins are applied.
      */
-    private static boolean isJava(ArtifactoryTask artifactoryTask) {
-        artifactoryTask.project.components.contains(new SoftwareComponent() {
+    private static boolean isJava(Project project) {
+        project.components.contains(new SoftwareComponent() {
             @Override
             String getName() {
                 return "java"

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.ProjectEvaluationListener
 import org.gradle.api.ProjectState
 import org.gradle.api.Task
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.ivy.IvyPublication
@@ -108,11 +109,25 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
             if (resolver != null) {
                 defineResolvers(artifactoryTask.project, resolver)
             }
-            if (artifactoryTask.isCiServerBuild()) {
+            if (artifactoryTask.isCiServerBuild() && isJava(artifactoryTask)) {
                 addDefaultPublicationsOrConfigurations(artifactoryTask);
             }
             artifactoryTask.projectEvaluated()
         }
+    }
+
+    /**
+     * Return true if the 'java' or 'java-library' plugins are applied.
+     * @param artifactoryTask - The artifactory task
+     * @return true if the 'java' or 'java-library' plugins are applied.
+     */
+    private static boolean isJava(ArtifactoryTask artifactoryTask) {
+        artifactoryTask.project.components.contains(new SoftwareComponent() {
+            @Override
+            String getName() {
+                return "java"
+            }
+        })
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

**The issue**
In CI builds, MavenJava and IvyJava default publications are automatically injected. This behavior causes issue when running, for example, C++ project with Gradle.

**Solution**
Inject MavenJava and IvyJava only if `java` or `java-library` plugin are applied.

**More information**
Jenkins Jira isssue: https://www.jfrog.com/jira/browse/HAP-1307