### PR TITLE
BI-562 - Command executor in Linux does not accept multiple commands

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -157,11 +157,10 @@ public class CommandExecutor implements Serializable {
         }
         if (SystemUtils.IS_OS_WINDOWS) {
             args.addAll(0, Arrays.asList("cmd", "/c"));
-        } else if (SystemUtils.IS_OS_MAC) {
-            // In MacOS, the arguments for '/bin/sh -c' must be a single string. For example "/bin/sh","-c", "npm i".
+        } else {
             String strArgs = join(" ", args);
             args = new ArrayList<String>() {{
-                add("/bin/sh");
+                add("/bin/bash");
                 add("-c");
                 add(strArgs);
             }};


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/415

Currently the command executor for Linux, run each command separately:
```java
Runtime.getRuntime().exec(args.toArray(new String[0]), env, execDir)
```
However, it doesn't work for multiple commands, like commands with `&&`.

To support multiple commands, the command executor can get for both Linux and Mac 3 arguments:
1. `/bin/bash`
2. `-c`
3. The commands to run in 1 string