### PR TITLE
Release script - fix set next development version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,6 +158,7 @@ node('java') {
             }
 
             echo "Bump development version"
+            selectedProjects = getSelectedProjects(BUILD_PROJECTS, projectsConfig)
             bumpVersion(selectedProjects, projectsConfig, latestNextVersion, 'nextVersion')
             sh 'git commit -am "[artifactory-release] Next development version"'
             wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: 'GITHUB_API_KEY', var: 'SECRET']]]) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Setting the next development version should set the next build-info version too:
https://github.com/jfrog/build-info/commit/5cd06acba9e5408cc0c671ab128e58889e4e1026#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R8