### PR TITLE
Builds are not incremental

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -122,6 +122,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
             log.debug("Configuring extractModuleInfo task for project ${project.path}")
             extractModuleTask = createExtractModuleTask(project)
         }
+        extractModuleTask.outputs.upToDateWhen { false }
         extractModuleTask.moduleFile.set(project.layout.buildDirectory.file("moduleInfo.json"))
         extractModuleTask.mustRunAfter(project.tasks.withType(ArtifactoryTask.class))
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Jira - https://www.jfrog.com/jira/browse/GAP-321

To allow incremental builds, extractModuleInfo task should always be executed.
Otherwise, users have to clean between every build.
