### PR TITLE
BI-562 - Command executor in Linux does not accept multiple commands - fix

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -160,7 +160,7 @@ public class CommandExecutor implements Serializable {
         } else {
             String strArgs = join(" ", args);
             args = new ArrayList<String>() {{
-                add("/bin/bash");
+                add("/bin/sh");
                 add("-c");
                 add(strArgs);
             }};


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Revert `/bin/bash` to `/bin/sh` following @saper's  [review](https://github.com/jfrog/build-info/pull/452#discussion_r570107488).