### PR TITLE
Bugfix - docker push fail to collect build info while using repo inst…

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
@@ -301,6 +301,34 @@ public class DockerUtils {
         EntityUtils.consume(response.getEntity());
     }
 
+    /**
+     * @param imagePath - path to an image in artifactory without proxy e.g. image/image-tag
+     * @param repo - target repo to search
+     * @param cmd - docker push cmd/ docker pull cmd
+     * @return All possible paths in Artifactory in order to find image manifest using proxy.
+     */
+    public static List<String> getArtManifestPath(String imagePath, String repo, CommandType cmd) {
+        ArrayList<String> paths = new ArrayList<>();
+        // Assuming reverse proxy e.g. ecosysjfrog-docker-local.jfrog.io.
+        paths.add(repo + "/" + imagePath);
+
+        // Assuming proxy-less e.g. orgab.jfrog.team/docker-local.
+        paths.add(imagePath);
+
+        int totalSlash = org.apache.commons.lang.StringUtils.countMatches(imagePath, "/");
+        if (cmd == CommandType.Push || totalSlash > 3) {
+            return paths;
+        }
+        // Assume reverse proxy - this time with 'library' as part of the path.
+        paths.add(repo + "/library/" + imagePath);
+
+        // Assume proxy-less - this time with 'library' as part of the path.
+        int secondSlash = StringUtils.ordinalIndexOf(imagePath, "/", 2);
+        paths.add(repo + "/library/" + imagePath.substring(secondSlash + 1));
+
+        return paths;
+    }
+
     public enum CommandType {
         Push,
         Pull

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
@@ -262,13 +262,13 @@ public class DockerImage implements Serializable {
         String ImagePath = DockerUtils.getImagePath(imageTag);
         ArrayList<String> manifestPathCandidate = new ArrayList<>(DockerUtils.getArtManifestPath(ImagePath, targetRepo, cmdType));
         logger.info("Trying to fetch manifest from Artifactory.");
-        int listLen = manifestPathCandidate.toArray().length;
+        int listLen = manifestPathCandidate.size();
         for (int i = 0; i < listLen; i++) {
             try {
                 checkAndSetManifestAndImagePathCandidates(manifestPathCandidate.get(i), dependenciesClient);
                 return;
             } catch (IOException e) {
-                // Ignore - unless we have no search path.
+                // Throw the exception only if we reached the end of the loop, which means we tried all options.
                 if (i == listLen - 1) {
                     throw e;
                 }


### PR DESCRIPTION
…ead subdomain for docker registry

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
