### PR TITLE
Gradle - Collect build info when publisher is missing

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleModuleExtractor.java
@@ -75,6 +75,7 @@ public class GradleModuleExtractor implements ModuleExtractor<Project> {
                 .id(moduleId)
                 .repository(repo);
         try {
+            // Extract the module's artifacts information if a publisher exists.
             ArtifactoryClientConfiguration.PublisherHandler publisher = ArtifactoryPluginUtil.getPublisherHandler(project);
             if (publisher != null) {
                 boolean excludeArtifactsFromBuild = publisher.isFilterExcludedArtifactsFromBuild();
@@ -91,11 +92,11 @@ public class GradleModuleExtractor implements ModuleExtractor<Project> {
                     deployExcludeDetails = new ArrayList<>();
                 }
                 builder.artifacts(calculateArtifacts(deployIncludeDetails))
-                        .excludedArtifacts(calculateArtifacts(deployExcludeDetails))
-                        .dependencies(calculateDependencies(project, moduleId));
+                        .excludedArtifacts(calculateArtifacts(deployExcludeDetails));
             } else {
                 log.warn("No publisher config found for project: " + project.getName());
             }
+            builder.dependencies(calculateDependencies(project, moduleId));
         } catch (Exception e) {
             log.error("Error during extraction: ", e);
         }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -101,6 +101,13 @@ public class DeployTask extends DefaultTask {
         exportBuildInfo(build, getExportFile(accRoot));
 
         // Export generated.
+        generateBuildInfoJson(accRoot, build);
+
+        // Handle deployment.
+        handleBuildInfoDeployment(accRoot, build, allDeployDetails);
+    }
+
+    private void generateBuildInfoJson(ArtifactoryClientConfiguration accRoot, Build build) throws IOException {
         if (isGenerateBuildInfoToFile(accRoot)) {
             try {
                 exportBuildInfo(build, new File(accRoot.info.getGeneratedBuildInfoFilePath()));
@@ -109,8 +116,9 @@ public class DeployTask extends DefaultTask {
                 throw new IOException("Failed writing build info to file", e);
             }
         }
+    }
 
-        // Handle deployment.
+    private void handleBuildInfoDeployment(ArtifactoryClientConfiguration accRoot, Build build, Map<String, Set<DeployDetails>> allDeployDetails) throws IOException {
         ArtifactoryBuildInfoClient client = null;
         String contextUrl = accRoot.publisher.getContextUrl();
         if (contextUrl != null) {

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Consts.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Consts.java
@@ -34,7 +34,8 @@ public class Consts {
     // CI example paths
     static final Path LIBS_DIR = GRADLE_EXTRACTOR.resolve(Paths.get("build", "libs"));
     static final Path INIT_SCRIPT = GRADLE_EXTRACTOR_SRC.resolve(Paths.get("main", "resources", "initscripttemplate.gradle"));
-    static final Path BUILD_INFO_PROPERTIES_SOURCE = PROJECTS_ROOT.resolve("buildinfo.properties");
+    static final Path BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER = PROJECTS_ROOT.resolve("buildinfo.properties.deployer");
+    static final Path BUILD_INFO_PROPERTIES_SOURCE_RESOLVER = PROJECTS_ROOT.resolve("buildinfo.properties.resolver");
     static final Path BUILD_INFO_PROPERTIES_TARGET = TEST_DIR.toPath().resolve("buildinfo.properties");
 
     // Expected artifacts

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
@@ -85,7 +85,7 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void ciServerTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "", true, true, true);
+        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "", true, true);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
@@ -99,7 +99,7 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void ciServerPublicationsTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", true, true, true);
+        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", true, true);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
@@ -113,27 +113,27 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void requestedByTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", false, true, true);
+        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", false, true);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
         // Run Gradle
         BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
         int expectedArtifactsPerModule = VersionNumber.parse(gradleVersion).getMajor() >= 6 ? 5 : 4;
-        checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 3, expectedArtifactsPerModule, true);
+        checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 3, expectedArtifactsPerModule);
     }
 
     @Test(dataProvider = "gradleVersions")
     public void ciServerResolverOnlyTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "", false, false, true);
+        generateBuildInfoProperties(getUrl(), getUsername(), getPassword(), localRepo1, virtualRepo, "", false, false);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
         // Run Gradle
         BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
         // Check results
-        checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 2, 0, true);
+        checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 2, 0);
     }
 }

--- a/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.deployer
+++ b/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.deployer
@@ -8,10 +8,3 @@ artifactory.publish.unstable=false
 artifactory.publish.buildInfo=true
 artifactory.publish.maven=true
 artifactory.publish.ivy=true
-
-# Resolver settings
-artifactory.resolve.contextUrl=${contextUrl}
-artifactory.resolve.repoKey=${virtualRepo}
-artifactory.resolve.username=${username}
-artifactory.resolve.password=${password}
-

--- a/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.resolver
+++ b/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.resolver
@@ -1,0 +1,5 @@
+# Resolver settings
+artifactory.resolve.contextUrl=${contextUrl}
+artifactory.resolve.repoKey=${virtualRepo}
+artifactory.resolve.username=${username}
+artifactory.resolve.password=${password}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
