### PR TITLE
Bugfix - build retention service has an empty body

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SendBuildRetention.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SendBuildRetention.java
@@ -2,6 +2,7 @@ package org.jfrog.build.extractor.clientConfiguration.client.artifactory.service
 
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
 import org.jfrog.build.api.BuildRetention;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
@@ -29,9 +30,14 @@ public class SendBuildRetention extends VoidJFrogService {
     @Override
     public HttpRequestBase createRequest() throws IOException {
         log.info(createBuildRetentionLogMsg(buildRetention, async));
-        log.debug(toJsonString(buildRetention));
+        String buildRetentionString = toJsonString(buildRetention);
+        log.debug(buildRetentionString);
         String url = RETENTION_REST_URL + buildName + "?async=" + async + getProjectQueryParam(project, "&project=");
-        return new HttpPost(url);
+        StringEntity stringEntity = new StringEntity(buildRetentionString, "UTF-8");
+        stringEntity.setContentType("application/json");
+        HttpPost request = new HttpPost(url);
+        request.setEntity(stringEntity);
+        return request;
     }
 
     private String createBuildRetentionLogMsg(BuildRetention buildRetention, boolean async) {

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -44,13 +44,15 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
      * Send build info to artifactory, receive it and compare.
      */
     @Test
-    public void sendBuildInfoTest() throws IOException {
+    public void sendBuildInfoAndBuildRetentioTest() throws IOException {
         doSendBuildInfoTest(null);
+        sendBuildRetentionTest("");
     }
 
     @Test
     public void sendBuildInfoWithProjectTest() throws IOException {
         doSendBuildInfoTest("jit");
+        sendBuildRetentionTest("jit");
     }
 
     private void doSendBuildInfoTest(String project) throws IOException {
@@ -97,10 +99,10 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
     }
 
     @Test
-    public void sendBuildRetentionTest() throws IOException {
+    private void sendBuildRetentionTest(String project) throws IOException {
         BuildRetention buildRetention = new BuildRetention();
         buildRetention.setCount(1);
         buildRetention.setDeleteBuildArtifacts(false);
-        artifactoryManager.sendBuildRetention(buildRetention, BUILD_NAME, null, false);
+        artifactoryManager.sendBuildRetention(buildRetention, BUILD_NAME, project, false);
     }
 }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -46,13 +46,13 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
     @Test
     public void sendBuildInfoAndBuildRetentioTest() throws IOException {
         doSendBuildInfoTest(null);
-        sendBuildRetentionTest("");
+        sendBuildRetention("");
     }
 
     @Test
     public void sendBuildInfoWithProjectTest() throws IOException {
         doSendBuildInfoTest("jit");
-        sendBuildRetentionTest("jit");
+        sendBuildRetention("jit");
     }
 
     private void doSendBuildInfoTest(String project) throws IOException {
@@ -99,7 +99,7 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
     }
 
     @Test
-    private void sendBuildRetentionTest(String project) throws IOException {
+    private void sendBuildRetention(String project) throws IOException {
         BuildRetention buildRetention = new BuildRetention();
         buildRetention.setCount(1);
         buildRetention.setDeleteBuildArtifacts(false);

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -98,7 +98,6 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
         Assert.assertEquals(toJsonString(buildInfoToSend), toJsonString(receivedBuildInfo));
     }
 
-    @Test
     private void sendBuildRetention(String project) throws IOException {
         BuildRetention buildRetention = new BuildRetention();
         buildRetention.setCount(1);

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -30,6 +30,8 @@ import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJso
 public class ArtifactoryManagerTest extends IntegrationTestsBase {
     private static final String TEST_SPACE = "bi_client_test_space";
     private static final File tempWorkspace = new File(System.getProperty("java.io.tmpdir"), TEST_SPACE);
+    private static final String BUILD_NAME = "ArtifactoryManagerTest";
+    private static final String BUILD_NUMBER = "13";
 
     @BeforeMethod
     @AfterMethod
@@ -52,8 +54,6 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
     }
 
     private void doSendBuildInfoTest(String project) throws IOException {
-        final String BUILD_NAME = "ArtifactoryManagerTest";
-        final String BUILD_NUMBER = "13";
         final Date STARTED = new Date();
         final List<Vcs> VCS = Arrays.asList(new Vcs("foo", "1"),
                 new Vcs("bar", "2"),
@@ -94,5 +94,13 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
 
         // Compare
         Assert.assertEquals(toJsonString(buildInfoToSend), toJsonString(receivedBuildInfo));
+    }
+
+    @Test
+    public void sendBuildRetentionTest() throws IOException {
+        BuildRetention buildRetention = new BuildRetention();
+        buildRetention.setCount(1);
+        buildRetention.setDeleteBuildArtifacts(false);
+        artifactoryManager.sendBuildRetention(buildRetention, BUILD_NAME, null, false);
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
