### PR TITLE
Increase command executor timeout to 30 seconds

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -22,7 +22,7 @@ import static java.lang.String.join;
 public class CommandExecutor implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final int TIMEOUT_EXIT_VALUE = 124;
-    private static final int TIMEOUT_SECONDS = 10;
+    private static final int TIMEOUT_SECONDS = 30;
 
     private final String[] env;
     private final String executablePath;


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
