### PR TITLE
Allow choosing the Gradle publications during Gradle CI builds

### DIFF
--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
@@ -75,7 +75,21 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void ciServerTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo, virtualRepo);
+        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo, virtualRepo, "");
+        Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
+            put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
+        }};
+        // Run Gradle
+        BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
+        // Check results
+        checkBuildResults(dependenciesClient, buildInfoClient, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, getUrl(), localRepo);
+    }
+
+    @Test(dataProvider = "gradleVersions")
+    public void ciServerPublicationsTest(String gradleVersion) throws IOException {
+        // Create test environment
+        createTestDir(GRADLE_EXAMPLE_CI_SERVER);
+        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo, virtualRepo, "mavenJava,customIvyPublication");
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -82,9 +82,10 @@ public class Utils {
      * @param virtualRepo - Gradle remote repository
      * @throws IOException - In case of any IO error
      */
-    static void generateBuildInfoProperties(String contextUrl, String username, String password, String localRepo, String virtualRepo) throws IOException {
+    static void generateBuildInfoProperties(String contextUrl, String username, String password, String localRepo, String virtualRepo, String publications) throws IOException {
         String content = new String(Files.readAllBytes(BUILD_INFO_PROPERTIES_SOURCE), StandardCharsets.UTF_8);
         Map<String, String> valuesMap = new HashMap<String, String>() {{
+            put("publications", publications);
             put("contextUrl", contextUrl);
             put("username", username);
             put("password", password);

--- a/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties
+++ b/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties
@@ -1,4 +1,5 @@
 # Deployer settings
+artifactory.publish.publications=${publications}
 artifactory.publish.contextUrl=${contextUrl}
 artifactory.publish.repoKey=${localRepo}
 artifactory.publish.username=${username}

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server/build.gradle
@@ -38,6 +38,9 @@ configure(javaProjects()) {
         from components.java
         artifact(file("$rootDir/gradle.properties"))
       }
+      customIvyPublication(IvyPublication) {
+        from components.java
+      }
     }
   }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -430,6 +430,14 @@ public class ArtifactoryClientConfiguration {
         public void setArtifactSpecs(String artifactSpecs) {
             setStringValue(ARTIFACT_SPECS, artifactSpecs);
         }
+
+        public String getPublications() {
+            return getStringValue(PUBLICATIONS);
+        }
+
+        public void setPublications(String publications) {
+            setStringValue(PUBLICATIONS, publications);
+        }
     }
 
     public class ProxyHandler extends AuthenticationConfiguration {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -50,4 +50,5 @@ public interface ClientConfigurationFields {
     String FILTER_EXCLUDED_ARTIFACTS_FROM_BUILD = "filterExcludedArtifactsFromBuild";
     String EVEN_UNSTABLE = "unstable";
     String CONTEXT_URL = "contextUrl";
+    String PUBLICATIONS = "publications";
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Jenkins PR: https://github.com/jfrog/jenkins-artifactory-plugin/pull/309

Add 'publications' field to the publisher to allow customizing the Gradle publications.
If publications were chose, don't add the default mavenJava and ivyJava publications.
