### PR TITLE
Add projectSetting field to Dependency tree node

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
@@ -21,7 +21,7 @@ public class DependencyTree extends DefaultMutableTreeNode {
     private Issue topIssue = new Issue();
     private GeneralInfo generalInfo;
     private String packagePrefix = "";
-    private boolean projectSetting;
+    private boolean metadata;
 
     public DependencyTree() {
         super();
@@ -90,14 +90,20 @@ public class DependencyTree extends DefaultMutableTreeNode {
         return getChildren().stream().anyMatch(DependencyTree::isLicenseViolating);
     }
 
+    /**
+     * @return true in one of the following cases:
+     * Node represents the root of the dependency tree.
+     * Node represents a project.
+     * Node represents a module in project.
+     */
     @SuppressWarnings("unused")
-    public boolean isProjectSetting() {
-        return projectSetting;
+    public boolean isMetadata() {
+        return metadata;
     }
 
     @SuppressWarnings("unused")
-    public void setProjectSetting(boolean projectSetting) {
-        this.projectSetting = projectSetting;
+    public void setMetadata(boolean metadata) {
+        this.metadata = metadata;
     }
 
     public void setPrefix(String prefix) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
@@ -21,6 +21,13 @@ public class DependencyTree extends DefaultMutableTreeNode {
     private Issue topIssue = new Issue();
     private GeneralInfo generalInfo;
     private String packagePrefix = "";
+
+    /**
+     * metadata should be true if one of the following statement is true:
+     * Node represents the root of the dependency tree.
+     * Node represents a project.
+     * Node represents a module in project.
+     */
     private boolean metadata;
 
     public DependencyTree() {
@@ -90,12 +97,6 @@ public class DependencyTree extends DefaultMutableTreeNode {
         return getChildren().stream().anyMatch(DependencyTree::isLicenseViolating);
     }
 
-    /**
-     * @return true in one of the following cases:
-     * Node represents the root of the dependency tree.
-     * Node represents a project.
-     * Node represents a module in project.
-     */
     @SuppressWarnings("unused")
     public boolean isMetadata() {
         return metadata;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
@@ -21,7 +21,8 @@ public class DependencyTree extends DefaultMutableTreeNode {
     private Issue topIssue = new Issue();
     private GeneralInfo generalInfo;
     private String packagePrefix = "";
- 
+    private boolean projectSetting;
+
     public DependencyTree() {
         super();
     }
@@ -87,6 +88,16 @@ public class DependencyTree extends DefaultMutableTreeNode {
             return true;
         }
         return getChildren().stream().anyMatch(DependencyTree::isLicenseViolating);
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isProjectSetting() {
+        return projectSetting;
+    }
+
+    @SuppressWarnings("unused")
+    public void setProjectSetting(boolean projectSetting) {
+        this.projectSetting = projectSetting;
     }
 
     public void setPrefix(String prefix) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
