### PR TITLE
Optimize pip

### DIFF
--- a/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractor.java
+++ b/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractor.java
@@ -23,9 +23,9 @@ public class PipBuildInfoExtractor {
 
     private static final String PIP_AQL_FORMAT =
             "items.find({" +
-                    "\"repo\": \"%s\"," +
-                    "\"$or\": [%s]" +
-                    "}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")";
+                    "\"repo\":\"%s\"," +
+                    "\"$or\":[%s]" +
+                    "}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")";
     private static final String PIP_AQL_FILE_PART = "{\"name\":\"%s\"},";
     private static final int PIP_AQL_BULK_SIZE = 3;
 

--- a/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractor.java
+++ b/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractor.java
@@ -26,12 +26,8 @@ public class PipBuildInfoExtractor {
                     "\"repo\": \"%s\"," +
                     "\"$or\": [%s]" +
                     "}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")";
-    private static final String PIP_AQL_FILE_PART =
-            "{\"$and\":[{" +
-                    "\"path\":{\"$match\":\"*\"}," +
-                    "\"name\":{\"$match\":\"%s\"}" +
-                    "}]},";
-    private static final int PIP_AQL_BULK_SIZE = 100;
+    private static final String PIP_AQL_FILE_PART = "{\"name\":\"%s\"},";
+    private static final int PIP_AQL_BULK_SIZE = 3;
 
     Build extract(ArtifactoryDependenciesClient client, String repository, String installationLog, Path executionPath, String module, Log logger) throws IOException {
         // Parse logs and create dependency list of <pkg-name, pkg-file>
@@ -94,9 +90,9 @@ public class PipBuildInfoExtractor {
      * Get Dependencies information from Artifactory by running AQL to get the checksums.
      *
      * @param fileToPackageMap - Mapping between a downloaded file to its package name.
-     * @param repository - Resolution repository.
-     * @param client - Artifactory client for fetching artifacts data.
-     * @param logger - The logger.
+     * @param repository       - Resolution repository.
+     * @param client           - Artifactory client for fetching artifacts data.
+     * @param logger           - The logger.
      * @return Mapping of a package-name and its Dependency object.
      * @throws IOException
      */
@@ -110,7 +106,7 @@ public class PipBuildInfoExtractor {
     }
 
     static List<String> createAqlQueries(Map<String, String> fileToPackageMap, String repository, int bulkSize) {
-        List<String> aqlQueries =  new ArrayList<>();
+        List<String> aqlQueries = new ArrayList<>();
         StringBuilder filesQueryPartBuilder = new StringBuilder();
         int filesCounter = 0;
         for (String file : fileToPackageMap.keySet()) {

--- a/build-info-extractor-pip/src/test/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractorTest.java
+++ b/build-info-extractor-pip/src/test/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractorTest.java
@@ -15,15 +15,15 @@ public class PipBuildInfoExtractorTest {
     private Object[][] createAqlQueriesProvider() {
         return new Object[][]{
                 {fileToPackageTestMap, 2, Arrays.asList(
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file2.whl\"},{\"name\":\"file4.egg\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file3.tar.gz\"},{\"name\":\"file1.tgz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")},
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file2.whl\"},{\"name\":\"file4.egg\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")",
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file3.tar.gz\"},{\"name\":\"file1.tgz\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")")},
                 {fileToPackageTestMap, 1, Arrays.asList(
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file2.whl\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file4.egg\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file3.tar.gz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file1.tgz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")},
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file2.whl\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")",
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file4.egg\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")",
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file3.tar.gz\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")",
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file1.tgz\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")")},
                 {fileToPackageTestMap, 4, Collections.singletonList(
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file2.whl\"},{\"name\":\"file4.egg\"},{\"name\":\"file3.tar.gz\"},{\"name\":\"file1.tgz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")}
+                        "items.find({\"repo\":\"repository\",\"$or\":[{\"name\":\"file2.whl\"},{\"name\":\"file4.egg\"},{\"name\":\"file3.tar.gz\"},{\"name\":\"file1.tgz\"}]}).include(\"name\",\"repo\",\"path\",\"actual_sha1\",\"actual_md5\")")}
         };
     }
 

--- a/build-info-extractor-pip/src/test/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractorTest.java
+++ b/build-info-extractor-pip/src/test/java/org/jfrog/build/extractor/pip/extractor/PipBuildInfoExtractorTest.java
@@ -15,15 +15,15 @@ public class PipBuildInfoExtractorTest {
     private Object[][] createAqlQueriesProvider() {
         return new Object[][]{
                 {fileToPackageTestMap, 2, Arrays.asList(
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file2.whl\"}}]},{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file4.egg\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file3.tar.gz\"}}]},{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file1.tgz\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")},
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file2.whl\"},{\"name\":\"file4.egg\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file3.tar.gz\"},{\"name\":\"file1.tgz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")},
                 {fileToPackageTestMap, 1, Arrays.asList(
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file2.whl\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file4.egg\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file3.tar.gz\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file1.tgz\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")},
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file2.whl\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file4.egg\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file3.tar.gz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")",
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file1.tgz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")},
                 {fileToPackageTestMap, 4, Collections.singletonList(
-                        "items.find({\"repo\": \"repository\",\"$or\": [{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file2.whl\"}}]},{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file4.egg\"}}]},{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file3.tar.gz\"}}]},{\"$and\":[{\"path\":{\"$match\":\"*\"},\"name\":{\"$match\":\"file1.tgz\"}}]}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")}
+                        "items.find({\"repo\": \"repository\",\"$or\": [{\"name\":\"file2.whl\"},{\"name\":\"file4.egg\"},{\"name\":\"file3.tar.gz\"},{\"name\":\"file1.tgz\"}]}).include(\"name\", \"repo\", \"path\", \"actual_sha1\", \"actual_md5\")")}
         };
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves #429 

* Reduce AQL bulk size from 100 to 3
* Optimize AQL queries by:
  * Change `"name":{"$match":"%s"}` to `"name":"%s"` because the file names are not wildcard patterns, we should use `equal` instead of `match`.
  * Delete redundant fields:
    * Remove `"path":{"$match":"*"}` because it is already the default
    * Remove spaces
