### PR TITLE
Sign JARs before publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
     apply plugin: 'groovy'
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.artifactory'
+    apply plugin: 'signing'
 
     repositories {
         mavenLocal()
@@ -118,7 +119,7 @@ subprojects {
 
             pom {
                 name = project.name
-                description = project.description
+                description = project.description ?: "JFrog Build-Info"
                 url = 'https://www.jfrog.com/confluence/display/JFROG/Build+Integration'
 
                 licenses {
@@ -140,6 +141,13 @@ subprojects {
                 }
             }
         }
+        signing {
+            def signingKey = findProperty("signingKey")
+            def signingPassword = findProperty("signingPassword")
+            useInMemoryPgpKeys(signingKey, signingPassword)
+            sign publication
+        }
+
         artifactoryPublish {
             publications(publication)
         }

--- a/ci/pipelines.release.yml
+++ b/ci/pipelines.release.yml
@@ -67,6 +67,8 @@ pipelines:
               env -i PATH=$PATH HOME=$HOME
               JFROG_CLI_BUILD_NAME=$JFROG_CLI_BUILD_NAME
               JFROG_CLI_BUILD_NUMBER=$JFROG_CLI_BUILD_NUMBER
+              ORG_GRADLE_PROJECT_signingKey=$int_mvn_central_signingKey
+              ORG_GRADLE_PROJECT_signingPassword=$int_mvn_central_signingPassword
               ./jfrog rt gradle clean aP -x test
             - ./jfrog rt bag
             - ./jfrog rt bp
@@ -76,7 +78,9 @@ pipelines:
               env -i PATH=$PATH HOME=$HOME
               ORG_GRADLE_PROJECT_sonatypeUsername=$int_mvn_central_user
               ORG_GRADLE_PROJECT_sonatypePassword=$int_mvn_central_password
-              ./gradlew clean build publishToSonatype closeSonatypeStagingRepository -x test
+              ORG_GRADLE_PROJECT_signingKey=$int_mvn_central_signingKey
+              ORG_GRADLE_PROJECT_signingPassword=$int_mvn_central_signingPassword
+              ./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository -x test
 
             # Update next development version
             - sed -i -e "/build-info-version=/ s/=.*/=$NEXT_DEVELOPMENT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_DEVELOPMENT_VERSION/" gradle.properties
@@ -84,7 +88,6 @@ pipelines:
 
             # Push changes
             - git push
-            - git push --tags
 
           onComplete:
             # Save .m2 cache


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

* Sign JARs automatically in the release job
* Release JARs to Maven Central in the end