### PR TITLE
Add getUsedModules and modTidy to GoDriver

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -18,11 +18,11 @@ import java.util.Map;
  */
 public class GoDriver implements Serializable {
     private static final List<String> GO_LIST_USED_MODULES_CMD =
-            Arrays.asList("list", "-f" ,"\"{{with .Module}}{{.Path}} {{.Version}}{{end}}\"", "all");
+            Arrays.asList("list", "-f", "\"{{with .Module}}{{.Path}} {{.Version}}{{end}}\"", "all");
     private static final String GO_MOD_GRAPH_CMD = "mod graph";
+    private static final String GO_LIST_MODULE_CMD = "list -m";
     private static final String GO_MOD_TIDY_CMD = "mod tidy";
     private static final String GO_VERSION_CMD = "version";
-    private static final String GO_LIST_MODULE = "list -m";
 
     private static final long serialVersionUID = 1L;
     private final CommandExecutor commandExecutor;
@@ -89,7 +89,7 @@ public class GoDriver implements Serializable {
     }
 
     public String getModuleName() throws IOException {
-        CommandResults commandResults = runCmd(GO_LIST_MODULE, false);
+        CommandResults commandResults = runCmd(GO_LIST_MODULE_CMD, false);
         return commandResults.getRes().trim();
     }
 }

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -17,14 +17,17 @@ import java.util.Map;
  * Created by Bar Belity on 13/02/2020.
  */
 public class GoDriver implements Serializable {
-    private static final String GO_VERSION_CMD = "version";
+    private static final List<String> GO_LIST_USED_MODULES_CMD =
+            Arrays.asList("list", "-f" ,"\"{{with .Module}}{{.Path}} {{.Version}}{{end}}\"", "all");
     private static final String GO_MOD_GRAPH_CMD = "mod graph";
+    private static final String GO_MOD_TIDY_CMD = "mod tidy";
+    private static final String GO_VERSION_CMD = "version";
     private static final String GO_LIST_MODULE = "list -m";
 
     private static final long serialVersionUID = 1L;
-    private CommandExecutor commandExecutor;
-    private File workingDirectory;
-    private Log logger;
+    private final CommandExecutor commandExecutor;
+    private final File workingDirectory;
+    private final Log logger;
 
     public GoDriver(String executablePath, Map<String, String> env, File workingDirectory, Log logger) {
         this.commandExecutor = new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, "go"), env);
@@ -74,6 +77,15 @@ public class GoDriver implements Serializable {
 
     public CommandResults modGraph(boolean prompt) throws IOException {
         return runCmd(GO_MOD_GRAPH_CMD, prompt);
+    }
+
+    public void modTidy(boolean prompt) throws IOException {
+        runCmd(GO_MOD_TIDY_CMD, prompt);
+    }
+
+    public CommandResults getUsedModules(boolean prompt) throws IOException {
+        List<String> argsList = new ArrayList<>(GO_LIST_USED_MODULES_CMD);
+        return runCmd(argsList, prompt);
     }
 
     public String getModuleName() throws IOException {

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -1,0 +1,47 @@
+package org.jfrog.build.extractor.go;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.io.FileUtils;
+import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.extractor.executor.CommandResults;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ **/
+public class GoDriverTest {
+    private static final Path PROJECT_ORIGIN = Paths.get(".").toAbsolutePath().normalize()
+            .resolve(Paths.get("src", "test", "resources", "org", "jfrog", "build", "extractor", "project1"));
+    private static final Set<String> EXPECTED_USED_MODULES = Sets.newHashSet("github.com/jfrog/dependency",
+            "rsc.io/sampler v1.3.0",
+            "golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c",
+            "rsc.io/quote v1.5.2");
+
+    @Test
+    public void testListUsedModules() throws IOException {
+        File projectDir = Files.createTempDirectory("").toFile();
+        try {
+            FileUtils.copyDirectory(PROJECT_ORIGIN.toFile(), projectDir);
+            GoDriver driver = new GoDriver(null, System.getenv(), projectDir, new NullLog());
+            driver.modTidy(false);
+            CommandResults results = driver.getUsedModules(false);
+            Set<String> actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n"))
+                    .map(String::trim)
+                    .collect(Collectors.toSet());
+            assertEquals(actualUsedModules, EXPECTED_USED_MODULES);
+        } finally {
+            FileUtils.deleteDirectory(projectDir);
+        }
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Add 2 new commands to the Go Driver:
1. getUsedModules - run `go list -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all`
2. modTidy - run `go mod tidy`