### PR TITLE
Fix signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ subprojects {
             }
         }
         signing {
+            required { buildInfoVersion.isRelease() }
             def signingKey = findProperty("signingKey")
             def signingPassword = findProperty("signingPassword")
             useInMemoryPgpKeys(signingKey, signingPassword)

--- a/ci/pipelines.release.yml
+++ b/ci/pipelines.release.yml
@@ -64,9 +64,6 @@ pipelines:
 
             # Run install and publish
             - >
-              env -i PATH=$PATH HOME=$HOME
-              JFROG_CLI_BUILD_NAME=$JFROG_CLI_BUILD_NAME
-              JFROG_CLI_BUILD_NUMBER=$JFROG_CLI_BUILD_NUMBER
               ORG_GRADLE_PROJECT_signingKey=$int_mvn_central_signingKey
               ORG_GRADLE_PROJECT_signingPassword=$int_mvn_central_signingPassword
               ./jfrog rt gradle clean aP -x test
@@ -75,7 +72,6 @@ pipelines:
 
             # Publish to Maven Central
             - >
-              env -i PATH=$PATH HOME=$HOME
               ORG_GRADLE_PROJECT_sonatypeUsername=$int_mvn_central_user
               ORG_GRADLE_PROJECT_sonatypePassword=$int_mvn_central_password
               ORG_GRADLE_PROJECT_signingKey=$int_mvn_central_signingKey


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Remove `env -i` command when running a command that requires signing.
The reason is that `env -i MULTILINE_ENV_KEY=$MULTILINE_ENV_KEY` returns an error.