### PR TITLE
Update file-specs-java to 1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ allprojects {
     group = 'org.jfrog.buildinfo'
 
     repositories {
-        maven { url "https://releases.jfrog.io/artifactory/oss-releases" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
 }
@@ -267,7 +266,7 @@ project('build-info-extractor') {
     dependencies {
         implementation project(':build-info-client')
         implementation project(':build-info-api')
-        implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.0.0'
+        implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.0.2'
 
         testImplementation "org.easymock:easymockclassextension:2.5.2"
         testFixturesApi project(':build-info-client')


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/build-info/issues/522

file-specs-java 1.0.2 is uploaded to Maven Central. Let's include it in the build and make sure it downloaded from Maven Central and not from https://releases.jfrog.io.
