### PR TITLE
Fix - tests fail after upgrade go version to 1.16

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
@@ -80,10 +80,10 @@ public class GoRun extends GoCommand {
             }
             // We create the GoDriver here as env might had changed.
             this.goDriver = new GoDriver(GO_CLIENT_CMD, env, path.toFile(), logger);
-            this.moduleName = goDriver.getModuleName();
             // First try to run 'go version' to make sure go is in PATH, and write the output to logger.
             goDriver.version(true);
             goDriver.runCmd(goCmdArgs, true);
+            this.moduleName = goDriver.getModuleName();
             collectDependencies();
             return createBuild();
         } catch (Exception e) {

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
@@ -32,7 +32,7 @@ public class GoExtractorTest extends IntegrationTestsBase {
     private static final String GO_REMOTE_REPO = "build-info-tests-go-remote";
     private static final String GO_VIRTUAL_REPO = "build-info-tests-go-virtual";
     private static final String[] GO_PACKAGE_EXTENSIONS = {".zip", ".mod", ".info"};
-    private static final String GO_BUILD_CMD = "build";
+    private static final String GO_BUILD_CMD = "build -mod=mod";
 
     private static final Path PROJECTS_ROOT = Paths.get(".").toAbsolutePath().normalize().resolve(Paths.get("src", "test", "resources", "org", "jfrog", "build", "extractor"));
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Since go 1.16, build commands like go build and go test no longer modify go.mod and go.sum by default. Instead, they report an error if a module requirement or checksum needs to be added or updated.
Related PR: https://github.com/jfrog/jenkins-artifactory-plugin/pull/444