### PR TITLE
BI-534 - Add artifact's path field to Build-Info in Docker, Npm and Go

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
@@ -148,7 +148,7 @@ public class DockerImage implements Serializable {
             }
             HttpResponse httpResponse = propertyChangeClient.executeUpdateFileProperty(layer.getFullPath(), artifactsPropsStr);
             validateResponse(httpResponse);
-            Artifact artifact = new ArtifactBuilder(layer.getFileName()).sha1(layer.getSha1()).addProperties(properties).build();
+            Artifact artifact = new ArtifactBuilder(layer.getFileName()).sha1(layer.getSha1()).addProperties(properties).remotePath(layer.getFullPath()).build();
             artifacts.add(artifact);
         }
         buildInfoModule.setArtifacts(new ArrayList<>(artifacts));

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
@@ -173,6 +173,7 @@ public class GoPublish extends GoCommand {
         Artifact deployedArtifact =  new ArtifactBuilder(moduleName + ":" + artifactName)
                 .md5(response.getChecksums().getMd5())
                 .sha1(response.getChecksums().getSha1())
+                .remotePath(deploymentRepo + "/" + deployDetails.getArtifactPath())
                 .build();
 
         return deployedArtifact;

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmPublish.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmPublish.java
@@ -137,6 +137,7 @@ public class NpmPublish extends NpmCommand {
         deployedArtifact = new ArtifactBuilder(npmPackageInfo.getModuleId())
                 .md5(response.getChecksums().getMd5())
                 .sha1(response.getChecksums().getSha1())
+                .remotePath(repo + "/" + npmPackageInfo.getDeployPath())
                 .build();
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
@@ -77,7 +77,9 @@ public class UploadSpecHelper {
      */
     public static String wildcardCalculateTargetPath(String targetPattern, File artifactFile) {
         if (targetPattern.endsWith("/") || targetPattern.equals("")) {
-            return targetPattern + calculateTargetRelativePath(artifactFile);
+            String newTargetPattern = targetPattern + calculateTargetRelativePath(artifactFile);
+            // Trim prefixing '/' if exists.
+            return newTargetPattern.startsWith("/") ? newTargetPattern.substring(1) : newTargetPattern;
         }
         return targetPattern;
     }


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
