### PR TITLE
Fix NoSuchMethodError when using IOUtils.toString(InputStream, Charset)

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
@@ -50,7 +50,7 @@ public abstract class JFrogService<TResult> {
             throw new IllegalArgumentException("JFrog service failed. Received " + statusCode);
         }
         try (InputStream stream = entity.getContent()) {
-            String ResponseMessage = IOUtils.toString(stream, StandardCharsets.UTF_8);
+            String ResponseMessage = IOUtils.toString(stream, StandardCharsets.UTF_8.name());
             throw new IOException("JFrog service failed. Received " + statusCode + ": " + ResponseMessage);
         }
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/Download.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/Download.java
@@ -15,6 +15,6 @@ public class Download extends DownloadBase<String> {
 
     @Override
     protected void setResponse(InputStream stream) throws IOException {
-        result = IOUtils.toString(stream, StandardCharsets.UTF_8);
+        result = IOUtils.toString(stream, StandardCharsets.UTF_8.name());
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ScanBuild.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ScanBuild.java
@@ -71,7 +71,7 @@ public class ScanBuild extends JFrogService<ArtifactoryXrayResponse> {
     @Override
     protected void setResponse(InputStream stream) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        String content = IOUtils.toString(stream, StandardCharsets.UTF_8);
+        String content = IOUtils.toString(stream, StandardCharsets.UTF_8.name());
         JsonNode result;
         try {
             result = mapper.readTree(content);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Same as https://github.com/jfrog/build-info/pull/450
Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/506

Use [IOUtils.toString(InputStream,String)](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#toString-java.io.InputStream-java.lang.String-) instead of [IOUtils.toString(InputStream, Charset)](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#toString-java.io.InputStream-java.nio.charset.Charset-) to support usage of Apache Commons older than 2.3. This issue may occur in the Jenkins plugin whereby Apache Commons 2.2 used in the classloader from one of the other plugins.