### PR TITLE
Reduce dependency tree memory consumption

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/GeneralInfo.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/GeneralInfo.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.scan;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
@@ -7,17 +8,14 @@ import java.io.Serializable;
 /**
  * @author yahavi
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class GeneralInfo implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     private String componentId = "";
-    private String name = "";
-    private String path = "";
     private String pkgType = "";
-    private String groupId = "";
-    private String artifactId = "";
-    private String version = "";
+    private String path = "";
     private String sha1 = "";
 
     @SuppressWarnings("WeakerAccess")
@@ -25,48 +23,43 @@ public class GeneralInfo implements Serializable {
     }
 
     @SuppressWarnings("unused")
-    public GeneralInfo(String componentId, String name, String path, String pkgType) {
+    public GeneralInfo(String componentId, String path, String pkgType) {
         this.componentId = componentId;
-        this.name = name;
         this.path = path;
         this.pkgType = pkgType;
     }
 
     public String getGroupId() {
-        if (StringUtils.isNotBlank(groupId)) {
-            return groupId;
+        int colonMatches = StringUtils.countMatches(componentId, ":");
+        if (colonMatches != 2) {
+            return "";
         }
-        return isValid() ? componentId.substring(0, componentId.indexOf(":")) : "";
+        return componentId.substring(0, componentId.indexOf(":"));
     }
 
     public String getArtifactId() {
-        if (StringUtils.isNotBlank(artifactId)) {
-            return artifactId;
-        }
-        if (!isValid()) {
+        int colonMatches = StringUtils.countMatches(componentId, ":");
+        if (colonMatches < 1 || colonMatches > 2) {
             return "";
         }
         int indexOfColon = componentId.indexOf(":");
-        if (StringUtils.countMatches(componentId, ":") == 1) {
+        if (colonMatches == 1) {
             return componentId.substring(0, indexOfColon);
         }
         return componentId.substring(indexOfColon + 1, componentId.lastIndexOf(":"));
     }
 
     public String getVersion() {
-        if (StringUtils.isNotBlank(version)) {
-            return version;
+        int colonMatches = StringUtils.countMatches(componentId, ":");
+        if (colonMatches < 1 || colonMatches > 2) {
+            return "";
         }
-        return isValid() ? componentId.substring(componentId.lastIndexOf(":") + 1) : "";
+        return componentId.substring(componentId.lastIndexOf(":") + 1);
     }
 
     @SuppressWarnings("unused")
     public String getComponentId() {
         return componentId;
-    }
-
-    public String getName() {
-        return name;
     }
 
     public String getPath() {
@@ -88,28 +81,8 @@ public class GeneralInfo implements Serializable {
         return this;
     }
 
-    public GeneralInfo name(String name) {
-        this.name = name;
-        return this;
-    }
-
     public GeneralInfo path(String path) {
         this.path = path;
-        return this;
-    }
-
-    public GeneralInfo groupId(String groupId) {
-        this.groupId = groupId;
-        return this;
-    }
-
-    public GeneralInfo artifactId(String artifactId) {
-        this.artifactId = artifactId;
-        return this;
-    }
-
-    public GeneralInfo version(String version) {
-        this.version = version;
         return this;
     }
 
@@ -122,10 +95,5 @@ public class GeneralInfo implements Serializable {
     public GeneralInfo sha1(String sha1) {
         this.sha1 = sha1;
         return this;
-    }
-
-    private boolean isValid() {
-        int colonCount = StringUtils.countMatches(componentId, ":");
-        return colonCount == 1 || colonCount == 2;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Issue.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Issue.java
@@ -1,6 +1,7 @@
 package org.jfrog.build.extractor.scan;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
@@ -10,26 +11,21 @@ import java.util.Objects;
 /**
  * @author yahavi
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Issue implements Comparable<Issue> {
 
-    private String created;
-    private String description;
-    private String issueType = "N/A";
-    private String provider;
     private Severity severity = Severity.Normal;
-    private String summary;
-    private String component = "";
     private List<String> fixedVersions;
+    private String component = "";
+    private String description;
+    private String summary;
 
     public Issue() {
     }
 
     @SuppressWarnings("unused")
-    public Issue(String created, String description, String issueType, String provider, Severity severity, String summary, List<String> fixedVersions) {
-        this.created = created;
+    public Issue(String description, Severity severity, String summary, List<String> fixedVersions) {
         this.description = description;
-        this.issueType = issueType;
-        this.provider = provider;
         this.severity = severity;
         this.summary = summary;
         this.fixedVersions = fixedVersions;
@@ -47,23 +43,9 @@ public class Issue implements Comparable<Issue> {
         this.component = component;
     }
 
-    public String getCreated() {
-        return created;
-    }
-
     @SuppressWarnings("unused")
     public String getDescription() {
         return description;
-    }
-
-    @SuppressWarnings("unused")
-    public String getIssueType() {
-        return issueType;
-    }
-
-    @SuppressWarnings("unused")
-    public String getProvider() {
-        return provider;
     }
 
     @SuppressWarnings("unused")

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/License.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/License.java
@@ -1,6 +1,7 @@
 package org.jfrog.build.extractor.scan;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
@@ -10,13 +11,14 @@ import java.util.Objects;
 /**
  * @author yahavi
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class License {
-    private static String UNKNOWN_LICENCE_FULL_NAME = "Unknown license";
+    private static final String UNKNOWN_LICENCE_FULL_NAME = "Unknown license";
     @SuppressWarnings("FieldCanBeLocal")
-    private static String UNKNOWN_LICENCE_NAME = "Unknown";
+    private static final String UNKNOWN_LICENCE_NAME = "Unknown";
     private List<String> components = new ArrayList<>();
-    private String fullName;
-    private String name;
+    private final String fullName;
+    private final String name;
     private List<String> moreInfoUrl = new ArrayList<>();
     private boolean violate;
 
@@ -55,6 +57,7 @@ public class License {
         return violate;
     }
 
+    @SuppressWarnings("unused")
     public void setViolate(boolean violate) {
         this.violate = violate;
     }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
@@ -5,7 +5,10 @@ import org.apache.commons.compress.utils.Sets;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.testng.Assert.*;
 import static org.testng.AssertJUnit.assertEquals;
@@ -182,7 +185,7 @@ public class DependencyTreeTest {
      * @return the random issue
      */
     private Issue createIssue(Severity severity) {
-        return new Issue(generateUID(), generateUID(), generateUID(), generateUID(), severity, generateUID(), Lists.newArrayList());
+        return new Issue(generateUID(), severity, generateUID(), Lists.newArrayList());
     }
 
     /**

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/GeneralInfoTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/GeneralInfoTest.java
@@ -1,0 +1,47 @@
+package org.jfrog.build.extractor.scan;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author yahavi
+ **/
+public class GeneralInfoTest {
+
+    @Test
+    public void testEmptyComponentId() {
+        GeneralInfo generalInfo = new GeneralInfo().componentId("");
+        assertEquals(generalInfo.getComponentId(), "");
+        assertEquals(generalInfo.getGroupId(), "");
+        assertEquals(generalInfo.getArtifactId(), "");
+        assertEquals(generalInfo.getVersion(), "");
+    }
+
+    @Test
+    public void testNoColon() {
+        GeneralInfo generalInfo = new GeneralInfo().componentId("component");
+        assertEquals(generalInfo.getComponentId(), "component");
+        assertEquals(generalInfo.getGroupId(), "");
+        assertEquals(generalInfo.getArtifactId(), "");
+        assertEquals(generalInfo.getVersion(), "");
+    }
+
+    @Test
+    public void testArtifactVersion() {
+        GeneralInfo generalInfo = new GeneralInfo().componentId("artifact:1.2.3");
+        assertEquals(generalInfo.getComponentId(), "artifact:1.2.3");
+        assertEquals(generalInfo.getGroupId(), "");
+        assertEquals(generalInfo.getArtifactId(), "artifact");
+        assertEquals(generalInfo.getVersion(), "1.2.3");
+    }
+
+    @Test
+    public void testGroupArtifactVersion() {
+        GeneralInfo generalInfo = new GeneralInfo().componentId("group:artifact:1.2.3");
+        assertEquals(generalInfo.getComponentId(), "group:artifact:1.2.3");
+        assertEquals(generalInfo.getGroupId(), "group");
+        assertEquals(generalInfo.getArtifactId(), "artifact");
+        assertEquals(generalInfo.getVersion(), "1.2.3");
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

The following variables exist for every dependency tree node and can be removed to reduce RAM consumption:
* name
* groupId
* artifactId
* version

The following variables exist for every issue and can be removed to reduce RAM consumption:
* created
* issueType
* provider

Finally, all empty fields in `GeneralInfo`, `Issue`, and `License` will be ignored when saving to the file system.