### PR TITLE
NoSuchMethodError is thrown using IOUtils.toString(in, StandardCharsets.UTF_8)

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/ArtifactoryHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/ArtifactoryHttpClient.java
@@ -251,7 +251,7 @@ public class ArtifactoryHttpClient implements AutoCloseable {
                 return artifactoryResponse;
             }
             try (InputStream in = response.getEntity().getContent()) {
-                String content = IOUtils.toString(in, StandardCharsets.UTF_8);
+                String content = IOUtils.toString(in, StandardCharsets.UTF_8.name());
                 if (StringUtils.isEmpty(content)) {
                     return artifactoryResponse;
                 }
@@ -296,7 +296,7 @@ public class ArtifactoryHttpClient implements AutoCloseable {
     private String getResponseEntityContent(HttpEntity responseEntity) throws IOException {
         InputStream in = responseEntity.getContent();
         if (in != null) {
-            return IOUtils.toString(in, StandardCharsets.UTF_8);
+            return IOUtils.toString(in, StandardCharsets.UTF_8.name());
         }
         return "";
     }

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
@@ -229,7 +229,7 @@ public class DockerUtils {
     public static String entityToString(HttpEntity entity) throws IOException {
         if (entity != null) {
             InputStream is = entity.getContent();
-            return IOUtils.toString(is, StandardCharsets.UTF_8);
+            return IOUtils.toString(is, StandardCharsets.UTF_8.name());
         }
         return "";
     }

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
@@ -95,7 +95,7 @@ public class DockerImage implements Serializable {
         logger.info("Trying to download manifest from " + downloadUrl);
         try (CloseableHttpResponse response = dependenciesClient.downloadArtifact(downloadUrl)) {
             entity = response.getEntity();
-            return Pair.of(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8), pathWithoutRepo);
+            return Pair.of(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8.name()), pathWithoutRepo);
         } catch (Exception e) {
             if (dependenciesClient.isLocalRepo(targetRepo)) {
                 throw e;
@@ -121,7 +121,7 @@ public class DockerImage implements Serializable {
             try (CloseableHttpResponse response = dependenciesClient.downloadArtifact(downloadUrl)) {
                 entity = response.getEntity();
                 pathWithoutRepo = StringUtils.substringAfter(manifestPath, "/");
-                return Pair.of(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8), pathWithoutRepo);
+                return Pair.of(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8.name()), pathWithoutRepo);
             }
         } finally {
             EntityUtils.consumeQuietly(entity);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/420