### PR TITLE
Bugfix - Error when trying to download an empty (zero bytes size) file

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
@@ -149,8 +149,7 @@ public abstract class JFrogService<TResult> {
             return;
         }
         try (InputStream stream = entity.getContent()) {
-            long contentLength = entity.getContentLength();
-            if (contentLength == 0 || responseType == JFrogServiceResponseType.EMPTY) {
+            if (responseType == JFrogServiceResponseType.EMPTY) {
                 return;
             }
             setResponse(stream);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
@@ -149,6 +149,7 @@ public abstract class JFrogService<TResult> {
         }
         if (entity == null) {
             handleEmptyEntity();
+            return;
         }
         try (InputStream stream = entity.getContent()) {
             setResponse(stream);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
@@ -144,18 +144,22 @@ public abstract class JFrogService<TResult> {
     }
 
     private void processResponse(HttpEntity entity) throws IOException {
-        if (entity == null) {
-            handleEmptyEntity();
+        if (responseType == JFrogServiceResponseType.EMPTY) {
             return;
         }
+        if (entity == null) {
+            handleEmptyEntity();
+        }
         try (InputStream stream = entity.getContent()) {
-            if (responseType == JFrogServiceResponseType.EMPTY) {
-                return;
-            }
             setResponse(stream);
         }
     }
 
+    /**
+     * For services with responseType.OBJECT (expected a return value) may
+     * override this function which helps to handle scenarios whereby a response body needs to be read
+     * but do entity is found.
+     */
     protected void handleEmptyEntity() throws IOException {
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DownloadToFile.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DownloadToFile.java
@@ -29,10 +29,9 @@ public class DownloadToFile extends DownloadBase<File> {
         // Save InputStream to file
         try (FileOutputStream fileOutputStream = new FileOutputStream(dest)) {
             IOUtils.copyLarge(inputStream, fileOutputStream);
-
             return dest;
         } catch (IOException e) {
-            throw new IOException(String.format("Could not create or write to file: %s", dest.getCanonicalPath()), e);
+            throw new IOException(String.format("Could not create nor write to file: %s", dest.getCanonicalPath()), e);
         }
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/DownloadTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/DownloadTest.java
@@ -124,6 +124,7 @@ public class DownloadTest extends IntegrationTestsBase {
         Map<String, Integer> testFilesMap = new HashMap<String, Integer>() {{
             put("file1", MIN_SIZE_FOR_CONCURRENT_DOWNLOAD);
             put("file2", MIN_SIZE_FOR_CONCURRENT_DOWNLOAD - 1);
+            put("zeroByte", 0);
         }};
 
         Object[][] tests = new Object[testFilesMap.size()][4];


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

All JFrog services ignore response with zero content length, this isn't fit to upload service, as it stops the download flow before reaching file creation. Therefore it was removed.
Fixes  https://github.com/jfrog/jenkins-artifactory-plugin/issues/490