### PR TITLE
Publish Gradle plugin to Gradle Gallery

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,10 @@
 name: "Publish to Gradle Gallery"
+# During the build-info release, the build-info JARs upload to the Maven Central repository.
+# The upload is asynchronous and may take few hours.
+# Since the Gradle plugin depends on the build-info JARs, we should publish it to the Gradle Gallery only after we make
+# sure the upload to Maven Central completed successfully.
+# To solve this out, this workflow runs every 4 hours to check if the Gradle plugin should be published to the Gradle
+# Gallery and publish the Gradle plugin if needed.
 on:
   schedule:
     # Once per 4 hours
@@ -17,7 +23,7 @@ jobs:
         with:
           text: ${{ env.LATEST_MVN_CENTRAL_VERSION }}
           regex: "[0-9]+.[0-9]+.[0-9]"
-      - name: Test Resolved Version
+      - name: "Test Resolved Version"
         run: |
           echo "Illegal version: $LATEST_MVN_CENTRAL_VERSION"
           exit 1
@@ -27,7 +33,7 @@ jobs:
           if curl -fL https://plugins.gradle.org/m2/org.jfrog.buildinfo/build-info-extractor-gradle/${{ steps.check-version.outputs.match }}; then
             echo "SHOULD_NOT_PUBLISH=TRUE" >> $GITHUB_ENV
           fi
-      - name: Log if Already Exist
+      - name: "Log if Already Exist"
         run: echo "::warning::Version $LATEST_MVN_CENTRAL_VERSION already exist in the Gradle Gallery."
         if: ${{ env.SHOULD_NOT_PUBLISH == 'TRUE'}}
       - uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,47 @@
+name: "Publish to Gradle Gallery"
+on:
+  schedule:
+    # Once per 4 hours
+    - cron: "0 */4 * * *"
+jobs:
+  Publish_if_needed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Get Maven Central Latest Version"
+        run: |
+          export LATEST_MVN_CENTRAL_VERSION=`curl -s https://search.maven.org/solrsearch/select\?q\=g:"org.jfrog.buildinfo"+AND+a:"build-info-extractor-gradle" | jq -r '.response.docs[0].latestVersio'`
+          echo "LATEST_MVN_CENTRAL_VERSION=$LATEST_MVN_CENTRAL_VERSION" >> $GITHUB_ENV
+      - name: "Convert Version to Regex"
+        uses: actions-ecosystem/action-regex-match@v2
+        id: check-version
+        with:
+          text: ${{ env.LATEST_MVN_CENTRAL_VERSION }}
+          regex: "[0-9]+.[0-9]+.[0-9]"
+      - name: Test Resolved Version
+        run: |
+          echo "Illegal version: $LATEST_MVN_CENTRAL_VERSION"
+          exit 1
+        if: ${{ steps.check-version.outputs.match == '' }}
+      - name: "Check Version in Gradle Gallery"
+        run: |
+          if curl -fL https://plugins.gradle.org/m2/org.jfrog.buildinfo/build-info-extractor-gradle/${{ steps.check-version.outputs.match }}; then
+            echo "SHOULD_NOT_PUBLISH=TRUE" >> $GITHUB_ENV
+          fi
+      - name: Log if Already Exist
+        run: echo "::warning::Version $LATEST_MVN_CENTRAL_VERSION already exist in the Gradle Gallery."
+        if: ${{ env.SHOULD_NOT_PUBLISH == 'TRUE'}}
+      - uses: actions/checkout@v2
+        with:
+          ref: refs/tags/build-info-gradle-extractor-${{ env.LATEST_MVN_CENTRAL_VERSION }}
+        if: ${{ env.SHOULD_NOT_PUBLISH != 'TRUE'}}
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "8"
+        if: ${{ env.SHOULD_NOT_PUBLISH != 'TRUE'}}
+      - name: "Publish to Gradle Gallery"
+        run: ./gradlew clean build -x test publishPlugins
+        if: ${{ env.SHOULD_NOT_PUBLISH != 'TRUE'}}
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/omscno1vb7g11qu2?svg=true)](https://ci.appveyor.com/project/jfrog-ecosystem/build-info)
+[![Build status](https://ci.appveyor.com/api/projects/status/omscno1vb7g11qu2?svg=true)](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) [![Gradle plugin](https://img.shields.io/gradle-plugin-portal/v/com.jfrog.artifactory?label=Gradle%20Artifactory%20plugin)](https://plugins.gradle.org/plugin/com.jfrog.artifactory)
 
 ## Overview
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/build-info/issues/518

Check every 4 hours if the `build-info-extractor-gradle` version in the Maven Central is newer than the latest published in the Gradle gallery. If it does, update the version in the Gradle Gallery.