### PR TITLE
Fail to deserialize deployable artifacts

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
@@ -1,9 +1,6 @@
 package org.jfrog.build.extractor.docker;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -14,6 +11,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 public class DockerUtils {
     /**
@@ -74,19 +73,6 @@ public class DockerUtils {
             }
         }
         return "";
-    }
-
-    /**
-     * Create an object mapper for serialization/deserialization.
-     * This mapper ignore unknown properties and null values.
-     *
-     * @return a new object mapper
-     */
-    public static ObjectMapper createMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        return mapper;
     }
 
     /**

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/BuildDockerCreator.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/BuildDockerCreator.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.jfrog.build.extractor.docker.DockerUtils.createMapper;
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class BuildDockerCreator extends PackageManagerExtractor {

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/types/NpmPackageInfo.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/types/NpmPackageInfo.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.npm.types;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.producerConsumer.ProducerConsumerItem;
@@ -9,6 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Objects;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 public class NpmPackageInfo implements Serializable, ProducerConsumerItem {
     private static final long serialVersionUID = 1L;
@@ -67,8 +68,7 @@ public class NpmPackageInfo implements Serializable, ProducerConsumerItem {
     }
 
     public void readPackageInfo(InputStream inputStream) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectMapper mapper = createMapper();
 
         NpmPackageInfo npmPackageInfo = mapper.readValue(inputStream, NpmPackageInfo.class);
 

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/types/NugetProjectAssets.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/types/NugetProjectAssets.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.nuget.types;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 
@@ -8,6 +7,8 @@ import java.io.*;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 public class NugetProjectAssets {
     private static final long serialVersionUID = 1L;
@@ -155,7 +156,7 @@ public class NugetProjectAssets {
     public void readProjectAssets(File projectAssets) throws IOException {
         try (FileInputStream fis = new FileInputStream(projectAssets)) {
             String json = inputStreamToString(fis);
-            ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            ObjectMapper mapper = createMapper();
             NugetProjectAssets assets = mapper.readValue(json, NugetProjectAssets.class);
             this.setVersion(assets.getVersion());
             this.setLibraries(assets.getLibraries());

--- a/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/extractor/DependenciesCache.java
+++ b/build-info-extractor-pip/src/main/java/org/jfrog/build/extractor/pip/extractor/DependenciesCache.java
@@ -2,10 +2,8 @@ package org.jfrog.build.extractor.pip.extractor;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.util.Log;
 
@@ -16,6 +14,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 /**
  * Created by Bar Belity on 19/07/2020.
@@ -30,13 +30,7 @@ import java.util.Map;
 public class DependenciesCache {
 
     private static final int CACHE_VERSION = 1;
-    private static ObjectMapper objectMapper;
-
-    static {
-        objectMapper = new ObjectMapper();
-        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-    }
+    private static final ObjectMapper objectMapper = createMapper();
 
     @JsonProperty("version")
     private int version = CACHE_VERSION;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -292,6 +293,20 @@ public abstract class BuildInfoExtractorUtils {
 
     public static String getModuleIdString(String organisation, String name, String version) {
         return organisation + ':' + name + ':' + version;
+    }
+
+    /**
+     * Create an object mapper for serialization/deserialization.
+     * This mapper ignore unknown properties and null values.
+     *
+     * @return a new object mapper
+     */
+    public static ObjectMapper createMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
     }
 
     private static class PrefixPredicate implements Predicate<Object> {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -1,10 +1,8 @@
 package org.jfrog.build.extractor;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.google.common.base.Charsets;
@@ -16,16 +14,16 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
+
 /**
  * Utilities for serializing/deserializing Module info as json
  */
 public class ModuleExtractorUtils {
     private static JsonFactory createJsonFactory() {
         JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        ObjectMapper mapper = createMapper();
         mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         jsonFactory.setCodec(mapper);
         return jsonFactory;
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/JFrogService.java
@@ -1,7 +1,5 @@
 package org.jfrog.build.extractor.clientConfiguration.client;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import org.apache.commons.codec.net.URLCodec;
@@ -21,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.apache.commons.codec.binary.StringUtils.getBytesUtf8;
 import static org.apache.commons.codec.binary.StringUtils.newStringUsAscii;
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 /**
  * JFrogService represents a generic way of processing a REST endpoint process that structures how REST sends, handles errors, and parses the response.
@@ -65,10 +64,8 @@ public abstract class JFrogService<TResult> {
      */
     protected ObjectMapper getMapper() {
         if (mapper == null) {
-            mapper = new ObjectMapper();
-            mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            mapper = createMapper();
             mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
-            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         }
         return mapper;
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/deploy/DeployableArtifactsUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/deploy/DeployableArtifactsUtils.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.clientConfiguration.deploy;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jfrog.build.client.DeployableArtifactDetail;
@@ -9,11 +8,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
+
 /**
  * Utilities for deployable artifacts.
  * Deployable artifacts file is a list of DeployableArtifactDetail.
  * The DeployDetails set is prepared in the build artifacts phase. From DeployDetails set we extract the list of DeployableArtifactDetail.
- *
+ * <p>
  * Created by yahavi on 25/04/2017.
  */
 public class DeployableArtifactsUtils {
@@ -30,20 +31,19 @@ public class DeployableArtifactsUtils {
         Map<String, List<DeployableArtifactDetail>> deployableArtifactsDetails = new HashMap<>();
         deployableArtifactsByModule.forEach((module, deployableArtifacts) ->
                 deployableArtifactsDetails.put(module, DeployableArtifactsUtils.getDeployableArtifactsPaths(deployableArtifacts)));
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ObjectMapper mapper = createMapper();
         mapper.writeValue(toFile, deployableArtifactsDetails);
     }
 
     /**
      * For backward compatibility, save the deployable artifacts as list (for pipelines using Gradle Artifactory Plugin with version 4.15.1 and above, along with Jenkins Artifactory Plugin bellow 3.6.1)
-     * */
+     */
     @Deprecated
     private static void saveBackwardCompatibleDeployableArtifacts(Map<String, Set<DeployDetails>> deployableArtifactsByModule, File toFile) throws IOException {
-        List<DeployableArtifactDetail> deployableArtifactsList = new ArrayList<DeployableArtifactDetail>();
+        List<DeployableArtifactDetail> deployableArtifactsList = new ArrayList<>();
         deployableArtifactsByModule.forEach((module, deployableArtifacts) ->
-            deployableArtifactsList.addAll(DeployableArtifactsUtils.getDeployableArtifactsPaths(deployableArtifacts)));
-        ObjectMapper mapper = new ObjectMapper();
+                deployableArtifactsList.addAll(DeployableArtifactsUtils.getDeployableArtifactsPaths(deployableArtifacts)));
+        ObjectMapper mapper = createMapper();
         mapper.writeValue(toFile, deployableArtifactsList);
     }
 
@@ -60,20 +60,22 @@ public class DeployableArtifactsUtils {
         if (fromFile == null || fromFile.length() == 0) {
             return new HashMap<>();
         }
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(fromFile, new TypeReference<Map<String, List<DeployableArtifactDetail>>>(){});
+        ObjectMapper mapper = createMapper();
+        return mapper.readValue(fromFile, new TypeReference<Map<String, List<DeployableArtifactDetail>>>() {
+        });
     }
 
     /**
      * For backwards compatibility, load the deployable artifacts as list (for pipelines using Gradle Artifactory Plugin with version bellow 4.15.0, along with Jenkins Artifactory Plugin 3.6.1 and above)
-     * */
+     */
     @Deprecated
     private static Map<String, List<DeployableArtifactDetail>> loadBackwardCompatibleDeployableArtifactsFromFile(File fromFile) throws IOException {
         if (fromFile == null || fromFile.length() == 0) {
             return new HashMap<>();
         }
-        ObjectMapper mapper = new ObjectMapper();
-        List<DeployableArtifactDetail> backwardCompatibleList = mapper.readValue(fromFile, new TypeReference<List<DeployableArtifactDetail>>(){});
+        ObjectMapper mapper = createMapper();
+        List<DeployableArtifactDetail> backwardCompatibleList = mapper.readValue(fromFile, new TypeReference<List<DeployableArtifactDetail>>() {
+        });
         // Convert to map
         Map<String, List<DeployableArtifactDetail>> deployableArtifactMap = new HashMap<>();
         if (!backwardCompatibleList.isEmpty()) {
@@ -83,7 +85,7 @@ public class DeployableArtifactsUtils {
     }
 
     private static List<DeployableArtifactDetail> getDeployableArtifactsPaths(Set<DeployDetails> deployDetails) {
-        List<DeployableArtifactDetail> deployableArtifacts = new ArrayList<DeployableArtifactDetail>();
+        List<DeployableArtifactDetail> deployableArtifacts = new ArrayList<>();
         for (DeployDetails artifact : deployDetails) {
             deployableArtifacts.add(new DeployableArtifactDetail(artifact.getFile().getAbsolutePath(), artifact.getArtifactPath(), artifact.getSha1(), artifact.getSha256(), artifact.getDeploySucceeded(), artifact.getTargetRepository()));
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/JsonSerializer.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/JsonSerializer.java
@@ -16,7 +16,6 @@
 
 package org.jfrog.build.extractor.clientConfiguration.util;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,6 +23,8 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 import java.io.IOException;
 import java.io.StringWriter;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 /**
  * @author jbaruch
@@ -33,10 +34,9 @@ public class JsonSerializer<T> {
 
     public String toJSON(T object) throws IOException {
         JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        ObjectMapper mapper = createMapper();
 
         mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         jsonFactory.setCodec(mapper);
         StringWriter writer = new StringWriter();
         JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/JsonUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/JsonUtils.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.clientConfiguration.util;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -10,6 +9,8 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
 public class JsonUtils {
     public static String toJsonString(Object object) throws IOException {
@@ -33,9 +34,8 @@ public class JsonUtils {
 
     public static JsonFactory createJsonFactory() {
         JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        ObjectMapper mapper = createMapper();
         mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         jsonFactory.setCodec(mapper);
         return jsonFactory;
     }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/522#issuecomment-880781341

Fix the following issue:
> Unrecognized field "targetRepository" (class org.jfrog.build.client.DeployableArtifactDetail), not marked as ignorable (5 known properties: "sourcePath", "deploySucceeded", "artifactDest", "sha1", "sha256"])
 at [Source: (File); line: 1, column: 529] (through reference chain: java.util.LinkedHashMap["charging-notification-java-client"]->java.util.ArrayList[0]->org.jfrog.build.client.DeployableArtifactDetail["targetRepository"])
