### PR TITLE
IDE scan - fix top issue severity

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Issue.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Issue.java
@@ -84,7 +84,7 @@ public class Issue implements Comparable<Issue> {
     @JsonIgnore
     @SuppressWarnings("WeakerAccess")
     public boolean isTopSeverity() {
-        return getSeverity() == Severity.High;
+        return getSeverity() == Severity.Critical;
     }
 
     @JsonIgnore


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Top available issue severity should be critical. 
This issue effects dependency trees with critical top issue (red), however the top issue displayed is high (orange):
<img width="358" alt="image" src="https://user-images.githubusercontent.com/11367982/116993353-0b780980-ace0-11eb-87a0-e945b846d49c.png">
