### PR TITLE
Build automation - build all if none selected - fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ node('java') {
 
             // If no project is selected - build all of them.
             // This functionality is important in order to allow triggering by SCM.
-            def projectsToBuild = selectedProjects ?: projectsConfig.keySet()
+            def projectsToBuild = (selectedProjects && !selectedProjects.contains('ALL')) ?: projectsConfig.keySet()
             projectsToBuild.each { proj ->
                 stage("Building ${proj}") {
                     def buildConfig = projectsConfig[proj]


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Add support for `ALL` option when running the build info Jenkins job.
When the project is auto-triggered by SCM, the multi-select will choose the first option. In order to automatically build all projects, we should have the first option to be 'ALL'.
