### PR TITLE
Bug fix - NuGet - package.config read fails

### DIFF
--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/types/NugetPackgesConfig.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/types/NugetPackgesConfig.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class NugetPackgesConfig implements Serializable {
@@ -61,7 +62,7 @@ public class NugetPackgesConfig implements Serializable {
     private String inputStreamToString(InputStream is) throws IOException {
         StringBuilder sb = new StringBuilder();
         String line;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             while ((line = br.readLine()) != null) {
                 sb.append(line);
             }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
This PR fixes https://github.com/jfrog/jenkins-artifactory-plugin/issues/329