### PR TITLE
Allow setting the SSL Context in the base client

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/ArtifactoryHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/ArtifactoryHttpClient.java
@@ -34,6 +34,7 @@ import org.apache.http.util.EntityUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.util.URI;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -65,6 +66,7 @@ public class ArtifactoryHttpClient implements AutoCloseable {
     private int connectionRetries = DEFAULT_CONNECTION_RETRY;
     private ProxyConfiguration proxyConfiguration;
     private boolean insecureTls = false;
+    private SSLContext sslContext;
 
     private PreemptiveHttpClient deployClient;
 
@@ -137,6 +139,10 @@ public class ArtifactoryHttpClient implements AutoCloseable {
         this.insecureTls = insecureTls;
     }
 
+    public void setSslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
     public int getConnectionRetries() {
         return connectionRetries;
     }
@@ -165,6 +171,7 @@ public class ArtifactoryHttpClient implements AutoCloseable {
                     .setConnectionRetries(connectionRetries)
                     .setInsecureTls(insecureTls)
                     .setTimeout(connectionTimeout)
+                    .setSslContext(sslContext)
                     .setLog(log);
             if (proxyConfiguration != null) {
                 clientBuilder.setProxyConfiguration(proxyConfiguration);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientBuilderBase.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientBuilderBase.java
@@ -5,6 +5,7 @@ import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBaseClient;
 
+import javax.net.ssl.SSLContext;
 import java.io.Serializable;
 
 /**
@@ -18,6 +19,7 @@ public abstract class ArtifactoryClientBuilderBase<T extends ArtifactoryClientBu
     protected int connectionTimeout = -1;
     protected int connectionRetry = -1;
     protected String artifactoryUrl;
+    protected SSLContext sslContext;
     protected String username;
     protected String password;
     protected String accessToken;
@@ -40,6 +42,11 @@ public abstract class ArtifactoryClientBuilderBase<T extends ArtifactoryClientBu
 
     public T setArtifactoryUrl(String artifactoryUrl) {
         this.artifactoryUrl = artifactoryUrl;
+        return self();
+    }
+
+    public T setSslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
         return self();
     }
 
@@ -105,6 +112,8 @@ public abstract class ArtifactoryClientBuilderBase<T extends ArtifactoryClientBu
                     proxyConfiguration.username,
                     proxyConfiguration.password);
         }
+
+        client.setSslContext(sslContext);
 
         if (connectionTimeout != -1) {
             client.setConnectionTimeout(connectionTimeout);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBaseClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBaseClient.java
@@ -12,6 +12,7 @@ import org.jfrog.build.client.ArtifactoryHttpClient;
 import org.jfrog.build.client.ArtifactoryVersion;
 import org.jfrog.build.client.ProxyConfiguration;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 
 /**
@@ -118,6 +119,10 @@ public abstract class ArtifactoryBaseClient implements AutoCloseable {
 
     public void setInsecureTls(boolean insecureTls) {
         httpClient.setInsecureTls(insecureTls);
+    }
+
+    public void setSslContext(SSLContext sslContext) {
+        httpClient.setSslContext(sslContext);
     }
 
     public String getArtifactoryUrl() {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

To allow setting the SSL context in the Intelij IDEA plugin, lets add a setter in the base Artifactory HTTP client.