### PR TITLE
Honor system proxy settings

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -206,7 +206,7 @@ public class DeployTask extends DefaultTask {
         String proxyHost = proxy.getHost();
         Integer proxyPort = proxy.getPort();
 
-        boolean isHttps = contextUrl.startsWith("http") && !contextUrl.startsWith("https");
+        boolean isHttps = !contextUrl.startsWith("http://");
 
         // If no proxyHost is explicitly set, check for the JVM system proxyHost property:
         if (StringUtils.isBlank(proxyHost)) {


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

This partially addresses #149. If no `proxyHost` is specified by the Gradle plugin consumer, the Gradle plugin tries using the JVM "http(s).proxyHost" property. Similarly, if no `proxyPort` is specified by the Gradle plugin consumer, it tries using the JVM "http(s).proxyPort" property.

Whether the "http" or "https" property is used depends on the `contextUrl`: "http" if the `contextUrl` starts with "http://", "https" otherwise.

This does not address the part of #149 that mentions non-proxy-hosts. **This may be a blocker for this PR**, since now this plugin could try using a proxy when `contextUrl` is actually part of non-proxy-hosts. Please let me know if you think non-proxy-hosts handling must be part of this PR.

I didn't write tests yet since I'd like confirmation about whether the above behavior choices are correct. Once these are confirmed I'm happy to add tests.