### PR TITLE
Log the executed "nuget" and "dotnet" commands - Fix

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -44,7 +44,7 @@ public class GoDriver implements Serializable {
     public CommandResults runCmd(List<String> args, boolean prompt) throws IOException {
         CommandResults goCmdResult;
         try {
-            goCmdResult = commandExecutor.exeCommand(workingDirectory, args, logger);
+            goCmdResult = commandExecutor.exeCommand(workingDirectory, args, null, logger);
         } catch (IOException | InterruptedException e) {
             throw new IOException("Go execution failed", e);
         }

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
@@ -127,7 +127,7 @@ public class GoExtractorTest extends IntegrationTestsBase {
         List<String> goCleanArgs = new ArrayList<>();
         goCleanArgs.add("clean");
         goCleanArgs.add("-modcache");
-        goCommandExecutor.exeCommand(PROJECTS_ROOT.toFile(), goCleanArgs, log);
+        goCommandExecutor.exeCommand(PROJECTS_ROOT.toFile(), goCleanArgs, null, log);
         env.clear();
         // Since we are handling dummy projects, we want to avoid package validation against Go's checksum DB.
         env.put("GONOSUMDB", "github.com/jfrog");

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/NpmDriver.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/NpmDriver.java
@@ -70,7 +70,7 @@ public class NpmDriver implements Serializable {
         args.add("--long");
         args.addAll(extraArgs);
         try {
-            CommandResults npmCommandRes = commandExecutor.exeCommand(workingDirectory, args, null);
+            CommandResults npmCommandRes = commandExecutor.exeCommand(workingDirectory, args, null, null);
             String res = StringUtils.isBlank(npmCommandRes.getRes()) ? "{}" : npmCommandRes.getRes();
             JsonNode npmLsResults = jsonReader.readTree(res);
             if (!npmCommandRes.isOk() && !npmLsResults.has("problems")) {
@@ -100,7 +100,7 @@ public class NpmDriver implements Serializable {
 
     private String runCommand(File workingDirectory, String[] args, List<String> extraArgs, Log logger) throws IOException, InterruptedException {
         List<String> finalArgs = Stream.concat(Arrays.stream(args), extraArgs.stream()).collect(Collectors.toList());
-        CommandResults npmCommandRes = commandExecutor.exeCommand(workingDirectory, finalArgs, logger);
+        CommandResults npmCommandRes = commandExecutor.exeCommand(workingDirectory, finalArgs, null, logger);
         if (!npmCommandRes.isOk()) {
             throw new IOException(npmCommandRes.getErr() + npmCommandRes.getRes());
         }

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/DotnetDriver.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/DotnetDriver.java
@@ -23,9 +23,9 @@ public class DotnetDriver extends ToolchainDriverBase {
     public String addSource(String configPath, ArtifactoryDependenciesClient client, String repo, String sourceName, String username, String password) throws IOException {
         try {
             String sourceUrl = buildNugetSourceUrl(client, repo);
-            List<String> extraArgs = new ArrayList<>();
-            extraArgs.addAll(Arrays.asList(FLAG_PREFIX + CONFIG_FILE_FLAG, configPath, FLAG_PREFIX + NAME_FLAG, sourceName, FLAG_PREFIX + USERNAME_FLAG, username, FLAG_PREFIX + PASSWORD_FLAG, password, CLEAR_TEXT_PASSWORD_FLAG));
-            return runCommand(new String[]{"nuget", "add", "source", sourceUrl}, extraArgs, logger);
+            List<String> extraArgs = Arrays.asList(getFlagSyntax(CONFIG_FILE_FLAG), configPath, getFlagSyntax(NAME_FLAG), sourceName);
+            List<String> credentials = Arrays.asList(getFlagSyntax(USERNAME_FLAG), username, getFlagSyntax(PASSWORD_FLAG), password, CLEAR_TEXT_PASSWORD_FLAG);
+            return runCommand(new String[]{"nuget", "add", "source", sourceUrl}, extraArgs, credentials, logger);
         } catch (Exception e) {
             throw new IOException("dotnet nuget add source failed: " + e.getMessage() + ". Please make sure .NET Core 3.1.200 SDK or above is installed.", e);
         }
@@ -36,7 +36,7 @@ public class DotnetDriver extends ToolchainDriverBase {
         List<String> args = new ArrayList<>();
         args.add(GLOBAL_PACKAGES_ARG);
         args.add(getFlagSyntax(LIST_FLAG));
-        String output = runCommand(new String[]{"nuget", LOCALS_ARG,}, args, logger);
+        String output = runCommand(new String[]{"nuget", LOCALS_ARG}, args, null, logger);
         return output.replaceFirst(GLOBAL_PACKAGES_REGEX, "").trim();
     }
 

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/NugetDriver.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/NugetDriver.java
@@ -6,7 +6,10 @@ import org.jfrog.build.extractor.executor.CommandExecutor;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class NugetDriver extends ToolchainDriverBase {
     private static final String FLAG_PREFIX = "-";
@@ -19,9 +22,9 @@ public class NugetDriver extends ToolchainDriverBase {
     public String addSource(String configPath, ArtifactoryDependenciesClient client, String repo, String sourceName, String username, String password) throws IOException {
         try {
             String sourceUrl = buildNugetSourceUrl(client, repo);
-            List<String> extraArgs = new ArrayList<>();
-            extraArgs.addAll(Arrays.asList(FLAG_PREFIX + CONFIG_FILE_FLAG, configPath, FLAG_PREFIX + SOURCE_FLAG, sourceUrl, FLAG_PREFIX + NAME_FLAG, sourceName, FLAG_PREFIX + USERNAME_FLAG, username, FLAG_PREFIX + PASSWORD_FLAG, password));
-            return runCommand(new String[]{"sources", "add"}, extraArgs, logger);
+            List<String> extraArgs = Arrays.asList(getFlagSyntax(CONFIG_FILE_FLAG), configPath, getFlagSyntax(SOURCE_FLAG), sourceUrl, getFlagSyntax(NAME_FLAG), sourceName);
+            List<String> credentials = Arrays.asList(getFlagSyntax(USERNAME_FLAG), username, getFlagSyntax(PASSWORD_FLAG), password);
+            return runCommand(new String[]{"sources", "add"}, extraArgs, credentials, logger);
         } catch (Exception e) {
             throw new IOException("nuget sources add failed: " + e.getMessage(), e);
         }
@@ -32,7 +35,7 @@ public class NugetDriver extends ToolchainDriverBase {
         List<String> args = new ArrayList<>();
         args.add(GLOBAL_PACKAGES_ARG);
         args.add(getFlagSyntax(LIST_FLAG));
-        String output = runCommand(new String[]{LOCALS_ARG, }, args, logger);
+        String output = runCommand(new String[]{LOCALS_ARG}, args, null, logger);
         return output.replaceFirst(GLOBAL_PACKAGES_REGEX, "").trim();
     }
 

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/ToolchainDriverBase.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/drivers/ToolchainDriverBase.java
@@ -60,7 +60,7 @@ abstract public class ToolchainDriverBase implements Serializable {
     abstract public String getFlagSyntax(String flagName);
 
     public String help() throws IOException, InterruptedException {
-        return runCommand(new String[]{"help"}, Collections.emptyList(), logger);
+        return runCommand(new String[]{"help"}, Collections.emptyList(), null, logger);
     }
 
     protected String buildNugetSourceUrl(ArtifactoryBaseClient client, String repo) throws Exception {
@@ -73,17 +73,28 @@ abstract public class ToolchainDriverBase implements Serializable {
         return sourceUrlBuilder.build().toURL().toString();
     }
 
-    public void runCmd(String args, List<String> extraArgs, boolean prompt) throws IOException, InterruptedException {
+    public void runCmd(String args, List<String> extraArgs, List<String> credentials, boolean prompt) throws IOException, InterruptedException {
         Log logger = prompt ? this.logger : null;
-        String cmdOutput = runCommand(args.split(" "), extraArgs, logger);
+        String cmdOutput = runCommand(args.split(" "), extraArgs, credentials, logger);
         if (prompt) {
             logger.info(cmdOutput);
         }
     }
 
-    protected String runCommand(String[] args, List<String> extraArgs, Log logger) throws IOException, InterruptedException {
+    /**
+     * Run .NET/Nuget command.
+     *
+     * @param args        - Base args, such as "nuget add source source-url"
+     * @param extraArgs   - Extra args, such as "--config=config-path --name=source-name"
+     * @param credentials - Credentials, such as "--username=username --password=password"
+     * @param logger      - The logger of the command
+     * @return the output.
+     * @throws IOException          if the command execution returned an error.
+     * @throws InterruptedException if the command execution interrupted.
+     */
+    protected String runCommand(String[] args, List<String> extraArgs, List<String> credentials, Log logger) throws IOException, InterruptedException {
         List<String> finalArgs = Stream.concat(Arrays.stream(args), extraArgs.stream()).collect(Collectors.toList());
-        CommandResults nugetCommandRes = commandExecutor.exeCommand(workingDirectory, finalArgs, logger);
+        CommandResults nugetCommandRes = commandExecutor.exeCommand(workingDirectory, finalArgs, credentials, logger);
         if (!nugetCommandRes.isOk()) {
             throw new IOException(nugetCommandRes.getErr() + nugetCommandRes.getRes());
         }

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
@@ -180,7 +180,7 @@ public class NugetRun extends PackageManagerExtractor {
                 String configPath = configFile.getAbsolutePath();
                 extraArgs = StringUtils.isBlank(configPath) ? null : Arrays.asList(toolchainDriver.getFlagSyntax(ToolchainDriverBase.CONFIG_FILE_FLAG), configPath);
             }
-            toolchainDriver.runCmd(nugetCmdArgs, extraArgs, true);
+            toolchainDriver.runCmd(nugetCmdArgs, extraArgs, null, true);
         }
     }
 

--- a/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/PipDriver.java
+++ b/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/PipDriver.java
@@ -48,7 +48,7 @@ public class PipDriver implements Serializable {
     }
 
     public String runCommand(File workingDirectory, List<String> args, Log logger) throws IOException, InterruptedException {
-        CommandResults pipCommandRes = commandExecutor.exeCommand(workingDirectory, args, logger);
+        CommandResults pipCommandRes = commandExecutor.exeCommand(workingDirectory, args, null, logger);
         if (!pipCommandRes.isOk()) {
             throw new IOException(pipCommandRes.getErr() + pipCommandRes.getRes());
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -95,6 +95,7 @@ public class CommandExecutor implements Serializable {
         if (credentials == null || credentials.isEmpty()) {
             return command;
         }
+        // The mask pattern is a regex, which is used to mask all credentials
         String maskPattern = String.join("|", credentials);
         return command.replaceAll(maskPattern, "***");
     }
@@ -115,7 +116,7 @@ public class CommandExecutor implements Serializable {
         try {
             CommandResults commandRes = new CommandResults();
             Process process = runProcess(execDir, args, credentials, env, logger);
-            // The output stream is not necessary in non-interactive scenarios
+            // The output stream is not necessary in non-interactive scenarios, therefore we can close it now.
             process.getOutputStream().close();
             try (InputStream inputStream = process.getInputStream();
                  InputStream errorStream = process.getErrorStream()) {
@@ -169,6 +170,5 @@ public class CommandExecutor implements Serializable {
         output = maskCredentials(output, credentials);
 
         logger.info("Executing command: " + output);
-
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/issuesCollection/IssuesCollector.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/issuesCollection/IssuesCollector.java
@@ -139,7 +139,7 @@ public class IssuesCollector implements Serializable {
             args.add(previousVcsRevision + "..");
         }
         CommandExecutor commandExecutor = new CommandExecutor("git", null);
-        CommandResults res = commandExecutor.exeCommand(execDir, args, logger);
+        CommandResults res = commandExecutor.exeCommand(execDir, args, null, logger);
         if (!res.isOk()) {
             throw new IOException(ISSUES_COLLECTION_ERROR_PREFIX + "Git log command failed: " + res.getErr());
         }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/GitUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/GitUtilsTest.java
@@ -33,7 +33,7 @@ public class GitUtilsTest {
 
     private String getGitFieldWithExecutor(File execDir, Log log, List<String> args) throws IOException, InterruptedException {
         CommandExecutor executor = new CommandExecutor("git", null);
-        CommandResults res = executor.exeCommand(execDir, args, log);
+        CommandResults res = executor.exeCommand(execDir, args, null, log);
         Assert.assertTrue(res.isOk());
         return res.getRes().trim();
     }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -1,9 +1,16 @@
 package org.jfrog.build.extractor.executor;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.jfrog.build.api.util.NullLog;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
-import static org.testng.Assert.assertEquals;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.*;
 
 /**
  * Created by Bar Belity on 04/08/2020.
@@ -25,5 +32,33 @@ public class CommandExecutorTest {
     public void getFixedWindowsPathTest(String path, String expected) {
         String actual = CommandExecutor.getFixedWindowsPath(path);
         assertEquals(actual, expected);
+    }
+
+    @DataProvider
+    private Object[][] maskCredentialsPathProvider() {
+        return new Object[][]{
+                {"command with no secrets", "command with no secrets", Lists.newArrayList()},
+                {"command with no secrets", "command with no secrets", null},
+                {"command with one secret --password=abc123", "command with one secret ***", Lists.newArrayList("--password=abc123")},
+                {"command with two secrets --username=Grogu --password=abc123", "command with two secrets *** ***", Lists.newArrayList("--username=Grogu", "--password=abc123")}
+        };
+    }
+
+    @Test(dataProvider = "maskCredentialsPathProvider")
+    public void testMaskCredentials(String command, String expected, List<String> credentials) {
+        assertEquals(CommandExecutor.maskCredentials(command, credentials), expected);
+    }
+
+    @Test
+    public void testExeCommand() {
+        List<String> args = new ArrayList<>();
+        args.add("--version");
+        CommandExecutor executor = new CommandExecutor("git", System.getenv());
+        try {
+            CommandResults results = executor.exeCommand(null, args, null, new NullLog());
+            assertTrue(results.isOk(), results.getErr() + results.getRes());
+        } catch (InterruptedException | IOException e) {
+            fail(ExceptionUtils.getRootCauseMessage(e));
+        }
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

This PR is targeting an issue introduced in https://github.com/jfrog/build-info/pull/420.
The command executor in mac is expecting to get all command arguments as a string variable.
For example, when running the go test in the Jenkins Artifactory plugin we may get an error with the usage of Go:
```
[Pipeline] rtGoRun
Executing command: /bin/sh -c go list -m
Go is a tool for managing Go source code.

Usage:

	go <command> [arguments]
```
