### PR TITLE
Fix tests collisions caused by multiple runs

### DIFF
--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
@@ -3,6 +3,7 @@ package org.jfrog.gradle.plugin.artifactory;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.util.VersionNumber;
 import org.jfrog.build.IntegrationTestsBase;
+import org.jfrog.build.api.Build;
 import org.jfrog.build.api.BuildInfoConfigProperties;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -59,6 +60,9 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, envVars, false);
         // Check results
         checkBuildResults(artifactoryManager, buildResult, false, localRepo1);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -69,6 +73,9 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, envVars, false);
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -79,6 +86,9 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, envVars, false);
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -93,6 +103,9 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -107,6 +120,9 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -121,6 +137,9 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
         int expectedArtifactsPerModule = VersionNumber.parse(gradleVersion).getMajor() >= 6 ? 5 : 4;
         checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 3, expectedArtifactsPerModule);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -135,5 +154,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
         // Check results
         checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 2, 0);
+        // Cleanup
+        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
+        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
     }
 }

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
@@ -1,9 +1,9 @@
 package org.jfrog.gradle.plugin.artifactory;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.util.VersionNumber;
 import org.jfrog.build.IntegrationTestsBase;
-import org.jfrog.build.api.Build;
 import org.jfrog.build.api.BuildInfoConfigProperties;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -61,8 +61,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         // Check results
         checkBuildResults(artifactoryManager, buildResult, false, localRepo1);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -74,8 +74,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -87,8 +87,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -104,8 +104,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -121,8 +121,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         // Check results
         checkBuildResults(artifactoryManager, buildResult, VersionNumber.parse(gradleVersion).getMajor() >= 6, localRepo1);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -138,8 +138,8 @@ public class GradlePluginTest extends IntegrationTestsBase {
         int expectedArtifactsPerModule = VersionNumber.parse(gradleVersion).getMajor() >= 6 ? 5 : 4;
         checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 3, expectedArtifactsPerModule);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
     @Test(dataProvider = "gradleVersions")
@@ -155,7 +155,7 @@ public class GradlePluginTest extends IntegrationTestsBase {
         // Check results
         checkLocalBuild(buildResult, BUILD_INFO_JSON.toFile(), 2, 0);
         // Cleanup
-        Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
-        cleanTestBuilds(buildInfo.getName(), buildInfo.getNumber(), null);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 }

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
@@ -190,6 +191,15 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     public static Build getBuildInfo(ArtifactoryManager artifactoryManager, BuildResult buildResult) throws IOException {
+        Pair<String,String> buildDetails = getBuildDetails(buildResult);
+        return artifactoryManager.getBuildInfo(buildDetails.getLeft(), buildDetails.getRight(), null);
+    }
+
+    /**
+     * @param buildResult Details of the build
+     * @return A pair of: Left item - buildResult's build name, Right item - buildResult's build number
+     */
+    public static Pair<String,String> getBuildDetails( BuildResult buildResult)  {
         // Get build info URL
         String[] res = StringUtils.substringAfter(buildResult.getOutput(), BUILD_BROWSE_URL).split("/");
         assertTrue(ArrayUtils.getLength(res) >= 3, "Couldn't find build info URL link");
@@ -197,7 +207,7 @@ public class Utils {
         // Extract build name and number from build info URL
         String buildName = res[1];
         String buildNumber = StringUtils.substringBefore(res[2], System.lineSeparator());
-        return artifactoryManager.getBuildInfo(buildName, buildNumber, null);
+        return Pair.of(buildName, buildNumber);
     }
 
     /**

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -191,7 +191,7 @@ public class Utils {
      * @throws IOException - In case of any IO error
      */
     public static Build getBuildInfo(ArtifactoryManager artifactoryManager, BuildResult buildResult) throws IOException {
-        Pair<String,String> buildDetails = getBuildDetails(buildResult);
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
         return artifactoryManager.getBuildInfo(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
@@ -199,7 +199,7 @@ public class Utils {
      * @param buildResult Details of the build
      * @return A pair of: Left item - buildResult's build name, Right item - buildResult's build number
      */
-    public static Pair<String,String> getBuildDetails( BuildResult buildResult)  {
+    public static Pair<String, String> getBuildDetails(BuildResult buildResult) {
         // Get build info URL
         String[] res = StringUtils.substringAfter(buildResult.getOutput(), BUILD_BROWSE_URL).split("/");
         assertTrue(ArrayUtils.getLength(res) >= 3, "Couldn't find build info URL link");

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -147,9 +147,6 @@ public class Utils {
         Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
         assertNotNull(buildInfo);
         checkBuildInfoModules(buildInfo, 3, expectModuleArtifacts ? 5 : 4);
-
-        // Cleanup
-        artifactoryManager.deleteBuild(buildInfo.getName(), buildInfo.getNumber(), null, true);
     }
 
     static void assertProjectsSuccess(BuildResult buildResult) {
@@ -192,7 +189,7 @@ public class Utils {
      * @return build info or null
      * @throws IOException - In case of any IO error
      */
-    private static Build getBuildInfo(ArtifactoryManager artifactoryManager, BuildResult buildResult) throws IOException {
+    public static Build getBuildInfo(ArtifactoryManager artifactoryManager, BuildResult buildResult) throws IOException {
         // Get build info URL
         String[] res = StringUtils.substringAfter(buildResult.getOutput(), BUILD_BROWSE_URL).split("/");
         assertTrue(ArrayUtils.getLength(res) >= 3, "Couldn't find build info URL link");

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -147,6 +147,9 @@ public class Utils {
         Build buildInfo = getBuildInfo(artifactoryManager, buildResult);
         assertNotNull(buildInfo);
         checkBuildInfoModules(buildInfo, 3, expectModuleArtifacts ? 5 : 4);
+
+        // Cleanup
+        artifactoryManager.deleteBuild(buildInfo.getName(), buildInfo.getNumber(), null, true);
     }
 
     static void assertProjectsSuccess(BuildResult buildResult) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -22,6 +22,7 @@ import org.jfrog.build.client.artifactoryXrayResponse.ArtifactoryXrayResponse;
 import org.jfrog.build.extractor.clientConfiguration.client.ManagerBase;
 import org.jfrog.build.extractor.clientConfiguration.client.RepositoryType;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.*;
+import org.jfrog.build.extractor.clientConfiguration.client.response.GetAllBuildNumbersResponse;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.usageReport.UsageReporter;
 
@@ -145,13 +146,18 @@ public class ArtifactoryManager extends ManagerBase {
         sendModuleInfoService.execute(jfrogHttpClient);
     }
 
+    public GetAllBuildNumbersResponse getAllBuildNumbers(String buildName, String project) throws IOException {
+        GetAllBuildNumbers getAllBuildNumbersService = new GetAllBuildNumbers(buildName, project, log);
+        return getAllBuildNumbersService.execute(jfrogHttpClient);
+    }
+
     public void deleteBuilds(String buildName, String project, boolean deleteArtifact) throws IOException {
         DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, deleteArtifact, log);
         deleteBuildsService.execute(jfrogHttpClient);
     }
 
-    public void deleteBuild(String buildName, String buildNumber, String project, boolean deleteArtifact) throws IOException {
-        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, buildNumber, deleteArtifact, log);
+    public void deleteBuilds(String buildName, String project, boolean deleteArtifact, String... buildNumbers) throws IOException {
+        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, buildNumbers, deleteArtifact, log);
         deleteBuildsService.execute(jfrogHttpClient);
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -145,6 +145,16 @@ public class ArtifactoryManager extends ManagerBase {
         sendModuleInfoService.execute(jfrogHttpClient);
     }
 
+    public void deleteBuilds(String buildName, String project, boolean deleteArtifact) throws IOException {
+        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, deleteArtifact, log);
+        deleteBuildsService.execute(jfrogHttpClient);
+    }
+
+    public void deleteBuild(String buildName, String buildNumber, String project, boolean deleteArtifact) throws IOException {
+        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, buildNumber, deleteArtifact, log);
+        deleteBuildsService.execute(jfrogHttpClient);
+    }
+
     public Build getBuildInfo(String buildName, String buildNumber, String project) throws IOException {
         if (LATEST.equals(buildNumber.trim()) || LAST_RELEASE.equals(buildNumber.trim())) {
             buildNumber = getLatestBuildNumber(buildName, buildNumber, project);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -151,13 +151,13 @@ public class ArtifactoryManager extends ManagerBase {
         return getAllBuildNumbersService.execute(jfrogHttpClient);
     }
 
-    public void deleteBuilds(String buildName, String project, boolean deleteArtifact) throws IOException {
-        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, deleteArtifact, log);
+    public void deleteBuilds(String buildName, String project, boolean deleteArtifacts) throws IOException {
+        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, deleteArtifacts, log);
         deleteBuildsService.execute(jfrogHttpClient);
     }
 
-    public void deleteBuilds(String buildName, String project, boolean deleteArtifact, String... buildNumbers) throws IOException {
-        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, buildNumbers, deleteArtifact, log);
+    public void deleteBuilds(String buildName, String project, boolean deleteArtifacts, String... buildNumbers) throws IOException {
+        DeleteBuilds deleteBuildsService = new DeleteBuilds(buildName, project, buildNumbers, deleteArtifacts, log);
         deleteBuildsService.execute(jfrogHttpClient);
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DeleteBuilds.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DeleteBuilds.java
@@ -1,50 +1,43 @@
 package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
+import org.jfrog.build.extractor.clientConfiguration.client.request.DeleteBuildsRequest;
 
 import java.io.IOException;
 
-/**
- * Delete multiple build numbers of a certain build.
- */
-public class DeleteBuilds extends VoidJFrogService {
-    public static final String DELETE_BUILDS_ENDPOINT = "api/build/";
-    private final String buildName;
-    private final boolean deleteArtifact;
-    private final String project;
-    private String buildNumber;
+import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJsonString;
 
+public class DeleteBuilds extends VoidJFrogService {
+    public static final String DELETE_BUILDS_ENDPOINT = "api/build/delete";
+
+    private final DeleteBuildsRequest deleteBuildsRequest;
+
+    /**
+     * Delete All build numbers of a certain build.
+     */
     public DeleteBuilds(String buildName, String project, boolean deleteArtifact, Log logger) {
         super(logger);
-        this.buildName = buildName;
-        this.project = project;
-        this.deleteArtifact = deleteArtifact;
+        deleteBuildsRequest = new DeleteBuildsRequest(buildName, project, deleteArtifact);
     }
 
-    public DeleteBuilds(String buildName, String project, String buildNumber, boolean deleteArtifact, Log logger) {
+    /**
+     * Delete multiple build numbers of a certain build.
+     */
+    public DeleteBuilds(String buildName, String project, String[] buildNumbers, boolean deleteArtifact, Log logger) {
         super(logger);
-        this.buildName = buildName;
-        this.project = project;
-        this.buildNumber = buildNumber;
-        this.deleteArtifact = deleteArtifact;
+        deleteBuildsRequest = new DeleteBuildsRequest(buildName, buildNumbers, project, deleteArtifact);
     }
 
     @Override
     public HttpRequestBase createRequest() throws IOException {
-        String requestUrl = DELETE_BUILDS_ENDPOINT + encodeUrl(buildName);
-        if (buildName == null) {
-            requestUrl += "?deleteAll=1";
-        } else {
-            requestUrl += "?buildNumbers=" + buildNumber;
-        }
-        requestUrl += "&artifacts=" + (deleteArtifact ? "1" : "0");
-        if (StringUtils.isNotEmpty(project)) {
-            requestUrl += "&project=" + project;
-        }
-        return new HttpDelete(requestUrl);
+        HttpPost request = new HttpPost(DELETE_BUILDS_ENDPOINT);
+        StringEntity stringEntity = new StringEntity(toJsonString(deleteBuildsRequest));
+        stringEntity.setContentType("application/json");
+        request.setEntity(stringEntity);
+        return request;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DeleteBuilds.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DeleteBuilds.java
@@ -1,0 +1,50 @@
+package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
+
+import java.io.IOException;
+
+/**
+ * Delete multiple build numbers of a certain build.
+ */
+public class DeleteBuilds extends VoidJFrogService {
+    public static final String DELETE_BUILDS_ENDPOINT = "api/build/";
+    private final String buildName;
+    private final boolean deleteArtifact;
+    private final String project;
+    private String buildNumber;
+
+    public DeleteBuilds(String buildName, String project, boolean deleteArtifact, Log logger) {
+        super(logger);
+        this.buildName = buildName;
+        this.project = project;
+        this.deleteArtifact = deleteArtifact;
+    }
+
+    public DeleteBuilds(String buildName, String project, String buildNumber, boolean deleteArtifact, Log logger) {
+        super(logger);
+        this.buildName = buildName;
+        this.project = project;
+        this.buildNumber = buildNumber;
+        this.deleteArtifact = deleteArtifact;
+    }
+
+    @Override
+    public HttpRequestBase createRequest() throws IOException {
+        String requestUrl = DELETE_BUILDS_ENDPOINT + encodeUrl(buildName);
+        if (buildName == null) {
+            requestUrl += "?deleteAll=1";
+        } else {
+            requestUrl += "?buildNumbers=" + buildNumber;
+        }
+        requestUrl += "&artifacts=" + (deleteArtifact ? "1" : "0");
+        if (StringUtils.isNotEmpty(project)) {
+            requestUrl += "&project=" + project;
+        }
+        return new HttpDelete(requestUrl);
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DeleteBuilds.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/DeleteBuilds.java
@@ -19,17 +19,17 @@ public class DeleteBuilds extends VoidJFrogService {
     /**
      * Delete All build numbers of a certain build.
      */
-    public DeleteBuilds(String buildName, String project, boolean deleteArtifact, Log logger) {
+    public DeleteBuilds(String buildName, String project, boolean deleteArtifacts, Log logger) {
         super(logger);
-        deleteBuildsRequest = new DeleteBuildsRequest(buildName, project, deleteArtifact);
+        deleteBuildsRequest = new DeleteBuildsRequest(buildName, project, deleteArtifacts);
     }
 
     /**
      * Delete multiple build numbers of a certain build.
      */
-    public DeleteBuilds(String buildName, String project, String[] buildNumbers, boolean deleteArtifact, Log logger) {
+    public DeleteBuilds(String buildName, String project, String[] buildNumbers, boolean deleteArtifacts, Log logger) {
         super(logger);
-        deleteBuildsRequest = new DeleteBuildsRequest(buildName, buildNumbers, project, deleteArtifact);
+        deleteBuildsRequest = new DeleteBuildsRequest(buildName, buildNumbers, project, deleteArtifacts);
     }
 
     @Override

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetAllBuildNumbers.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetAllBuildNumbers.java
@@ -1,0 +1,46 @@
+package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.clientConfiguration.client.JFrogService;
+import org.jfrog.build.extractor.clientConfiguration.client.response.GetAllBuildNumbersResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.getProjectQueryParam;
+
+public class GetAllBuildNumbers extends JFrogService<GetAllBuildNumbersResponse> {
+
+    private final String buildName;
+    private final String project;
+
+    public GetAllBuildNumbers(String buildName, String project, Log logger) {
+        super(logger);
+        this.buildName = buildName;
+        this.project = project;
+    }
+
+    @Override
+    public HttpRequestBase createRequest() {
+        String apiEndPoint = String.format("%s/%s%s", "api/build", encodeUrl(buildName), getProjectQueryParam(project));
+        return new HttpGet(apiEndPoint);
+    }
+
+    @Override
+    protected void setResponse(InputStream stream) throws IOException {
+        result = getMapper().readValue(stream, GetAllBuildNumbersResponse.class);
+    }
+
+    @Override
+    protected void handleUnsuccessfulResponse(HttpEntity entity) throws IOException {
+        if (statusCode == HttpStatus.SC_NOT_FOUND) {
+            result = new GetAllBuildNumbersResponse();
+        } else {
+            throwException(entity, getStatusCode());
+        }
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/request/DeleteBuildsRequest.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/request/DeleteBuildsRequest.java
@@ -1,0 +1,65 @@
+package org.jfrog.build.extractor.clientConfiguration.client.request;
+
+public class DeleteBuildsRequest {
+    public String buildName;
+    public String project;
+    public String[] buildNumbers;
+    public boolean deleteArtifacts;
+    public boolean deleteAll;
+
+    public DeleteBuildsRequest() {
+
+    }
+
+    public DeleteBuildsRequest(String buildName, String project, boolean deleteArtifacts) {
+        this.buildName = buildName;
+        this.project = project;
+        this.deleteArtifacts = deleteArtifacts;
+    }
+
+    public DeleteBuildsRequest(String buildName, String[] buildNumber, String project, boolean deleteArtifacts) {
+        this(buildName, project, deleteArtifacts);
+        this.buildNumbers = buildNumber;
+    }
+
+    public String getBuildName() {
+        return buildName;
+    }
+
+    public void setBuildName(String buildName) {
+        this.buildName = buildName;
+    }
+
+    public String[] getBuildNumbers() {
+        return buildNumbers;
+    }
+
+    public void setBuildNumbers(String[] buildNumbers) {
+        this.buildNumbers = buildNumbers;
+    }
+
+    public boolean isDeleteArtifacts() {
+        return deleteArtifacts;
+    }
+
+    public void setDeleteArtifacts(boolean deleteArtifacts) {
+        this.deleteArtifacts = deleteArtifacts;
+    }
+
+    public boolean isDeleteAll() {
+        return deleteAll;
+    }
+
+    public void setDeleteAll(boolean deleteAll) {
+        this.deleteAll = deleteAll;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
+    }
+
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/GetAllBuildNumbersResponse.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/GetAllBuildNumbersResponse.java
@@ -1,0 +1,46 @@
+package org.jfrog.build.extractor.clientConfiguration.client.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetAllBuildNumbersResponse {
+    public String uri;
+    public List<BuildsNumberDetails> buildsNumbers = new ArrayList<>();
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public List<BuildsNumberDetails> getBuildsNumbers() {
+        return buildsNumbers;
+    }
+
+    public void setBuildsNumbers(List<BuildsNumberDetails> buildsNumbers) {
+        this.buildsNumbers = buildsNumbers;
+    }
+
+    public static class BuildsNumberDetails {
+        public String uri;
+        public String started;
+
+        public String getStarted() {
+            return started;
+        }
+
+        public void setStarted(String started) {
+            this.started = started;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+    }
+}

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -98,7 +98,7 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
         Assert.assertEquals(toJsonString(buildInfoToSend), toJsonString(receivedBuildInfo));
 
         // Cleanup
-        artifactoryManager.deleteBuild(BUILD_NAME, BUILD_NUMBER, project, true);
+        cleanTestBuilds(BUILD_NAME, BUILD_NUMBER, project);
     }
 
     private void sendBuildRetention(String project) throws IOException {

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -31,7 +31,7 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
     private static final String TEST_SPACE = "bi_client_test_space";
     private static final File tempWorkspace = new File(System.getProperty("java.io.tmpdir"), TEST_SPACE);
     private static final String BUILD_NAME = "ArtifactoryManagerTest";
-    private static final String BUILD_NUMBER = "13";
+    private static final String BUILD_NUMBER = String.valueOf(System.currentTimeMillis());
 
     @BeforeMethod
     @AfterMethod
@@ -64,7 +64,7 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
         final Module module = new Module();
         module.setId("foo");
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(Build.STARTED_FORMAT);
-        final List<PromotionStatus> STATUSES = Arrays.asList(new PromotionStatus("a", "b", "c", simpleDateFormat.format(STARTED), "e", "f"));
+        final List<PromotionStatus> STATUSES = Collections.singletonList(new PromotionStatus("a", "b", "c", simpleDateFormat.format(STARTED), "e", "f"));
 
         BuildInfoBuilder buildInfoBuilder = new BuildInfoBuilder(BUILD_NAME)
                 .number(BUILD_NUMBER)
@@ -96,6 +96,9 @@ public class ArtifactoryManagerTest extends IntegrationTestsBase {
 
         // Compare
         Assert.assertEquals(toJsonString(buildInfoToSend), toJsonString(receivedBuildInfo));
+
+        // Cleanup
+        artifactoryManager.deleteBuild(BUILD_NAME, BUILD_NUMBER, project, true);
     }
 
     private void sendBuildRetention(String project) throws IOException {

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class IssuesCollectorTest extends IntegrationTestsBase {
     private static final String BASE_CONFIG_PATH = "/issuesCollection";
     private static final String BUILD_NAME = "IssuesCollectionTest";
+    private static final String BUILD_NUMBER = String.valueOf(System.currentTimeMillis());
     private IssuesCollector collector;
     private File testResourcesPath;
     private File dotGitPath;
@@ -122,7 +123,7 @@ public class IssuesCollectorTest extends IntegrationTestsBase {
 
     private void publishBuildInfoWithVcs(List<Vcs> vcsList) throws IOException {
         BuildInfoBuilder buildInfoBuilder = new BuildInfoBuilder(BUILD_NAME)
-                .number("123")
+                .number(BUILD_NUMBER)
                 .startedDate(new Date())
                 .url(getArtifactoryUrl())
                 .vcs(vcsList);
@@ -130,6 +131,9 @@ public class IssuesCollectorTest extends IntegrationTestsBase {
 
         // Publish build info
         artifactoryManager.publishBuildInfo(buildInfoToSend, null);
+
+        // Cleanup
+        artifactoryManager.deleteBuild(BUILD_NAME, BUILD_NUMBER, null, true);
     }
 
     @BeforeMethod

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/issuesCollection/IssuesCollectorTest.java
@@ -133,7 +133,7 @@ public class IssuesCollectorTest extends IntegrationTestsBase {
         artifactoryManager.publishBuildInfo(buildInfoToSend, null);
 
         // Cleanup
-        artifactoryManager.deleteBuild(BUILD_NAME, BUILD_NUMBER, null, true);
+        artifactoryManager.deleteBuilds(BUILD_NAME, null, true, BUILD_NUMBER);
     }
 
     @BeforeMethod

--- a/build-info-extractor/src/testFixtures/java/org/jfrog/build/IntegrationTestsBase.java
+++ b/build-info-extractor/src/testFixtures/java/org/jfrog/build/IntegrationTestsBase.java
@@ -277,7 +277,7 @@ public abstract class IntegrationTestsBase {
      */
     private static boolean isOldBuild(Matcher buildMatcher) {
         long repoTimestamp = Long.parseLong(buildMatcher.group(1));
-        return TimeUnit.MILLISECONDS.toHours(CURRENT_TIME - repoTimestamp) >= 0;
+        return TimeUnit.MILLISECONDS.toHours(CURRENT_TIME - repoTimestamp) >= 24;
     }
 
     public void cleanTestBuilds(String buildName, String buildNumber, String project) throws IOException {


### PR DESCRIPTION
* Add build delete service
* Delete published tests build
* Tests' build number changed from const-number to timestamp

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Related: https://github.com/jfrog/jenkins-artifactory-plugin/pull/529