### PR TITLE
Support Jfrog platform URL for published build

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/Build.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/Build.java
@@ -46,6 +46,7 @@ public class Build extends BaseBuildBean {
     private BuildAgent buildAgent;
     private Agent agent;
     private String started;
+    private long startedMillis;
     private long durationMillis;
     private String principal;
     private String artifactoryPrincipal;
@@ -230,6 +231,14 @@ public class Build extends BaseBuildBean {
     public String getStarted() {
         return started;
     }
+    /**
+     * Returns the started time of the build in a unit of milliseconds
+     *
+     * @return Build started time in a unit of milliseconds
+     */
+    public long getStartedMillis() {
+        return startedMillis;
+    }
 
     /**
      * Sets the started time of the build
@@ -246,7 +255,8 @@ public class Build extends BaseBuildBean {
      * @param startedDate Build start date to set
      */
     public void setStartedDate(Date startedDate) {
-        this.started = formatBuildStarted(startedDate.getTime());
+        startedMillis = startedDate.getTime();
+        started = formatBuildStarted(startedMillis);
     }
 
     /**

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java
@@ -52,7 +52,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.jfrog.build.client.ArtifactoryHttpClient.encodeUrl;
@@ -253,8 +252,8 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient implements
      * @return Link to the published build in JFrog platform e.g. https://myartifactory.com/ui/builds/gradle-cli/1/1619429119501/published
      * @throws ParseException
      */
-    public static String createBuildInfoUrl(String platformUrl, String buildName, String buildNumber, String timeStamp) throws ParseException {
-        return platformUrl + BUILD_BROWSE_PLATFORM_URL + "/" + encodeUrl(buildName) + "/" + encodeUrl(buildNumber) + "/" + (new SimpleDateFormat(Build.STARTED_FORMAT).parse(timeStamp)).getTime() + "/published";
+    public static String createBuildInfoUrl(String platformUrl, String buildName, String buildNumber, String timeStamp) {
+        return platformUrl + BUILD_BROWSE_PLATFORM_URL + "/" + encodeUrl(buildName) + "/" + encodeUrl(buildNumber) + "/" + timeStamp + "/published";
     }
 
     /**
@@ -840,11 +839,7 @@ public class ArtifactoryBuildInfoClient extends ArtifactoryBaseClient implements
         }
         String url;
         if (StringUtils.isNotBlank(platformUrl)) {
-            try {
-                url = createBuildInfoUrl(platformUrl, buildInfo.getName(), buildInfo.getNumber(), buildInfo.getStarted());
-            } catch (ParseException e) {
-                throw new IOException("Could not build the build-info url link", e);
-            }
+            url = createBuildInfoUrl(platformUrl, buildInfo.getName(), buildInfo.getNumber(), String.valueOf(buildInfo.getStartedMillis()));
         } else {
             url = createBuildInfoUrl(artifactoryUrl, buildInfo.getName(), buildInfo.getNumber());
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/retention/Utils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/retention/Utils.java
@@ -49,18 +49,22 @@ public class Utils {
 
     private static void sendRetentionIfNeeded(ArtifactoryBuildInfoClient client, BuildRetention retention, String buildName, ArtifactoryVersion version, boolean async) throws IOException {
         if (version.isAtLeast(ArtifactoryHttpClient.STANDALONE_BUILD_RETENTION_SUPPORTED_ARTIFACTORY_VERSION)) {
-            client.sendBuildRetetion(retention, encodeUrl(buildName), async);
+            client.sendBuildRetention(retention, encodeUrl(buildName), async);
         }
     }
 
-    public static void sendBuildAndBuildRetention(ArtifactoryBuildInfoClient client, Build build, ArtifactoryClientConfiguration clientConf) throws IOException {
+    public static void sendBuildAndBuildRetention(ArtifactoryBuildInfoClient client, Build build, ArtifactoryClientConfiguration clientConf, String platformUrl) throws IOException {
         BuildRetention retention = getBuildRetention(clientConf);
-        sendBuildAndBuildRetention(client, build, retention, clientConf.info.isAsyncBuildRetention());
+        sendBuildAndBuildRetention(client, build, retention, clientConf.info.isAsyncBuildRetention(), platformUrl);
     }
 
-    public static void sendBuildAndBuildRetention(ArtifactoryBuildInfoClient client, Build build, BuildRetention retention, boolean asyncBuildRetention) throws IOException {
+    public static void sendBuildAndBuildRetention(ArtifactoryBuildInfoClient client, Build build, ArtifactoryClientConfiguration clientConfl) throws IOException {
+        sendBuildAndBuildRetention(client, build, clientConfl, null);
+    }
+
+    public static void sendBuildAndBuildRetention(ArtifactoryBuildInfoClient client, Build build, BuildRetention retention, boolean asyncBuildRetention, String platformUrl) throws IOException {
         if (retention == null || retention.isEmpty()) {
-            client.sendBuildInfo(build);
+            client.sendBuildInfo(build, platformUrl);
             return;
         }
         ArtifactoryVersion version;
@@ -70,7 +74,11 @@ public class Utils {
             throw new RuntimeException(e);
         }
         addRetentionIfNeeded(build, retention, version);
-        client.sendBuildInfo(build);
+        client.sendBuildInfo(build, platformUrl);
         sendRetentionIfNeeded(client, retention, build.getName(), version, asyncBuildRetention);
+    }
+
+    public static void sendBuildAndBuildRetention(ArtifactoryBuildInfoClient client, Build build, BuildRetention retention, boolean asyncBuildRetention) throws IOException {
+        sendBuildAndBuildRetention(client, build, retention, asyncBuildRetention, null);
     }
 }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClientTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClientTest.java
@@ -75,7 +75,7 @@ public class ArtifactoryBuildInfoClientTest extends IntegrationTestsBase {
         Build buildInfoToSend = buildInfoBuilder.build();
 
         // Publish build info
-        buildInfoClient.sendBuildInfo(buildInfoToSend);
+        buildInfoClient.sendBuildInfo(buildInfoToSend, null);
 
         // Get build info
         Build receivedBuildInfo = buildInfoClient.getBuildInfo(BUILD_NAME, BUILD_NUMBER);

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
@@ -129,7 +129,7 @@ public class IssuesCollectorTest extends IntegrationTestsBase {
         Build buildInfoToSend = buildInfoBuilder.build();
 
         // Publish build info
-        buildInfoClient.sendBuildInfo(buildInfoToSend);
+        buildInfoClient.sendBuildInfo(buildInfoToSend, null);
     }
 
     @BeforeMethod


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Creates a platform URL after published build.
Related PR: https://github.com/jfrog/jenkins-artifactory-plugin/pull/455