### PR TITLE
BI-530 - Fix CommandExecutor environment initialization for Windows machines

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -29,12 +29,10 @@ public class CommandExecutor implements Serializable {
      */
     public CommandExecutor(String executablePath, Map<String, String> env) {
         this.executablePath = executablePath;
-        Map<String, String> fixedEnvMap = new HashMap<>(env);
-        // Fix PATH variable.
-        fixPathEnv(fixedEnvMap);
-
         Map<String, String> finalEnvMap = new HashMap<>(System.getenv());
-        if (!fixedEnvMap.isEmpty()) {
+        if (env != null) {
+            Map<String, String> fixedEnvMap = new HashMap<>(env);
+            fixPathEnv(fixedEnvMap);
             finalEnvMap.putAll(fixedEnvMap);
         }
         this.env = finalEnvMap.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).toArray(String[]::new);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -29,12 +29,15 @@ public class CommandExecutor implements Serializable {
      */
     public CommandExecutor(String executablePath, Map<String, String> env) {
         this.executablePath = executablePath;
-        Map<String, String> envMap = new HashMap<>(System.getenv());
-        if (env != null) {
-            envMap.putAll(env);
+        Map<String, String> fixedEnvMap = new HashMap<>(env);
+        // Fix PATH variable.
+        fixPathEnv(fixedEnvMap);
+
+        Map<String, String> finalEnvMap = new HashMap<>(System.getenv());
+        if (!fixedEnvMap.isEmpty()) {
+            finalEnvMap.putAll(fixedEnvMap);
         }
-        fixPathEnv(envMap);
-        this.env = envMap.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).toArray(String[]::new);
+        this.env = finalEnvMap.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).toArray(String[]::new);
     }
 
     /**
@@ -49,11 +52,39 @@ public class CommandExecutor implements Serializable {
             return;
         }
         if (isWindows()) {
-            path = path.replaceAll(":", File.pathSeparator);
+            path = getFixedWindowsPath(path);
         } else {
             path = path.replaceAll(";", File.pathSeparator) + ":/usr/local/bin";
         }
         env.replace("PATH", path);
+    }
+
+    /**
+     * Fix the PATH value to be valid for execution on a Windows machine.
+     * Take care of a case when either non-Windows or Windows environment-variables are received.
+     * Examples:
+     * "C:\my\first;Drive:\my\second" returns "C:\my\first;Drive:\my\second"
+     * "/Users/my/first:/Users/my/second" returns "/Users/my/first;/Users/my/second"
+     *
+     * @param path - Value of PATH environment variable.
+     * @return Fixed PATH value.
+     */
+    static String getFixedWindowsPath(String path) {
+        String[] pathParts = path.split(";");
+        String[] newPathParts = new String[pathParts.length];
+        for (int index = 0; index < pathParts.length; index++) {
+            String part = pathParts[index];
+            int backSlashIndex = part.indexOf('\\');
+            if (backSlashIndex < 0) {
+                newPathParts[index] = part.replaceAll(":", ";");
+                continue;
+            }
+            String startPart = part.substring(0, backSlashIndex);
+            String endPart = part.substring(backSlashIndex);
+            String newPart = startPart + endPart.replaceAll(":", ";");
+            newPathParts[index] = newPart;
+        }
+        return String.join(";", newPathParts);
     }
 
     /**

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -1,0 +1,29 @@
+package org.jfrog.build.extractor.executor;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Created by Bar Belity on 04/08/2020.
+ */
+public class CommandExecutorTest {
+
+    @DataProvider
+    private Object[][] getFixedWindowsPathProvider() {
+        return new Object[][]{
+                {"C:\\my\\first;Drive:\\my\\second", "C:\\my\\first;Drive:\\my\\second"},
+                {"C:\\my\\first;Drive:\\my\\second:\\my\\third", "C:\\my\\first;Drive:\\my\\second;\\my\\third"},
+                {"/Users/my/first:/Users/my/second", "/Users/my/first;/Users/my/second"},
+                {"/Users/my/first:/Users/my/sec;ond", "/Users/my/first;/Users/my/sec;ond"},
+                {"/Users/my/first:/Users/my/sec;ond:C:\\my\\third", "/Users/my/first;/Users/my/sec;ond:C:\\my\\third"},
+        };
+    }
+
+    @Test(dataProvider = "getFixedWindowsPathProvider")
+    public void getFixedWindowsPathTest(String path, String expected) {
+        String actual = CommandExecutor.getFixedWindowsPath(path);
+        assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
