### PR TITLE
Version test of incorrect Artifactory URL returns wrong message

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/Version.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/Version.java
@@ -23,7 +23,7 @@ public class Version implements Serializable {
     }
 
     public boolean isNotFound() {
-        return NOT_FOUND.equals(this);
+        return NOT_FOUND.version.equals(this.version);
     }
 
     public boolean isAtLeast(Version atLeast) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Actual:
If the Artifactory URL is incorrect, the "Test Connection" button results are "This plugin is compatible with version 2.2.3 of Artifactory and above. Please upgrade your Artifactory server!".

Expected:
"There is either an incompatible or no instance of Artifactory at the provided URL."