### PR TITLE
BI-552 - Improve VCS URL algorithm

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/GitUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/GitUtils.java
@@ -104,7 +104,7 @@ public class GitUtils {
             originalUrl += ".git";
         }
 
-        String maskedUrl = UrlUtils.maskCredentialsInUrl(originalUrl);
+        String maskedUrl = UrlUtils.removeCredentialsFromUrl(originalUrl);
         log.debug("Fetched url from git config: " + maskedUrl);
         return maskedUrl;
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/UrlUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/UrlUtils.java
@@ -10,21 +10,22 @@ import java.util.regex.Pattern;
  */
 public class UrlUtils {
 
-    private static Pattern CredentialsInUrlRegexpPattern = Pattern.compile("((http|https):\\/\\/.+:.*@)");
+    private static final Pattern CREDENTIALS_IN_URL_REGEX = Pattern.compile("(http|https|git)://.+@");
 
     /**
-     * Mask the credentials information from a given line (log, url...).
-     * The credentials are presented as user:password.
-     * @param lineWithCredentials - Line for masking url with credentials.
+     * Remove URL credentials information from a given line (log, URL...).
+     * The credentials are presented as 'user:password' or a token.
+     *
+     * @param lineWithCredentials - Line for masking URL with credentials.
      * @return The line with masked credentials.
      */
-    public static String maskCredentialsInUrl(String lineWithCredentials) {
-        Matcher matcher = CredentialsInUrlRegexpPattern.matcher(lineWithCredentials);
+    public static String removeCredentialsFromUrl(String lineWithCredentials) {
+        Matcher matcher = CREDENTIALS_IN_URL_REGEX.matcher(lineWithCredentials);
         if (!matcher.find()) {
             return lineWithCredentials;
         }
         String credentialsPart = matcher.group();
-        String[] split = credentialsPart.split("//");
-        return StringUtils.replace(lineWithCredentials, credentialsPart, split[0] + "//***.***@", 1);
+        String protocol = matcher.group(1);
+        return StringUtils.replace(lineWithCredentials, credentialsPart, protocol + "://");
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -141,7 +141,7 @@ public class CommandExecutor implements Serializable {
             args.add(1, "-c");
         }
         if (logger != null) {
-            logger.info("Executing command: " + UrlUtils.maskCredentialsInUrl(String.join(" ", args)));
+            logger.info("Executing command: " + UrlUtils.removeCredentialsFromUrl(String.join(" ", args)));
         }
         return Runtime.getRuntime().exec(args.toArray(new String[0]), env, execDir);
     }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/UrlUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/UrlUtilsTest.java
@@ -11,17 +11,21 @@ public class UrlUtilsTest {
 
     @Test(dataProvider = "testMaskUrlsProvider")
     public void testMaskCredentialsInUrl(String testName, String originalUrl, String expectedUrl) {
-        Assert.assertEquals(UrlUtils.maskCredentialsInUrl(originalUrl), expectedUrl, "Failed masking credentials on test name: " + testName);
+        Assert.assertEquals(UrlUtils.removeCredentialsFromUrl(originalUrl), expectedUrl, "Failed masking credentials on test name: " + testName);
     }
 
     @DataProvider
     private Object[][] testMaskUrlsProvider() {
         return new String[][]{
-                {"http", "This is an example line http://user:password@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line http://***.***@127.0.0.1:8081/artifactory/path/to/repo"},
-                {"https", "This is an example line https://user:password@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line https://***.***@127.0.0.1:8081/artifactory/path/to/repo"},
+                {"http", "This is an example line http://user:password@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line http://127.0.0.1:8081/artifactory/path/to/repo"},
+                {"https", "This is an example line https://user:password@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo"},
+                {"git", "This is an example line git://user:password@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line git://127.0.0.1:8081/artifactory/path/to/repo"},
+                {"http with token", "This is an example line http://123456@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line http://127.0.0.1:8081/artifactory/path/to/repo"},
+                {"https with token", "This is an example line https://123456@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo"},
+                {"git with token", "This is an example line git://123456@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line git://127.0.0.1:8081/artifactory/path/to/repo"},
                 {"No credentials", "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo", "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo"},
                 {"No http", "This is an example line", "This is an example line"},
-                {"Multiple @", "This is an example line https://[user]:passw@ord@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line https://***.***@127.0.0.1:8081/artifactory/path/to/repo"},
+                {"Multiple @", "This is an example line https://[user]:passw@ord@127.0.0.1:8081/artifactory/path/to/repo", "This is an example line https://127.0.0.1:8081/artifactory/path/to/repo"},
         };
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

When the VCS URL contains a URL with credentials, instead of masking it with '***', remove the credentials. This way, the VCS URL will be clickable.
For example:
Before the change:
`https://***:***@github.com/jfrog/build-info`
After the change:
`https://github.com/jfrog/build-info`