### PR TITLE
Make download headers comparisons case insensitive

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
@@ -357,7 +357,7 @@ public class DependenciesDownloaderHelper {
                 } else if (HttpHeaders.CONTENT_LENGTH.toUpperCase().equals(upperCaseHeader)) {
                     artifactMetaData.setSize(NumberUtils.toLong(header.getValue()));
                 } else if (HttpHeaders.ACCEPT_RANGES.toUpperCase().equals(upperCaseHeader)) {
-                    artifactMetaData.setAcceptRange("bytes".equals(header.getValue()));
+                    artifactMetaData.setAcceptRange("bytes".equalsIgnoreCase(header.getValue()));
                 }
             }
             return artifactMetaData;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
@@ -349,19 +349,15 @@ public class DependenciesDownloaderHelper {
         try {
             ArtifactMetaData artifactMetaData = new ArtifactMetaData();
             for (Header header : downloader.getArtifactoryManager().downloadHeaders(url)) {
-                switch (header.getName()) {
-                    case MD5_HEADER_NAME:
-                        artifactMetaData.setMd5(header.getValue());
-                        break;
-                    case SHA1_HEADER_NAME:
-                        artifactMetaData.setSha1(header.getValue());
-                        break;
-                    case HttpHeaders.CONTENT_LENGTH:
-                        artifactMetaData.setSize(NumberUtils.toLong(header.getValue()));
-                        break;
-                    case HttpHeaders.ACCEPT_RANGES:
-                        artifactMetaData.setAcceptRange("bytes".equals(header.getValue()));
-                        break;
+                String upperCaseHeader = StringUtils.upperCase(header.getName());
+                if (MD5_HEADER_NAME.toUpperCase().equals(upperCaseHeader)) {
+                    artifactMetaData.setMd5(header.getValue());
+                } else if (SHA1_HEADER_NAME.toUpperCase().equals(upperCaseHeader)) {
+                    artifactMetaData.setSha1(header.getValue());
+                } else if (HttpHeaders.CONTENT_LENGTH.toUpperCase().equals(upperCaseHeader)) {
+                    artifactMetaData.setSize(NumberUtils.toLong(header.getValue()));
+                } else if (HttpHeaders.ACCEPT_RANGES.toUpperCase().equals(upperCaseHeader)) {
+                    artifactMetaData.setAcceptRange("bytes".equals(header.getValue()));
                 }
             }
             return artifactMetaData;


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Supersedes https://github.com/jfrog/build-info/pull/534
Resolves #533 

Headers comparison should not be case-sensitive.