### PR TITLE
Gradle - skip uploading JAR if no jar produced in build

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperPublications.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperPublications.java
@@ -255,7 +255,7 @@ public class TaskHelperPublications extends TaskHelper {
             }
 
             boolean legacy = false;
-            Set<MavenArtifact> artifacts;
+            Set<MavenArtifact> artifacts = new HashSet<>();
             try {
                 // Gradle 5.0 and above:
                 artifacts = mavenNormalizedPublication.getAdditionalArtifacts();
@@ -263,6 +263,10 @@ public class TaskHelperPublications extends TaskHelper {
                 if (mavenNormalizedPublication.getMainArtifact() != null) {
                     createPublishArtifactInfoAndAddToDeployDetails(mavenNormalizedPublication.getMainArtifact(), deployDetails, mavenPublication, publicationName);
                 }
+            } catch (IllegalStateException exception) {
+                // The Jar task is disabled, and therefore getMainArtifact() threw an exception:
+                // "Artifact api.jar wasn't produced by this build."
+                log.warn("Illegal state detected at Maven publication '{}', {}: {}", publicationName, getProject(), exception.getMessage());
             } catch (NoSuchMethodError error) {
                 // Compatibility with older versions of Gradle:
                 artifacts = mavenNormalizedPublication.getAllArtifacts();


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

If Maven publication with `components.java` exist, but there are no JARs produced in the build, don't fail the build.
Instead log the returned exception with information about the project and the publication.
For example:
>  Illegal state detected at Maven publication: 'mavenJava', project ':api': Artifact api.jar wasn't produced by this build.