### PR TITLE
Use maven-2-default layout instead of gradle-default

### DIFF
--- a/build-info-extractor-gradle/src/test/resources/integration/settings/build-info-tests-gradle-local.json
+++ b/build-info-extractor-gradle/src/test/resources/integration/settings/build-info-tests-gradle-local.json
@@ -1,5 +1,5 @@
 {
   "packageType": "gradle",
-  "repoLayoutRef": "gradle-default",
+  "repoLayoutRef": "maven-2-default",
   "rclass": "local"
 }

--- a/build-info-extractor-gradle/src/test/resources/integration/settings/build-info-tests-gradle-remote.json
+++ b/build-info-extractor-gradle/src/test/resources/integration/settings/build-info-tests-gradle-remote.json
@@ -1,6 +1,6 @@
 {
   "packageType": "gradle",
-  "repoLayoutRef": "gradle-default",
+  "repoLayoutRef": "maven-2-default",
   "url": "https://jcenter.bintray.com",
   "rclass": "remote"
 }


### PR DESCRIPTION
Replacing gradle-default repository layout with maven-2-default due to gradle-default deprecation.