### PR TITLE
BI-565 collect issues should ignore errors when the revision of the previous build info doesn't exist

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/issuesCollection/IssuesCollector.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/issuesCollection/IssuesCollector.java
@@ -32,7 +32,16 @@ public class IssuesCollector implements Serializable {
     private static final String LATEST = "LATEST";
     private static final String GIT_LOG_LIMIT = "100";
 
+    public static Pattern REVISION_NOT_EXIST;
+
     public IssuesCollector() {
+    }
+
+    public static Pattern getRevisionNotExistPattern() {
+        if (REVISION_NOT_EXIST == null) {
+            REVISION_NOT_EXIST = Pattern.compile("fatal: Invalid revision range [a-fA-F0-9]+\\.\\.");
+        }
+        return REVISION_NOT_EXIST;
     }
 
     /**
@@ -141,8 +150,7 @@ public class IssuesCollector implements Serializable {
         CommandExecutor commandExecutor = new CommandExecutor("git", null);
         CommandResults res = commandExecutor.exeCommand(execDir, args, null, logger);
         if (!res.isOk()) {
-            Pattern pattern = Pattern.compile("fatal: Invalid revision range [a-fA-F0-9]+\\.\\.");
-            if (pattern.matcher(res.getErr()).find()) {
+            if (getRevisionNotExistPattern().matcher(res.getErr()).find()) {
                 logger.info("Revision: " + previousVcsRevision + " that was fetched from latest build info does not exist in the git revision range. No new issues are added.");
                 return "";
             }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/issuesCollection/IssuesCollector.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/issuesCollection/IssuesCollector.java
@@ -141,6 +141,11 @@ public class IssuesCollector implements Serializable {
         CommandExecutor commandExecutor = new CommandExecutor("git", null);
         CommandResults res = commandExecutor.exeCommand(execDir, args, null, logger);
         if (!res.isOk()) {
+            Pattern pattern = Pattern.compile("fatal: Invalid revision range [a-fA-F0-9]+\\.\\.");
+            if (pattern.matcher(res.getErr()).find()) {
+                logger.info("Revision: " + previousVcsRevision + " that was fetched from latest build info does not exist in the git revision range. No new issues are added.");
+                return "";
+            }
             throw new IOException(ISSUES_COLLECTION_ERROR_PREFIX + "Git log command failed: " + res.getErr());
         }
         return res.getRes();

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
@@ -93,8 +93,11 @@ public class IssuesCollectorTest extends IntegrationTestsBase {
     }
 
     @Test
-    // Test collection with a made up revision - the command should not throw an error, and 0 issues should be returned.
-    public void testCollectIssuesWithBadRevision() throws IOException, InterruptedException {
+    /**
+     * Test collection with a made up revision - the command should not throw an error, and 0 issues should be returned.
+     * This test covers the cenario of missing revision on the 'git log' output, probably due to a squash / revert. therefore, ignore and don't collect new issues.
+     */
+    public void testCollectIssuesWithNonExistingRevision() throws IOException, InterruptedException {
         List<Vcs> vcsList = Collections.singletonList(new Vcs("http://TESTING.com", "abcdefABCDEF1234567890123456789012345678"));
         runCollectIssues("git_issues2_.git_suffix", vcsList, 0);
     }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
@@ -92,6 +92,13 @@ public class IssuesCollectorTest extends IntegrationTestsBase {
         runCollectIssues("git_issues2_.git_suffix", vcsList, 2);
     }
 
+    @Test
+    // Test collection with a made up revision - the command should not throw an error, and 0 issues should be returned.
+    public void testCollectIssuesWithBadRevision() throws IOException, InterruptedException {
+        List<Vcs> vcsList = Collections.singletonList(new Vcs("http://TESTING.com", "abcdefABCDEF1234567890123456789012345678"));
+        runCollectIssues("git_issues2_.git_suffix", vcsList, 0);
+    }
+
     private void runCollectIssues(String sourceFolder, List<Vcs> vcs, int expectedNumOfIssues) throws IOException, InterruptedException {
         // Copy the provided folder and create .git
         FileUtils.deleteDirectory(dotGitPath);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
