### PR TITLE
Fix deserialization error in GetRepositoriesKeys

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetRepositoriesKeys.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetRepositoriesKeys.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class GetRepositoriesKeys extends JFrogService<List<String>> {
     private static final String REPOS_REST_URL = "api/repositories?type=";
@@ -19,7 +21,6 @@ public class GetRepositoriesKeys extends JFrogService<List<String>> {
     protected final Log log;
     RepositoryType repositoryType;
 
-    @SuppressWarnings("unchecked")
     public GetRepositoriesKeys(RepositoryType repositoryType, Log logger) {
         super(logger);
         result = new ArrayList<>();
@@ -37,8 +38,9 @@ public class GetRepositoriesKeys extends JFrogService<List<String>> {
 
     @Override
     protected void setResponse(InputStream stream) throws IOException {
-        GetRepositoriesKeyResponse localRepositories = getMapper(true).readValue(stream, GetRepositoriesKeyResponse.class);
-        result = localRepositories.getRepositoriesKey();
+        List<GetRepositoriesKeyResponse> keys = getMapper(true).readValue(stream, new TypeReference<List<GetRepositoriesKeyResponse>>() {
+        });
+        result = keys.stream().map(GetRepositoriesKeyResponse::getKey).collect(Collectors.toList());
     }
 
     @Override

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetRepositoriesKeys.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetRepositoriesKeys.java
@@ -1,13 +1,13 @@
 package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.client.JFrogService;
 import org.jfrog.build.extractor.clientConfiguration.client.RepositoryType;
-import org.jfrog.build.extractor.clientConfiguration.client.response.GetRepositoriesKeyResponse;
+import org.jfrog.build.extractor.clientConfiguration.client.response.GetRepositoriesResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,9 +38,9 @@ public class GetRepositoriesKeys extends JFrogService<List<String>> {
 
     @Override
     protected void setResponse(InputStream stream) throws IOException {
-        List<GetRepositoriesKeyResponse> keys = getMapper(true).readValue(stream, new TypeReference<List<GetRepositoriesKeyResponse>>() {
-        });
-        result = keys.stream().map(GetRepositoriesKeyResponse::getKey).collect(Collectors.toList());
+        List<GetRepositoriesResponse> keys = getMapper(true).readValue(stream,
+                TypeFactory.defaultInstance().constructCollectionLikeType(List.class, GetRepositoriesResponse.class));
+        result = keys.stream().map(GetRepositoriesResponse::getKey).collect(Collectors.toList());
     }
 
     @Override

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/GetRepositoriesKeyResponse.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/GetRepositoriesKeyResponse.java
@@ -1,32 +1,13 @@
 package org.jfrog.build.extractor.clientConfiguration.client.response;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class GetRepositoriesKeyResponse {
-    private List<LocalRepository> results;
+    private String key;
 
-    public List<LocalRepository> getResults() {
-        return results;
+    public String getKey() {
+        return key;
     }
 
-    public void setResults(List<LocalRepository> key) {
-        this.results = key;
-    }
-
-    public List<String> getRepositoriesKey() {
-        return results.stream().map(LocalRepository::getKey).collect(Collectors.toList());
-    }
-
-    public static class LocalRepository {
-        private String key;
-
-        public String getKey() {
-            return key;
-        }
-
-        public void setKey(String key) {
-            this.key = key;
-        }
+    public void setKey(String key) {
+        this.key = key;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/GetRepositoriesResponse.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/GetRepositoriesResponse.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.client.response;
 
-public class GetRepositoriesKeyResponse {
+public class GetRepositoriesResponse {
     private String key;
 
     public String getKey() {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

The response of `GET api/repositories`is a list of repositories. Therefore the response value of GetRepositoriesKey should be a list.