### PR TITLE
Exception raised during download when 'java.io.tmpdir' is not defined

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/util/CommonUtils.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/util/CommonUtils.java
@@ -163,7 +163,7 @@ public class CommonUtils {
      * If not defined in POSIX compliant systems - use '/tmp' folder.
      * If defined but directory does not exist - try to create it.
      *
-     * @throws RuntimeException if case of missing 'java.io.tmpdir' is missing in Windows or the path is not accessible.
+     * @throws RuntimeException if 'java.io.tmpdir' property is missing in Windows or the path is not accessible.
      */
     public static void handleJavaTmpdirProperty() {
         String tmpDirPath = FileUtils.getTempDirectoryPath();
@@ -177,7 +177,7 @@ public class CommonUtils {
             try {
                 Files.createDirectories(Paths.get(tmpDirPath));
             } catch (IOException e) {
-                throw new RuntimeException("The directory defined in the system property 'java.io.tmpdir' (" + tmpDirPath + ") doesn't exit. " +
+                throw new RuntimeException("The directory defined by the system property 'java.io.tmpdir' (" + tmpDirPath + ") doesn't exit. " +
                         "An attempt to create a directory in this path failed: ", e);
             }
         } else if (SystemUtils.IS_OS_UNIX) {

--- a/build-info-api/src/test/java/org/jfrog/build/api/util/CreateTempDirTests.java
+++ b/build-info-api/src/test/java/org/jfrog/build/api/util/CreateTempDirTests.java
@@ -41,7 +41,7 @@ public class CreateTempDirTests {
     public void createTempDirMissingProperty() {
         System.setProperty(JAVA_IO_TMPDIR_PROP, "");
         if (SystemUtils.IS_OS_WINDOWS) {
-            assertThrows(IOException.class, CommonUtils::handleJavaTmpdirProperty);
+            assertThrows(RuntimeException.class, CommonUtils::handleJavaTmpdirProperty);
             return;
         }
         try {

--- a/build-info-api/src/test/java/org/jfrog/build/api/util/CreateTempDirTests.java
+++ b/build-info-api/src/test/java/org/jfrog/build/api/util/CreateTempDirTests.java
@@ -1,0 +1,66 @@
+package org.jfrog.build.api.util;
+
+import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.jfrog.build.api.util.CommonUtils.handleJavaTmpdirProperty;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.FileAssert.fail;
+
+/**
+ * @author yahavi
+ **/
+@Test
+public class CreateTempDirTests {
+
+    private static final String JAVA_IO_TMPDIR_PROP = "java.io.tmpdir";
+    private static final String OLD_JAVA_IO_TMPDIR = System.getProperty(JAVA_IO_TMPDIR_PROP);
+
+    @AfterMethod
+    public void setUp() {
+        System.setProperty(JAVA_IO_TMPDIR_PROP, OLD_JAVA_IO_TMPDIR);
+    }
+
+    public void createTempDirPropertyExist() {
+        String oldJavaIoTmpdir = System.getProperty(JAVA_IO_TMPDIR_PROP);
+        try {
+            handleJavaTmpdirProperty();
+            assertEquals(System.getProperty(JAVA_IO_TMPDIR_PROP), oldJavaIoTmpdir);
+        } catch (RuntimeException e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+    public void createTempDirMissingProperty() {
+        System.setProperty(JAVA_IO_TMPDIR_PROP, "");
+        if (SystemUtils.IS_OS_WINDOWS) {
+            assertThrows(IOException.class, CommonUtils::handleJavaTmpdirProperty);
+            return;
+        }
+        try {
+            handleJavaTmpdirProperty();
+            assertEquals(System.getProperty(JAVA_IO_TMPDIR_PROP), "/tmp");
+        } catch (RuntimeException e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+    public void createTempDirMissingDir() {
+        Path currentDir = Paths.get("not-exist-dir").toAbsolutePath();
+        System.setProperty(JAVA_IO_TMPDIR_PROP, currentDir.toString());
+        try {
+            handleJavaTmpdirProperty();
+            assertEquals(System.getProperty(JAVA_IO_TMPDIR_PROP), currentDir.toString());
+        } catch (RuntimeException e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+}

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
@@ -12,11 +12,9 @@ import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryDependenciesClient;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -271,19 +269,6 @@ public class DockerUtils {
         int indexOfFirstSlash = imageTag.indexOf("/");
         int indexOfLastColon = imageTag.lastIndexOf(":");
         return indexOfFirstSlash < indexOfLastColon;
-    }
-
-    /**
-     * Docker-Java uses the temp dir to execute binaries, in some cases the default temp dir (especially on Linux OS)
-     * might have a NONEXE flag, therefore we override it with our build info extractor dir.
-     *
-     * @param path - Local path to create temp dir.
-     */
-    public static void initTempDir(File path) {
-        // Extract the dir path.
-        String pathDir = path.getAbsoluteFile().getParent();
-        // Set the Java temp dir system property. As a result, java will create it for us.
-        System.setProperty("java.io.tmpdir", Paths.get(pathDir, "DockerJavaTemp").toString());
     }
 
     /**

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPull.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPull.java
@@ -13,11 +13,9 @@ import org.jfrog.build.extractor.docker.DockerJavaWrapper;
 import org.jfrog.build.extractor.docker.DockerUtils;
 import org.jfrog.build.extractor.docker.types.DockerImage;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.jfrog.build.extractor.docker.DockerUtils.initTempDir;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class DockerPull extends DockerCommand {
@@ -58,8 +56,7 @@ public class DockerPull extends DockerCommand {
                     clientConfiguration.resolver.getPassword(),
                     clientConfiguration.getLog(),
                     clientConfiguration.getAllProperties());
-            // Init temp dir.
-            initTempDir(new File(clientConfiguration.info.getGeneratedBuildInfoFilePath()));
+
             // Exe docker pull & collect build info.
             dockerPush.executeAndSaveBuildInfo(clientConfiguration);
         } catch (RuntimeException e) {

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPush.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPush.java
@@ -18,12 +18,10 @@ import org.jfrog.build.extractor.docker.types.DockerImage;
 import org.jfrog.build.extractor.docker.types.DockerLayer;
 import org.jfrog.build.extractor.docker.types.DockerLayers;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
 import static org.jfrog.build.extractor.clientConfiguration.util.DeploymentUrlUtils.buildMatrixParamsString;
-import static org.jfrog.build.extractor.docker.DockerUtils.initTempDir;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class DockerPush extends DockerCommand {
@@ -73,7 +71,7 @@ public class DockerPush extends DockerCommand {
                     clientConfiguration.publisher.getPassword(),
                     clientConfiguration.getLog(),
                     clientConfiguration.getAllProperties());
-            initTempDir(new File(clientConfiguration.info.getGeneratedBuildInfoFilePath()));
+
             // Exe docker push & collect build info.
             dockerPush.executeAndSaveBuildInfo(clientConfiguration);
         } catch (RuntimeException e) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
@@ -134,6 +134,7 @@ public class SpecsHelper {
      * @throws IOException in case of IOException
      */
     public List<Dependency> downloadArtifactsBySpec(String spec, ArtifactoryDependenciesClient client, String targetDirectory) throws IOException {
+        // During download, temp directories are created. This will make sure 'java.io.tmpdir' property is defined in Unix.
         handleJavaTmpdirProperty();
         DependenciesDownloaderHelper helper = new DependenciesDownloaderHelper(client, targetDirectory, log);
         return helper.downloadDependencies(getSpecFromString(spec, new SearchBasedSpecValidator()));

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
+import static org.jfrog.build.api.util.CommonUtils.handleJavaTmpdirProperty;
 import static org.jfrog.build.client.PreemptiveHttpClientBuilder.CONNECTION_POOL_SIZE;
 
 /**
@@ -133,6 +134,7 @@ public class SpecsHelper {
      * @throws IOException in case of IOException
      */
     public List<Dependency> downloadArtifactsBySpec(String spec, ArtifactoryDependenciesClient client, String targetDirectory) throws IOException {
+        handleJavaTmpdirProperty();
         DependenciesDownloaderHelper helper = new DependenciesDownloaderHelper(client, targetDirectory, log);
         return helper.downloadDependencies(getSpecFromString(spec, new SearchBasedSpecValidator()));
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 
+import static org.jfrog.build.api.util.CommonUtils.handleJavaTmpdirProperty;
+
 /**
  * Created by Bar Belity on 12/07/2020.
  */
@@ -26,6 +28,7 @@ public abstract class PackageManagerExtractor implements Serializable {
      * @throws RuntimeException in case of any error.
      */
     public void executeAndSaveBuildInfo(ArtifactoryClientConfiguration clientConfiguration) throws RuntimeException {
+        handleJavaTmpdirProperty();
         Build build = execute();
         if (build == null) {
             return;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
@@ -28,6 +28,7 @@ public abstract class PackageManagerExtractor implements Serializable {
      * @throws RuntimeException in case of any error.
      */
     public void executeAndSaveBuildInfo(ArtifactoryClientConfiguration clientConfiguration) throws RuntimeException {
+        // During build extractor's job, temp directories are created. This will make sure 'java.io.tmpdir' property is defined in Unix.
         handleJavaTmpdirProperty();
         Build build = execute();
         if (build == null) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
