### PR TITLE
Allow configuring min size of checksum deploy in Gradle

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoFields.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoFields.java
@@ -50,7 +50,7 @@ public interface BuildInfoFields {
     String GENERATED_BUILD_INFO = "generated.build.info";
     String VCS = "vcs";
     String DEPLOYABLE_ARTIFACTS = "deployable.artifacts.map";
-    String CHECKSUM_DEPLOY_MIN_FILE_SIZE = "checksumDeployMinFileSize";
+    String MIN_CHECKSUM_DEPLOY_SIZE_KB = "minChecksumDeploySizeKb";
     // Backward compatibility for pipelines using Gradle Artifactory Plugin with version bellow 4.15.1, or Jenkins Artifactory Plugin bellow 3.6.1
     @Deprecated
     String BACKWARD_COMPATIBLE_DEPLOYABLE_ARTIFACTS = "deployable.artifacts";

--- a/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoFields.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoFields.java
@@ -50,6 +50,7 @@ public interface BuildInfoFields {
     String GENERATED_BUILD_INFO = "generated.build.info";
     String VCS = "vcs";
     String DEPLOYABLE_ARTIFACTS = "deployable.artifacts.map";
+    String CHECKSUM_DEPLOY_MIN_FILE_SIZE = "checksumDeployMinFileSize";
     // Backward compatibility for pipelines using Gradle Artifactory Plugin with version bellow 4.15.1, or Jenkins Artifactory Plugin bellow 3.6.1
     @Deprecated
     String BACKWARD_COMPATIBLE_DEPLOYABLE_ARTIFACTS = "deployable.artifacts";

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -176,7 +176,7 @@ public class DeployTask extends DefaultTask {
                             configureProxy(accRoot, client);
                             configConnectionTimeout(accRoot, client);
                             configRetriesParams(accRoot, client);
-                            client.setChecksumDeployMinFileSize(publisher.getChecksumDeployMinFileSize());
+                            client.setMinChecksumDeploySizeKb(publisher.getMinChecksumDeploySizeKb());
                             deployArtifacts(artifactoryTask.deployDetails, client, patterns, logPrefix);
                         }
                     }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -167,11 +167,8 @@ public class DeployTask extends DefaultTask {
                     }
 
                     if (publisher.isPublishArtifacts()) {
-                        ArtifactoryBuildInfoClient client = null;
-                        try {
-                            client = new ArtifactoryBuildInfoClient(contextUrl, username, password,
-                                    new GradleClientLogger(log));
-
+                        try (ArtifactoryBuildInfoClient client = new ArtifactoryBuildInfoClient(contextUrl, username, password,
+                                new GradleClientLogger(log))) {
                             log.debug("Uploading artifacts to Artifactory at '{}'", contextUrl);
                             IncludeExcludePatterns patterns = new IncludeExcludePatterns(
                                     publisher.getIncludePatterns(),
@@ -179,11 +176,8 @@ public class DeployTask extends DefaultTask {
                             configureProxy(accRoot, client);
                             configConnectionTimeout(accRoot, client);
                             configRetriesParams(accRoot, client);
+                            client.setChecksumDeployMinFileSize(publisher.getChecksumDeployMinFileSize());
                             deployArtifacts(artifactoryTask.deployDetails, client, patterns, logPrefix);
-                        } finally {
-                            if (client != null) {
-                                client.close();
-                            }
                         }
                     }
 

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         }
     }
     artifactoryPublish {
-        clientConfig.publisher.checksumDeployMinFileSize = 0
+        clientConfig.publisher.minChecksumDeploySizeKb = 0
     }
 }
 

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example/build.gradle
@@ -20,6 +20,9 @@ allprojects {
             }
         }
     }
+    artifactoryPublish {
+        clientConfig.publisher.checksumDeployMinFileSize = 0
+    }
 }
 
 artifactoryPublish.skip = true

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -50,6 +50,8 @@ import static org.jfrog.build.extractor.clientConfiguration.ClientProperties.*;
  * @author freds
  */
 public class ArtifactoryClientConfiguration {
+    public static final transient int DEFAULT_CHECKSUM_DEPLOY_MIN_FILE_SIZE = 10240; // Try checksum deploy of files greater than 10KB
+
     public final ResolverHandler resolver;
     public final PublisherHandler publisher;
     public final BuildInfoHandler info;
@@ -443,6 +445,14 @@ public class ArtifactoryClientConfiguration {
 
         public void setPublications(String publications) {
             setStringValue(PUBLICATIONS, publications);
+        }
+
+        public int getChecksumDeployMinFileSize() {
+            return getIntegerValue(CHECKSUM_DEPLOY_MIN_FILE_SIZE, DEFAULT_CHECKSUM_DEPLOY_MIN_FILE_SIZE);
+        }
+
+        public void setChecksumDeployMinFileSize(int checksumDeployMinSize) {
+            setIntegerValue(CHECKSUM_DEPLOY_MIN_FILE_SIZE, checksumDeployMinSize);
         }
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -50,7 +50,8 @@ import static org.jfrog.build.extractor.clientConfiguration.ClientProperties.*;
  * @author freds
  */
 public class ArtifactoryClientConfiguration {
-    public static final transient int DEFAULT_CHECKSUM_DEPLOY_MIN_FILE_SIZE = 10240; // Try checksum deploy of files greater than 10KB
+    // Try checksum deploy of files greater than 10KB
+    public static final transient int DEFAULT_MIN_CHECKSUM_DEPLOY_SIZE_KB = 10;
 
     public final ResolverHandler resolver;
     public final PublisherHandler publisher;
@@ -447,12 +448,12 @@ public class ArtifactoryClientConfiguration {
             setStringValue(PUBLICATIONS, publications);
         }
 
-        public int getChecksumDeployMinFileSize() {
-            return getIntegerValue(CHECKSUM_DEPLOY_MIN_FILE_SIZE, DEFAULT_CHECKSUM_DEPLOY_MIN_FILE_SIZE);
+        public int getMinChecksumDeploySizeKb() {
+            return getIntegerValue(MIN_CHECKSUM_DEPLOY_SIZE_KB, DEFAULT_MIN_CHECKSUM_DEPLOY_SIZE_KB);
         }
 
-        public void setChecksumDeployMinFileSize(int checksumDeployMinSize) {
-            setIntegerValue(CHECKSUM_DEPLOY_MIN_FILE_SIZE, checksumDeployMinSize);
+        public void setMinChecksumDeploySizeKb(int minChecksumDeploySizeKb) {
+            setIntegerValue(MIN_CHECKSUM_DEPLOY_SIZE_KB, minChecksumDeploySizeKb);
         }
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
@@ -703,7 +703,7 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient implements
     }
 
     private ArtifactoryUploadResponse tryChecksumDeploy(DeployDetails details, String uploadUrl) throws UnsupportedEncodingException {
-        // Try checksum deploy only on file size equal or greater than 'checksumDeployMinFileSize'
+        // Try checksum deploy only on file size equal or greater than 'minChecksumDeploySizeKb'
         long fileLength = details.getFile().length();
         if (fileLength < minChecksumDeploySizeKb * 1024) {
             log.debug("Skipping checksum deploy of file size " + fileLength + " bytes, falling back to regular deployment.");

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
@@ -59,7 +59,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 import static org.jfrog.build.client.ArtifactoryHttpClient.encodeUrl;
-import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.DEFAULT_CHECKSUM_DEPLOY_MIN_FILE_SIZE;
+import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.DEFAULT_MIN_CHECKSUM_DEPLOY_SIZE_KB;
 
 /**
  * Artifactory client to perform build info related tasks.
@@ -81,7 +81,7 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient implements
     private static final String USAGE_API = "/api/system/usage";
     private static final ArtifactoryVersion USAGE_ARTIFACTORY_MIN_VERSION = new ArtifactoryVersion("6.9.0");
 
-    private int checksumDeployMinFileSize = DEFAULT_CHECKSUM_DEPLOY_MIN_FILE_SIZE;
+    private int minChecksumDeploySizeKb = DEFAULT_MIN_CHECKSUM_DEPLOY_SIZE_KB;
 
     /**
      * Creates a new client for the given Artifactory url.
@@ -117,10 +117,10 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient implements
 
     /**
      * Set min file size for checksum deployment.
-     * @param checksumDeployMinFileSize - file size
+     * @param minChecksumDeploySizeKb - file size in KB
      */
-    public void setChecksumDeployMinFileSize(int checksumDeployMinFileSize) {
-        this.checksumDeployMinFileSize = checksumDeployMinFileSize;
+    public void setMinChecksumDeploySizeKb(int minChecksumDeploySizeKb) {
+        this.minChecksumDeploySizeKb = minChecksumDeploySizeKb;
     }
 
     /**
@@ -705,8 +705,8 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient implements
     private ArtifactoryUploadResponse tryChecksumDeploy(DeployDetails details, String uploadUrl) throws UnsupportedEncodingException {
         // Try checksum deploy only on file size equal or greater than 'checksumDeployMinFileSize'
         long fileLength = details.getFile().length();
-        if (fileLength < checksumDeployMinFileSize) {
-            log.debug("Skipping checksum deploy of file size " + fileLength + " , falling back to regular deployment.");
+        if (fileLength < minChecksumDeploySizeKb * 1024) {
+            log.debug("Skipping checksum deploy of file size " + fileLength + " bytes, falling back to regular deployment.");
             return null;
         }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
#341 

Instead of using 10MB, allow configuring the minimal file size of checksum deploy:
```gradle
allProjects {
    artifactoryPublish {
        clientConfig.publisher.minChecksumDeploySizeKb = 123
    }
}
```