### PR TITLE
Bugfix - env not collect in npm, Go, Pip, and NuGet builds

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -25,9 +25,9 @@ import org.jfrog.build.api.builder.BuildInfoBuilder;
 import org.jfrog.build.api.builder.PromotionStatusBuilder;
 import org.jfrog.build.api.release.Promotion;
 import org.jfrog.build.extractor.BuildInfoExtractor;
-import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.ModuleExtractorUtils;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.build.extractor.packageManager.PackageManagerUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -201,20 +201,13 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
             bib.addRunParameters(matrixParameter);
         }
 
-        if (clientConf.isIncludeEnvVars()) {
-            Properties envProperties = new Properties();
-            envProperties.putAll(clientConf.getAllProperties());
-            envProperties = BuildInfoExtractorUtils.getEnvProperties(envProperties, clientConf.getLog());
-            for (Map.Entry<Object, Object> envProp : envProperties.entrySet()) {
-                bib.addProperty(envProp.getKey(), envProp.getValue());
-            }
-        }
         log.debug("buildInfoBuilder = " + bib);
         // for backward compatibility for Artifactory 2.2.3
         Build build = bib.build();
         if (parentName != null && parentNumber != null) {
             build.setParentBuildId(parentName);
         }
+        PackageManagerUtils.collectEnvIfNeeded(clientConf, build);
         return build;
     }
 }

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
@@ -20,6 +20,7 @@ import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
+import org.jfrog.build.extractor.packageManager.PackageManagerUtils;
 import org.jfrog.build.extractor.retention.Utils;
 import org.jfrog.build.extractor.trigger.ArtifactoryBuildInfoTrigger;
 import org.jfrog.build.util.IvyBuildInfoLog;
@@ -132,20 +133,20 @@ public class ArtifactoryBuildListener implements BuildListener {
 
     private Task extractIvyTask(BuildEvent event) {
         Task task = event.getTask();
-        
+
         //Handle ivy tasks that are wrapped
-        if(task instanceof UnknownElement) {
+        if (task instanceof UnknownElement) {
             UnknownElement unknown = (UnknownElement) task;
             Object realThing = unknown.getRealThing();
-            if(realThing == null) {
+            if (realThing == null) {
                 unknown.maybeConfigure();
             }
             realThing = unknown.getRealThing();
             if (realThing instanceof Task) {
-                task = (Task)realThing;
+                task = (Task) realThing;
             }
         }
-        
+
         // Interested only in Ivy tasks
         String taskType = task.getTaskType();
         if (taskType != null
@@ -206,14 +207,14 @@ public class ArtifactoryBuildListener implements BuildListener {
         while (elements.hasMoreElements()) {
             Object element = elements.nextElement();
             if (element instanceof UnknownElement) {
-                UnknownElement unknown = (UnknownElement)element;
+                UnknownElement unknown = (UnknownElement) element;
                 element = unknown.getRealThing();
-                if(element == null) {
+                if (element == null) {
                     unknown.maybeConfigure();
                     element = unknown.getRealThing();
                 }
             }
-            if (element instanceof IvyAntSettings ) {
+            if (element instanceof IvyAntSettings) {
                 results.add(((IvyAntSettings) element).getConfiguredIvyInstance(task).getResolveEngine().getEventManager());
             }
         }
@@ -352,20 +353,12 @@ public class ArtifactoryBuildListener implements BuildListener {
             builder.addRunParameters(matrixParameter);
         }
 
-        if (clientConf.isIncludeEnvVars()) {
-            Properties envProperties = new Properties();
-            envProperties.putAll(clientConf.getAllProperties());
-            envProperties = BuildInfoExtractorUtils.getEnvProperties(envProperties, clientConf.getLog());
-            for (Map.Entry<Object, Object> envProp : envProperties.entrySet()) {
-                builder.addProperty(envProp.getKey(), envProp.getValue());
-            }
-        }
         Build build = builder.build();
+        PackageManagerUtils.collectEnvIfNeeded(clientConf, build);
         String contextUrl = clientConf.publisher.getContextUrl();
         String username = clientConf.publisher.getUsername();
         String password = clientConf.publisher.getPassword();
-        ArtifactoryBuildInfoClient client = new ArtifactoryBuildInfoClient(contextUrl, username, password, log);
-        try {
+        try (ArtifactoryBuildInfoClient client = new ArtifactoryBuildInfoClient(contextUrl, username, password, log)) {
             configureProxy(clientConf, client);
             configConnectionTimeout(clientConf, client);
             configRetriesParams(clientConf, client);
@@ -381,8 +374,6 @@ public class ArtifactoryBuildListener implements BuildListener {
             isDidDeploy = true;
         } catch (IOException e) {
             throw new RuntimeException(e);
-        } finally {
-            client.close();
         }
     }
 

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -41,6 +41,7 @@ import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.maven.resolver.ResolutionHelper;
+import org.jfrog.build.extractor.packageManager.PackageManagerUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -695,18 +696,12 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     public Build extract(ExecutionEvent event) {
         MavenSession session = event.getSession();
         if (!session.getResult().hasExceptions()) {
-            if (conf.isIncludeEnvVars()) {
-                Properties envProperties = new Properties();
-                envProperties.putAll(conf.getAllProperties());
-                envProperties = BuildInfoExtractorUtils.getEnvProperties(envProperties, conf.getLog());
-                for (Map.Entry<Object, Object> envProp : envProperties.entrySet()) {
-                    buildInfoBuilder.addProperty(envProp.getKey(), envProp.getValue());
-                }
-            }
             Date finish = new Date();
             long time = finish.getTime() - session.getRequest().getStartTime().getTime();
 
-            return buildInfoBuilder.durationMillis(time).build();
+            Build build = buildInfoBuilder.durationMillis(time).build();
+            PackageManagerUtils.collectEnvIfNeeded(conf, build);
+            return build;
         }
 
         return null;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
@@ -35,6 +35,7 @@ public abstract class PackageManagerExtractor implements Serializable {
         if (build == null) {
             return;
         }
+        PackageManagerUtils.collectEnvIfNeeded(clientConfiguration, build);
         saveBuildInfoToFile(clientConfiguration, build);
     }
 
@@ -49,37 +50,12 @@ public abstract class PackageManagerExtractor implements Serializable {
         if (StringUtils.isBlank(generatedBuildInfoPath)) {
             return;
         }
-        if (clientConfiguration.isIncludeEnvVars()) {
-            collectEnv(clientConfiguration, build);
-        }
         try {
             BuildInfoExtractorUtils.saveBuildInfoToFile(build, new File(generatedBuildInfoPath));
         } catch (Exception e) {
             clientConfiguration.getLog().error("Failed writing build info to file: ", e);
             throw new RuntimeException(e);
         }
-    }
-
-    /**
-     * Collect environment variables according to the env include-exclude patterns
-     *
-     * @param clientConfiguration - Artifactory client configuration
-     * @param build               - The target build
-     */
-    private static void collectEnv(ArtifactoryClientConfiguration clientConfiguration, Build build) {
-        // Create initial environment variables properties
-        Properties envProperties = new Properties();
-        envProperties.putAll(clientConfiguration.getAllProperties());
-
-        // Filter env according to the include-exclude patterns
-        envProperties = BuildInfoExtractorUtils.getEnvProperties(envProperties, clientConfiguration.getLog());
-
-        // Add results to the build
-        if (build.getProperties() != null) {
-            build.getProperties().putAll(envProperties);
-            return;
-        }
-        build.setProperties(envProperties);
     }
 
     protected static void validateRepoExists(ArtifactoryBaseClient client, String repo, String repoNotSpecifiedMsg) throws IOException {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -1,6 +1,7 @@
 package org.jfrog.build.extractor.packageManager;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.jfrog.build.api.Build;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 
@@ -37,5 +38,30 @@ public class PackageManagerUtils {
                 .setHost(rtUrl.getHost())
                 .setPath(rtUrl.getPath() + path);
         return proxyUrlBuilder.build().toURL().toString();
+    }
+
+    /**
+     * Collect environment variables according to the env include-exclude patterns.
+     *
+     * @param clientConfiguration - Artifactory client configuration
+     * @param build               - The target build
+     */
+    public static void collectEnvIfNeeded(ArtifactoryClientConfiguration clientConfiguration, Build build) {
+        if (!clientConfiguration.isIncludeEnvVars()) {
+            return;
+        }
+        // Create initial environment variables properties
+        Properties envProperties = new Properties();
+        envProperties.putAll(clientConfiguration.getAllProperties());
+
+        // Filter env according to the include-exclude patterns
+        envProperties = BuildInfoExtractorUtils.getEnvProperties(envProperties, clientConfiguration.getLog());
+
+        // Add results to the build
+        if (build.getProperties() != null) {
+            build.getProperties().putAll(envProperties);
+            return;
+        }
+        build.setProperties(envProperties);
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

When building npm, Go, Pip, and NuGet projects, we should allow collecting the environment during the extractor process.