### PR TITLE
Build scan - allow getIssueType to be case-insensitive

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/artifactoryXrayResponse/Issue.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/artifactoryXrayResponse/Issue.java
@@ -1,6 +1,7 @@
 package org.jfrog.build.client.artifactoryXrayResponse;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.io.Serializable;
@@ -115,10 +116,11 @@ public class Issue implements Serializable {
     }
 
     public IssueType getIssueType() {
-        if ("Security".equals(this.getType())) {
-            return IssueType.SECURITY;
-        } else if ("License".equals(this.getType())) {
-            return IssueType.LICENSE;
+        switch (StringUtils.defaultString(getType()).toUpperCase()) {
+            case "SECURITY":
+                return IssueType.SECURITY;
+            case "LICENSE":
+                return IssueType.LICENSE;
         }
         return null;
     }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jenkins-artifactory-plugin/issues/560

To support older Xray versions, we should accept either "security" and "Security" issue types. Same for the license type.