### PR TITLE
BI-540 - The Xray client does not support access tokens

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryXrayClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryXrayClient.java
@@ -44,9 +44,13 @@ public class ArtifactoryXrayClient extends ArtifactoryBaseClient {
      */
     private static final int HTTP_CLIENT_RETRIES = 0;
 
-    public ArtifactoryXrayClient(String artifactoryUrl, String username, String password, Log logger) {
-        super(artifactoryUrl, username, password, StringUtils.EMPTY, logger);
+    public ArtifactoryXrayClient(String artifactoryUrl, String username, String password, String accessToken, Log logger) {
+        super(artifactoryUrl, username, password, accessToken, logger);
         setConnectionRetries(HTTP_CLIENT_RETRIES);
+    }
+
+    public ArtifactoryXrayClient(String artifactoryUrl, String username, String password, Log logger) {
+        this(artifactoryUrl, username, password, StringUtils.EMPTY, logger);
     }
 
     public ArtifactoryXrayResponse xrayScanBuild(String buildName, String buildNumber, String context) throws IOException, InterruptedException {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

The username-password constructor left intact in order to not break the API.