### PR TITLE
BI-529 - Add scopes to dependencies tree nodes

### DIFF
--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTree.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTree.java
@@ -1,12 +1,15 @@
 package org.jfrog.build.extractor.npm.extractor;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.extractor.npm.types.NpmPackageInfo;
 import org.jfrog.build.extractor.npm.types.NpmScope;
 import org.jfrog.build.extractor.scan.DependenciesTree;
+import org.jfrog.build.extractor.scan.Scope;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Yahav Itzhak
@@ -17,18 +20,21 @@ public class NpmDependencyTree {
     /**
      * Create a npm dependencies tree from the results of 'npm ls' command.
      *
-     * @param scope   - 'production' or 'development'.
      * @param npmList - Results of 'npm ls' command.
      * @return Tree of npm PackageInfos.
      * @see NpmPackageInfo
      */
-    public static DependenciesTree createDependenciesTree(NpmScope scope, JsonNode npmList) {
+    public static DependenciesTree createDependenciesTree(JsonNode npmList) {
         DependenciesTree rootNode = new DependenciesTree();
-        populateDependenciesTree(rootNode, scope, npmList.get("dependencies"));
+        populateDependenciesTree(rootNode, npmList.get("dependencies"));
+        for (DependenciesTree child : rootNode.getChildren()) {
+            NpmPackageInfo packageInfo = (NpmPackageInfo) child.getUserObject();
+            child.setScopes(getScopes(packageInfo.getName(), packageInfo.getScope()));
+        }
         return rootNode;
     }
 
-    private static void populateDependenciesTree(DependenciesTree scanTreeNode, NpmScope scope, JsonNode dependencies) {
+    private static void populateDependenciesTree(DependenciesTree scanTreeNode, JsonNode dependencies) {
         if (dependencies == null) {
             return;
         }
@@ -37,16 +43,47 @@ public class NpmDependencyTree {
             String name = stringJsonNodeEntry.getKey();
             JsonNode versionNode = stringJsonNodeEntry.getValue().get("version");
             if (versionNode != null) {
-                addSubtree(stringJsonNodeEntry, scanTreeNode, name, versionNode.asText(), scope); // Mutual recursive call
+                addSubtree(stringJsonNodeEntry, scanTreeNode, name, versionNode.asText()); // Mutual recursive call
             }
         });
     }
 
-    private static void addSubtree(Map.Entry<String, JsonNode> stringJsonNodeEntry, DependenciesTree node, String name, String version, NpmScope scope) {
-        NpmPackageInfo npmPackageInfo = new NpmPackageInfo(name, version, ObjectUtils.defaultIfNull(scope, "").toString());
-        JsonNode childDependencies = stringJsonNodeEntry.getValue().get("dependencies");
+    private static void addSubtree(Map.Entry<String, JsonNode> stringJsonNodeEntry, DependenciesTree node, String name, String version) {
+        JsonNode jsonNode = stringJsonNodeEntry.getValue();
+        String devScope = (isDev(jsonNode) ? NpmScope.DEVELOPMENT : NpmScope.PRODUCTION).toString();
+        NpmPackageInfo npmPackageInfo = new NpmPackageInfo(name, version, devScope);
+        JsonNode childDependencies = jsonNode.get("dependencies");
         DependenciesTree childTreeNode = new DependenciesTree(npmPackageInfo);
-        populateDependenciesTree(childTreeNode, scope, childDependencies); // Mutual recursive call
+        populateDependenciesTree(childTreeNode, childDependencies); // Mutual recursive call
         node.add(childTreeNode);
+    }
+
+    /**
+     * Return true if the input dependency is a dev dependency.
+     *
+     * @param jsonNode - The dependency node in the 'npm ls' results
+     * @return true if the input dependency is a dev dependency
+     */
+    private static boolean isDev(JsonNode jsonNode) {
+        JsonNode development = jsonNode.get("_development");
+        return development != null && development.asBoolean(false);
+    }
+
+    /**
+     * Return a set of the relevant scopes. The set contains 'development' or 'production'. If the dependency has a
+     * custom scope, add it too.
+     *
+     * @param name     - The name of the dependency
+     * @param devScope - 'development' or 'production'
+     * @return set of the relevant scopes
+     */
+    private static Set<Scope> getScopes(String name, String devScope) {
+        Set<Scope> scopes = new HashSet<>();
+        scopes.add(new Scope(devScope));
+        String customScope = StringUtils.substringBetween(name, "@", "/");
+        if (customScope != null) {
+            scopes.add(new Scope(customScope));
+        }
+        return scopes;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependenciesTree.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependenciesTree.java
@@ -15,6 +15,7 @@ public class DependenciesTree extends DefaultMutableTreeNode {
 
     private Set<Issue> issues = new HashSet<>();
     private Set<License> licenses = new HashSet<>();
+    private Set<Scope> scopes = new HashSet<>();
     private GeneralInfo generalInfo;
     private Issue topIssue = new Issue();
 
@@ -34,6 +35,10 @@ public class DependenciesTree extends DefaultMutableTreeNode {
         this.licenses = licenses;
     }
 
+    public void setScopes(Set<Scope> scopes) {
+        this.scopes = scopes;
+    }
+
     @SuppressWarnings("unused")
     public void setGeneralInfo(GeneralInfo generalInfo) {
         this.generalInfo = generalInfo;
@@ -50,6 +55,10 @@ public class DependenciesTree extends DefaultMutableTreeNode {
 
     public Set<License> getLicenses() {
         return licenses;
+    }
+
+    public Set<Scope> getScopes() {
+        return scopes;
     }
 
     /**

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Scope.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Scope.java
@@ -1,0 +1,56 @@
+package org.jfrog.build.extractor.scan;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Objects;
+
+/**
+ * @author yahavi
+ */
+public class Scope {
+    private static final String NONE_SCOPE = "None";
+
+    private final String name;
+
+    @SuppressWarnings("unused")
+    public Scope() {
+        name = NONE_SCOPE;
+    }
+
+    public Scope(String name) {
+        this.name = StringUtils.capitalize(StringUtils.trim(name));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @JsonIgnore
+    @SuppressWarnings("unused")
+    public boolean isEmpty() {
+        return StringUtils.isBlank(name) || name.equals(Scope.NONE_SCOPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        return StringUtils.equals(toString(), other.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

* Add scope set to the dependencies tree node.
* Remove redundant 'npm ls --only=dev' command during the npm extractor. Instead, run 'npm ls --json --long' to get all required information.