### PR TITLE
Fix Docker push bugs cause by Restructuring Artifactory APIs.

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPush.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPush.java
@@ -110,7 +110,7 @@ public class DockerPush extends DockerCommand {
         }
         try (ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build()) {
             for (DockerLayer layer : layers.getLayers()) {
-                artifactoryManager.setProperties(layer.getFullPath(), artifactProperties, false);
+                artifactoryManager.setProperties(layer.getFullPath(), artifactProperties, true);
             }
         }
     }

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/types/DockerImage.java
@@ -100,8 +100,7 @@ public class DockerImage implements Serializable {
 
         downloadUrl = manifestPath + "/manifest.json";
         logger.info("Trying to download manifest from " + downloadUrl);
-        return Pair.of(artifactoryManager.download(downloadUrl), pathWithoutRepo);
-
+        return Pair.of(artifactoryManager.download(downloadUrl), StringUtils.substringAfter(manifestPath, "/"));
     }
 
     private void setBuildInfoModuleProps(ModuleBuilder moduleBuilder) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
The Jenkins Artifactory Plugin supports Docker push to Artifactory. After the push was successful, it sets each layer with build-name & build-number properties. if the build-name or build-number container special characters, the set properties will fail therefore we need to encode each property key and value.
Moreover, for "fat-manifest" images, the wrong path was returned which cause us to search the image manifest in the wrong place Artifactory.
