### PR TITLE
Bugfix - deploy file logging isn't showing full URL

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -240,11 +240,9 @@ public class ArtifactoryManager extends ManagerBase {
         return upload(details, logPrefix, null);
     }
 
-    public ArtifactoryUploadResponse upload(DeployDetails details, String logPrefix, Integer MinChecksumDeploySizeKb) throws IOException {
-        Upload uploadService = new Upload(details, logPrefix, MinChecksumDeploySizeKb, log);
-        ArtifactoryUploadResponse result = uploadService.execute(jfrogHttpClient);
-        log.info(logPrefix + " Deployed artifact: " + result.getUri());
-        return result;
+    public ArtifactoryUploadResponse upload(DeployDetails details, String logPrefix, Integer minChecksumDeploySizeKb) throws IOException {
+        Upload uploadService = new Upload(details, logPrefix, minChecksumDeploySizeKb, log);
+        return uploadService.execute(jfrogHttpClient);
     }
 
     public void deleteRepository(String repository) throws IOException {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -22,7 +22,6 @@ import org.jfrog.build.extractor.clientConfiguration.client.ManagerBase;
 import org.jfrog.build.extractor.clientConfiguration.client.RepositoryType;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.*;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
-import org.jfrog.build.extractor.clientConfiguration.util.DeploymentUrlUtils;
 import org.jfrog.build.extractor.usageReport.UsageReporter;
 
 import java.io.File;
@@ -243,7 +242,9 @@ public class ArtifactoryManager extends ManagerBase {
 
     public ArtifactoryUploadResponse upload(DeployDetails details, String logPrefix, Integer MinChecksumDeploySizeKb) throws IOException {
         Upload uploadService = new Upload(details, logPrefix, MinChecksumDeploySizeKb, log);
-        return uploadService.execute(jfrogHttpClient);
+        ArtifactoryUploadResponse result = uploadService.execute(jfrogHttpClient);
+        log.info(logPrefix + "Deployed artifact: " + result.getUri());
+        return result;
     }
 
     public void deleteRepository(String repository) throws IOException {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -243,7 +243,7 @@ public class ArtifactoryManager extends ManagerBase {
     public ArtifactoryUploadResponse upload(DeployDetails details, String logPrefix, Integer MinChecksumDeploySizeKb) throws IOException {
         Upload uploadService = new Upload(details, logPrefix, MinChecksumDeploySizeKb, log);
         ArtifactoryUploadResponse result = uploadService.execute(jfrogHttpClient);
-        log.info(logPrefix + "Deployed artifact: " + result.getUri());
+        log.info(logPrefix + " Deployed artifact: " + result.getUri());
         return result;
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/Upload.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/Upload.java
@@ -25,6 +25,8 @@ import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientCon
 public class Upload extends JFrogService<ArtifactoryUploadResponse> {
     public static final String SHA1_HEADER_NAME = "X-Checksum-Sha1";
     public static final String MD5_HEADER_NAME = "X-Checksum-Md5";
+    public static final String EXPLODE_HEADER_NAME = "X-Explode-Archive";
+    public static final String CHECKSUM_DEPLOY_HEADER_NAME = "X-Checksum-Deploy";
     private final DeployDetails details;
     private final String logPrefix;
     private final Integer minChecksumDeploySizeKb;
@@ -44,7 +46,7 @@ public class Upload extends JFrogService<ArtifactoryUploadResponse> {
         request.addHeader(HTTP.EXPECT_DIRECTIVE, HTTP.EXPECT_CONTINUE);
         if (details.isExplode()) {
             this.isExplode = true;
-            request.addHeader("X-Explode-Archive", "true");
+            request.addHeader(EXPLODE_HEADER_NAME, "true");
         }
         FileEntity fileEntity = new FileEntity(details.getFile(), "binary/octet-stream");
         request.setEntity(fileEntity);
@@ -66,6 +68,7 @@ public class Upload extends JFrogService<ArtifactoryUploadResponse> {
 
     @Override
     public ArtifactoryUploadResponse execute(JFrogHttpClient client) throws IOException {
+        log.info(logPrefix + "Deploying artifact: " + client.getUrl() + "/" + StringUtils.removeStart(buildDefaultUploadPath(details), "/"));
         ArtifactoryUploadResponse response = tryChecksumUpload(client);
         if (response != null) {
             // Checksum deploy was performed:
@@ -138,9 +141,8 @@ public class Upload extends JFrogService<ArtifactoryUploadResponse> {
             }
 
             HttpPut request = createHttpPutMethod(details);
-            log.info(logPrefix + "Deploying artifact: " + request.getURI().toString());
             // activate checksum deploy
-            request.addHeader("X-Checksum-Deploy", "true");
+            request.addHeader(CHECKSUM_DEPLOY_HEADER_NAME, "true");
 
             return request;
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/Upload.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/Upload.java
@@ -40,7 +40,6 @@ public class Upload extends JFrogService<ArtifactoryUploadResponse> {
     @Override
     public HttpRequestBase createRequest() throws IOException {
         HttpPut request = createHttpPutMethod(details);
-        log.info(logPrefix + "Deploying artifact: " + request.getURI().toString());
         // add the 100 continue directive
         request.addHeader(HTTP.EXPECT_DIRECTIVE, HTTP.EXPECT_CONTINUE);
         if (details.isExplode()) {
@@ -72,7 +71,6 @@ public class Upload extends JFrogService<ArtifactoryUploadResponse> {
             // Checksum deploy was performed:
             return response;
         }
-
         return super.execute(client);
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Before this fix, deployed artifacts were logging without full URL:
```
[consumer_0] Deploying artifact: bar-generic/example.gif;system-api=https%3A%2F%2Ffishtank.com;package=mccApp;build.timestamp=1622367545908;state=incremental;build.name=as;build.number=1;version=99.0.3.2
```
After this PR changes :
```
[consumer_0] Deploying artifact: https://ecosysjfrog.jfrog.io/artifactory/bar-generic/example.gif
```
Moreover, the printing log messages were duplicated, one for checksum deploy and the second time for the casual upload(in case checksum deploy failed)
Resolve: https://github.com/jfrog/build-info/issues/508