### PR TITLE
Switch to case insensitive comparison of HTTP headers

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
@@ -349,19 +349,14 @@ public class DependenciesDownloaderHelper {
         try {
             ArtifactMetaData artifactMetaData = new ArtifactMetaData();
             for (Header header : downloader.getArtifactoryManager().downloadHeaders(url)) {
-                switch (header.getName()) {
-                    case MD5_HEADER_NAME:
-                        artifactMetaData.setMd5(header.getValue());
-                        break;
-                    case SHA1_HEADER_NAME:
-                        artifactMetaData.setSha1(header.getValue());
-                        break;
-                    case HttpHeaders.CONTENT_LENGTH:
-                        artifactMetaData.setSize(NumberUtils.toLong(header.getValue()));
-                        break;
-                    case HttpHeaders.ACCEPT_RANGES:
-                        artifactMetaData.setAcceptRange("bytes".equals(header.getValue()));
-                        break;
+                if (MD5_HEADER_NAME.equalsIgnoreCase(header.getName())) {
+                    artifactMetaData.setMd5(header.getValue());
+                } else if (SHA1_HEADER_NAME.equalsIgnoreCase(header.getName())) {
+                    artifactMetaData.setSha1(header.getValue());
+                } else if (HttpHeaders.CONTENT_LENGTH.equalsIgnoreCase(header.getName())) {
+                    artifactMetaData.setSize(NumberUtils.toLong(header.getValue()));
+                } else if (HttpHeaders.ACCEPT_RANGES.equalsIgnoreCase(header.getName())) {
+                    artifactMetaData.setAcceptRange("bytes".equals(header.getValue()));
                 }
             }
             return artifactMetaData;


### PR DESCRIPTION
Fixes #533 

A bug was introduced in 67cefb2 where http headers no longer was compared case insensitively. This causes problems for Artifactory instances that run behind proxys that normalizes the http headers.

This change fixes the issue by mimicking the implementation in org.apache.http.message.HeaderGroup by using String#equalsIgnoreCase(). Which is the old and correct behaviour.

I haven't added any tests nor tried to build the code base since Gradle is unable to find some dependencies :(

- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
