### PR TITLE
Log the executed "nuget" and "dotnet" commands

### DIFF
--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/DotnetDriver.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/DotnetDriver.java
@@ -25,7 +25,7 @@ public class DotnetDriver extends ToolchainDriverBase {
             String sourceUrl = buildNugetSourceUrl(client, repo);
             List<String> extraArgs = new ArrayList<>();
             extraArgs.addAll(Arrays.asList(FLAG_PREFIX + CONFIG_FILE_FLAG, configPath, FLAG_PREFIX + NAME_FLAG, sourceName, FLAG_PREFIX + USERNAME_FLAG, username, FLAG_PREFIX + PASSWORD_FLAG, password, CLEAR_TEXT_PASSWORD_FLAG));
-            return runCommand(new String[]{"nuget", "add", "source", sourceUrl}, extraArgs);
+            return runCommand(new String[]{"nuget", "add", "source", sourceUrl}, extraArgs, logger);
         } catch (Exception e) {
             throw new IOException("dotnet nuget add source failed: " + e.getMessage() + ". Please make sure .NET Core 3.1.200 SDK or above is installed.", e);
         }
@@ -36,7 +36,7 @@ public class DotnetDriver extends ToolchainDriverBase {
         List<String> args = new ArrayList<>();
         args.add(GLOBAL_PACKAGES_ARG);
         args.add(getFlagSyntax(LIST_FLAG));
-        String output = runCommand(new String[]{"nuget", LOCALS_ARG,}, args);
+        String output = runCommand(new String[]{"nuget", LOCALS_ARG,}, args, logger);
         return output.replaceFirst(GLOBAL_PACKAGES_REGEX, "").trim();
     }
 

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/NugetDriver.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/NugetDriver.java
@@ -21,7 +21,7 @@ public class NugetDriver extends ToolchainDriverBase {
             String sourceUrl = buildNugetSourceUrl(client, repo);
             List<String> extraArgs = new ArrayList<>();
             extraArgs.addAll(Arrays.asList(FLAG_PREFIX + CONFIG_FILE_FLAG, configPath, FLAG_PREFIX + SOURCE_FLAG, sourceUrl, FLAG_PREFIX + NAME_FLAG, sourceName, FLAG_PREFIX + USERNAME_FLAG, username, FLAG_PREFIX + PASSWORD_FLAG, password));
-            return runCommand(new String[]{"sources", "add"}, extraArgs);
+            return runCommand(new String[]{"sources", "add"}, extraArgs, logger);
         } catch (Exception e) {
             throw new IOException("nuget sources add failed: " + e.getMessage(), e);
         }
@@ -32,7 +32,7 @@ public class NugetDriver extends ToolchainDriverBase {
         List<String> args = new ArrayList<>();
         args.add(GLOBAL_PACKAGES_ARG);
         args.add(getFlagSyntax(LIST_FLAG));
-        String output = runCommand(new String[]{LOCALS_ARG, }, args);
+        String output = runCommand(new String[]{LOCALS_ARG, }, args, logger);
         return output.replaceFirst(GLOBAL_PACKAGES_REGEX, "").trim();
     }
 

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/ToolchainDriverBase.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/ToolchainDriverBase.java
@@ -60,7 +60,7 @@ abstract public class ToolchainDriverBase implements Serializable {
     abstract public String getFlagSyntax(String flagName);
 
     public String help() throws IOException, InterruptedException {
-        return runCommand(new String[]{"help"}, Collections.emptyList());
+        return runCommand(new String[]{"help"}, Collections.emptyList(), logger);
     }
 
     protected String buildNugetSourceUrl(ArtifactoryBaseClient client, String repo) throws Exception {
@@ -81,11 +81,7 @@ abstract public class ToolchainDriverBase implements Serializable {
         }
     }
 
-    protected String runCommand(String[] args, List<String> extraArgs) throws IOException, InterruptedException {
-        return runCommand(args, extraArgs, null);
-    }
-
-    private String runCommand(String[] args, List<String> extraArgs, Log logger) throws IOException, InterruptedException {
+    protected String runCommand(String[] args, List<String> extraArgs, Log logger) throws IOException, InterruptedException {
         List<String> finalArgs = Stream.concat(Arrays.stream(args), extraArgs.stream()).collect(Collectors.toList());
         CommandResults nugetCommandRes = commandExecutor.exeCommand(workingDirectory, finalArgs, logger);
         if (!nugetCommandRes.isOk()) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -133,18 +133,17 @@ public class CommandExecutor implements Serializable {
     }
 
     private static Process runProcess(File execDir, List<String> args, String[] env, Log logger) throws IOException {
-        String strArgs = String.join(" ", args);
-        if (logger != null) {
-            logger.info("Executing command: " + UrlUtils.maskCredentialsInUrl(strArgs));
-        }
         if (isWindows()) {
-            return Runtime.getRuntime().exec(new String[]{"cmd", "/c", strArgs}, env, execDir);
-        }
+            args.add(0, "cmd");
+            args.add(1, "/c");
+        } else
         if (isMac()) {
-            return Runtime.getRuntime().exec(new String[]{"/bin/sh", "-c", strArgs}, env, execDir);
+            args.add(0, "/bin/sh");
+            args.add(1, "-c");
+        };
+        if (logger != null) {
+            logger.info("Executing command: " + UrlUtils.maskCredentialsInUrl(String.join(" ", args)));
         }
-        // Linux
         return Runtime.getRuntime().exec(args.toArray(new String[0]), env, execDir);
     }
-
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -136,11 +136,10 @@ public class CommandExecutor implements Serializable {
         if (isWindows()) {
             args.add(0, "cmd");
             args.add(1, "/c");
-        } else
-        if (isMac()) {
+        } else if (isMac()) {
             args.add(0, "/bin/sh");
             args.add(1, "-c");
-        };
+        }
         if (logger != null) {
             logger.info("Executing command: " + UrlUtils.maskCredentialsInUrl(String.join(" ", args)));
         }


### PR DESCRIPTION
This pull requests adds a log print for each "nuget" and "dotnet" command execited.

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
