### PR TITLE
Gradle Plugin - New "ALL_PUBLICATIONS" parameter

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.publish.Publication
+import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.ivy.IvyPublication
 import org.gradle.api.publish.ivy.plugins.IvyPublishPlugin
@@ -131,8 +132,16 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
      * @param publicationsNames - Publications names separated by commas
      */
     private static void addPublications(ArtifactoryTask artifactoryTask, PublishingExtension publishingExtension, String publicationsNames) {
+        PublicationContainer container = publishingExtension.getPublications();
         for (publicationName in publicationsNames.split(",")) {
-            Publication publication = publishingExtension.getPublications().findByName(publicationName);
+            // If ALL_PUBLICATIONS parameter was provided, add all publications and return.
+            if (publicationName == TaskHelperPublications.ALL_PUBLICATIONS) {
+                for (publication in container) {
+                    artifactoryTask.publications(publication)
+                }
+                return
+            }
+            Publication publication = container.findByName(publicationName);
             artifactoryTask.publications(publication)
         }
     }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -132,15 +132,22 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
      * @param publicationsNames - Publications names separated by commas
      */
     private static void addPublications(ArtifactoryTask artifactoryTask, PublishingExtension publishingExtension, String publicationsNames) {
-        PublicationContainer container = publishingExtension.getPublications();
-        for (publicationName in publicationsNames.split(",")) {
-            // If ALL_PUBLICATIONS parameter was provided, add all publications and return.
-            if (publicationName == TaskHelperPublications.ALL_PUBLICATIONS) {
-                for (publication in container) {
-                    artifactoryTask.publications(publication)
-                }
-                return
+        if (StringUtils.isEmpty(publicationsNames)) {
+            return
+        }
+
+        PublicationContainer container = publishingExtension.getPublications()
+        Collection<String> ciPublications = publicationsNames.split(",")
+
+        // If ALL_PUBLICATIONS parameter was provided, add all publications and return.
+        if (ciPublications.contains(TaskHelperPublications.ALL_PUBLICATIONS)) {
+            for (publication in container) {
+                artifactoryTask.publications(publication)
             }
+            return
+        }
+        // Add specified publications.
+        for (publicationName in ciPublications) {
             Publication publication = container.findByName(publicationName);
             artifactoryTask.publications(publication)
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Following the discussion in #407, the _publications_ method now accepts a new parameter, "ALL_PUBLICATIONS", that will trigger the usage of all publications configured in the build script.
The parameter can currently be passed in a `build.gradle` file and used by the Artifactory Plugin directly, or be passed to the _publications_ API in Jenkins.
Other CI integrations will be supported in the future, after the _publications_ API will be implemented on their end.