### PR TITLE
Upgrade go version to 1.15 for appveyor linux tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-stack: jdk 8, node 8, go 1.13, python 3.7.9
+stack: jdk 8, node 8, go 1.15, python 3.7.9
 skip_tags: true
 environment:
   matrix:


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
