### PR TITLE
Allow npm projects without name and versions

### DIFF
--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTree.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTree.java
@@ -8,6 +8,7 @@ import org.jfrog.build.extractor.npm.types.NpmScope;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.jfrog.build.extractor.scan.Scope;
 
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -21,18 +22,39 @@ public class NpmDependencyTree {
     /**
      * Create a npm dependency tree from the results of 'npm ls' command.
      *
-     * @param npmList - Results of 'npm ls' command.
+     * @param npmList    - Results of 'npm ls' command
+     * @param scope      - Dependency scope
+     * @param workingDir - The package.json directory
      * @return Tree of npm PackageInfos.
      * @see NpmPackageInfo
      */
-    public static DependencyTree createDependencyTree(JsonNode npmList, NpmScope scope) {
+    public static DependencyTree createDependencyTree(JsonNode npmList, NpmScope scope, Path workingDir) {
         DependencyTree rootNode = new DependencyTree();
-        populateDependenciesTree(rootNode, npmList.get("dependencies"), new String[]{npmList.get("name").asText() + ":" + npmList.get("version").asText()}, scope);
+        populateDependenciesTree(rootNode, npmList.get("dependencies"), new String[]{getProjectName(npmList, workingDir)}, scope);
         for (DependencyTree child : rootNode.getChildren()) {
             NpmPackageInfo packageInfo = (NpmPackageInfo) child.getUserObject();
             child.setScopes(getScopes(packageInfo.getName(), packageInfo.getScope()));
         }
         return rootNode;
+    }
+
+    /**
+     * Get npm project name to populate the root node.
+     *
+     * @param npmList    - Results of 'npm ls' command
+     * @param workingDir - The package.json directory
+     * @return <name>:<version>, <name> or <directory-name>
+     */
+    static String getProjectName(JsonNode npmList, Path workingDir) {
+        JsonNode name = npmList.get("name");
+        JsonNode version = npmList.get("version");
+        if (name != null && version != null) {
+            return name.asText() + ":" + version.asText();
+        }
+        if (name != null) {
+            return name.asText();
+        }
+        return workingDir.getFileName().toString();
     }
 
     /**

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTree.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTree.java
@@ -48,10 +48,10 @@ public class NpmDependencyTree {
     static String getProjectName(JsonNode npmList, Path workingDir) {
         JsonNode name = npmList.get("name");
         JsonNode version = npmList.get("version");
-        if (name != null && version != null) {
-            return name.asText() + ":" + version.asText();
-        }
         if (name != null) {
+            if (version != null) {
+                return name.asText() + ":" + version.asText();
+            }
             return name.asText();
         }
         return workingDir.getFileName().toString();

--- a/build-info-extractor-npm/src/test/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTreeTest.java
+++ b/build-info-extractor-npm/src/test/java/org/jfrog/build/extractor/npm/extractor/NpmDependencyTreeTest.java
@@ -1,0 +1,49 @@
+package org.jfrog.build.extractor.npm.extractor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
+
+/**
+ * @author yahavi
+ **/
+@Test
+public class NpmDependencyTreeTest {
+    private final ObjectMapper mapper = createMapper();
+
+    @DataProvider
+    private Object[][] getProjectNameProvider() {
+        return new Object[][]{
+                {new GetProjectNameProvider("{}", Paths.get("a", "b", "c"), "c")},
+                {new GetProjectNameProvider("{\"version\":\"1.2.3\"}", Paths.get("a", "b", "c"), "c")},
+                {new GetProjectNameProvider("{\"name\":\"loki\"}", Paths.get("a", "b", "c"), "loki")},
+                {new GetProjectNameProvider("{\"name\":\"loki\",\"version\":\"1.2.3\"}", Paths.get("a", "b", "c"), "loki:1.2.3")}
+        };
+    }
+
+    @Test(dataProvider = "getProjectNameProvider")
+    public void getProjectNameEmptyTest(GetProjectNameProvider projectNameProvider) throws JsonProcessingException {
+        JsonNode npmList = mapper.readTree(projectNameProvider.npmLsResults);
+        Assert.assertEquals(NpmDependencyTree.getProjectName(npmList, projectNameProvider.workingDir), projectNameProvider.expectedProjectName);
+    }
+
+    private static class GetProjectNameProvider {
+        private final String npmLsResults;
+        private final Path workingDir;
+        private final String expectedProjectName;
+
+        private GetProjectNameProvider(String npmLsResults, Path workingDir, String expectedProjectName) {
+            this.npmLsResults = npmLsResults;
+            this.workingDir = workingDir;
+            this.expectedProjectName = expectedProjectName;
+        }
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

`package.json` files are allowed to be without name and version nodes. Currently, the code throws NPE in such cases.
If `name` is missing, use the directory name as the project name.
If only `version` is missing, use the name without the version as the project name.
Otherwise, use <name>:<version> as the project name.