### PR TITLE
Deprecate 'artifactory.' property prefix.

### DIFF
--- a/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.deployer
+++ b/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.deployer
@@ -1,10 +1,10 @@
 # Deployer settings
-artifactory.publish.publications=${publications}
-artifactory.publish.contextUrl=${contextUrl}
-artifactory.publish.repoKey=${localRepo}
-artifactory.publish.username=${username}
-artifactory.publish.password=${password}
-artifactory.publish.unstable=false
-artifactory.publish.buildInfo=true
-artifactory.publish.maven=true
-artifactory.publish.ivy=true
+publish.publications=${publications}
+publish.contextUrl=${contextUrl}
+publish.repoKey=${localRepo}
+publish.username=${username}
+publish.password=${password}
+publish.unstable=false
+publish.buildInfo=true
+publish.maven=true
+publish.ivy=true

--- a/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.resolver
+++ b/build-info-extractor-gradle/src/test/resources/integration/buildinfo.properties.resolver
@@ -1,5 +1,5 @@
 # Resolver settings
-artifactory.resolve.contextUrl=${contextUrl}
-artifactory.resolve.repoKey=${virtualRepo}
-artifactory.resolve.username=${username}
-artifactory.resolve.password=${password}
+resolve.contextUrl=${contextUrl}
+resolve.repoKey=${virtualRepo}
+resolve.username=${username}
+resolve.password=${password}

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
@@ -43,11 +43,6 @@ public class BuildDeploymentHelper {
         logger.debug("Build Info Recorder: publication fork count: " + clientConf.publisher.getPublishForkCount());
         logger.debug("Build Info Recorder: publish build info: " + clientConf.publisher.isPublishBuildInfo());
 
-
-        if (clientConf.publisher.isPublishBuildInfo() || StringUtils.isNotBlank(clientConf.info.getGeneratedBuildInfoFilePath())) {
-            saveBuildInfoToFile(buildInfo, clientConf, basedir);
-        }
-
         if (!StringUtils.isEmpty(clientConf.info.getGeneratedBuildInfoFilePath())) {
             try {
                 BuildInfoExtractorUtils.saveBuildInfoToFile(buildInfo, new File(clientConf.info.getGeneratedBuildInfoFilePath()));

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -525,7 +525,9 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             if (artifactFile != null && artifactFile.isFile()) {
                 boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                 addArtifactToBuildInfo(artifact, pathConflicts, excludeArtifactsFromBuild, module);
-                addDeployableArtifact(artifact, artifactFile, pathConflicts, groupId, artifactId, artifactVersion, artifactClassifier, artifactExtension);
+                if (conf.publisher.isPublishArtifacts()) {
+                    addDeployableArtifact(artifact, artifactFile, pathConflicts, groupId, artifactId, artifactVersion, artifactClassifier, artifactExtension);
+                }
             }
         }
         /*
@@ -556,7 +558,9 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
                 if (pomFile != null && pomFile.isFile()) {
                     boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                     addArtifactToBuildInfo(pomArtifact, pathConflicts, excludeArtifactsFromBuild, module);
-                    addDeployableArtifact(pomArtifact, pomFile, pathConflicts, nonPomArtifact.getGroupId(), nonPomArtifact.getArtifactId(), nonPomArtifact.getVersion(), nonPomArtifact.getClassifier(), "pom");
+                    if (conf.publisher.isPublishArtifacts()) {
+                        addDeployableArtifact(pomArtifact, pomFile, pathConflicts, nonPomArtifact.getGroupId(), nonPomArtifact.getArtifactId(), nonPomArtifact.getVersion(), nonPomArtifact.getClassifier(), "pom");
+                    }
                 }
                 break;
             }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -396,6 +396,11 @@ public class ArtifactoryClientConfiguration {
             return getPrefix() + MATRIX;
         }
 
+        @Override
+        public String getDeprecatedMatrixParamPrefix() {
+            return getDeprecatedPrefix() + MATRIX;
+        }
+
         public String getDownloadSnapshotRepoKey() {
             return getStringValue(DOWN_SNAPSHOT_REPO_KEY);
         }
@@ -515,6 +520,11 @@ public class ArtifactoryClientConfiguration {
         @Override
         public String getMatrixParamPrefix() {
             return PROP_DEPLOY_PARAM_PROP_PREFIX;
+        }
+
+        @Override
+        public String getDeprecatedMatrixParamPrefix() {
+            return DEPRECATED_PROP_DEPLOY_PARAM_PROP_PREFIX;
         }
 
         public ArtifactSpecs getArtifactSpecs() {
@@ -858,6 +868,8 @@ public class ArtifactoryClientConfiguration {
 
         public abstract String getMatrixParamPrefix();
 
+        public abstract String getDeprecatedMatrixParamPrefix();
+
         public abstract String getContextUrl();
 
         public void setMatrixParam(String key, String value) {
@@ -910,15 +922,22 @@ public class ArtifactoryClientConfiguration {
             if (calculatedMatrixParams != null) {
                 return calculatedMatrixParams;
             }
+            Map<String, String> result = resolveMatrixParams(getMatrixParamPrefix());
+            if (result.size() == 0) {
+                result = resolveMatrixParams(getDeprecatedMatrixParamPrefix());
+            }
+            this.calculatedMatrixParams = ImmutableMap.copyOf(result);
+            return calculatedMatrixParams;
+        }
+
+        private Map<String, String> resolveMatrixParams(String matrixPrefix) {
             Map<String, String> result = new HashMap<>();
-            String matrixPrefix = getMatrixParamPrefix();
             for (Map.Entry<String, String> entry : props.entrySet()) {
                 if (entry.getKey().startsWith(matrixPrefix)) {
                     result.put(entry.getKey().substring(matrixPrefix.length()), entry.getValue());
                 }
             }
-            this.calculatedMatrixParams = ImmutableMap.copyOf(result);
-            return calculatedMatrixParams;
+            return result;
         }
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -922,15 +922,15 @@ public class ArtifactoryClientConfiguration {
             if (calculatedMatrixParams != null) {
                 return calculatedMatrixParams;
             }
-            Map<String, String> result = resolveMatrixParams(getMatrixParamPrefix());
+            Map<String, String> result = getResolveMatrixParams(getMatrixParamPrefix());
             if (result.size() == 0) {
-                result = resolveMatrixParams(getDeprecatedMatrixParamPrefix());
+                result = getResolveMatrixParams(getDeprecatedMatrixParamPrefix());
             }
             this.calculatedMatrixParams = ImmutableMap.copyOf(result);
             return calculatedMatrixParams;
         }
 
-        private Map<String, String> resolveMatrixParams(String matrixPrefix) {
+        private Map<String, String> getResolveMatrixParams(String matrixPrefix) {
             Map<String, String> result = new HashMap<>();
             for (Map.Entry<String, String> entry : props.entrySet()) {
                 if (entry.getKey().startsWith(matrixPrefix)) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientProperties.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientProperties.java
@@ -4,7 +4,55 @@ package org.jfrog.build.extractor.clientConfiguration;
  * @author Tomer Cohen
  */
 public interface ClientProperties {
-    String ARTIFACTORY_PREFIX = "artifactory.";
+
+    String PROP_CONTEXT_URL = "contextUrl";
+
+    String PROP_CONNECTION_RETRIES = "connectionRetries";
+
+    String PROP_TIMEOUT = "timeout";
+
+    String PROP_SO_TIMEOUT = "timeout.socket";
+
+    String PROP_MAX_CO_PER_ROUTE = "maxConPerRoute";
+
+    String PROP_MAX_TOTAL_CO = "maxTotalCon";
+
+    String PROP_PROXY_PREFIX = "proxy.";
+
+    String PROP_PACKAGE_MANAGER_PREFIX = "package.manager.";
+
+    String PROP_NPM_PREFIX = "npm.";
+
+    String PROP_PIP_PREFIX = "pip.";
+
+    String PROP_DOTNET_PREFIX = "dotnet.";
+
+    String PROP_DOCKER_PREFIX = "docker.";
+
+    String PROP_KANIKO_PREFIX = "kaniko.";
+
+    String PROP_GO_PREFIX = "go.";
+
+    /**
+     * The repo key in Artifactory from where to resolve artifacts.
+     */
+    String PROP_RESOLVE_PREFIX = "resolve.";
+
+    /**
+     * The repo key in Artifactory to where to publish release artifacts.
+     */
+    String PROP_PUBLISH_PREFIX = "publish.";
+
+    /**
+     * Property for whether to publish the artifacts even if the build is unstable
+     */
+    String PROP_PUBLISH_EVEN_UNSTABLE = "publish.unstable";
+
+
+    /**
+     * Prefix for properties that are dynamically added to deployment (as matrix params)
+     */
+    String PROP_DEPLOY_PARAM_PROP_PREFIX = "deploy.";
 
     /**
      * The URL of the artifactory web application (typically ending with '/artifactory')
@@ -13,57 +61,11 @@ public interface ClientProperties {
      * top level property.
      */
     @Deprecated
-    String PROP_CONTEXT_URL = ARTIFACTORY_PREFIX + "contextUrl";
-
-    String PROP_CONNECTION_RETRIES = ARTIFACTORY_PREFIX + "connectionRetries";
-
-    String PROP_TIMEOUT = ARTIFACTORY_PREFIX + "timeout";
-
-    String PROP_SO_TIMEOUT = ARTIFACTORY_PREFIX + "timeout.socket";
-
-    String PROP_MAX_CO_PER_ROUTE = ARTIFACTORY_PREFIX + "maxConPerRoute";
-
-    String PROP_MAX_TOTAL_CO = ARTIFACTORY_PREFIX + "maxTotalCon";
-
-    String PROP_PROXY_PREFIX = ARTIFACTORY_PREFIX + "proxy.";
-
-    String PROP_PACKAGE_MANAGER_PREFIX = ARTIFACTORY_PREFIX + "package.manager.";
-
-    String PROP_NPM_PREFIX = ARTIFACTORY_PREFIX + "npm.";
-
-    String PROP_PIP_PREFIX = ARTIFACTORY_PREFIX + "pip.";
-
-    String PROP_DOTNET_PREFIX = ARTIFACTORY_PREFIX + "dotnet.";
-
-    String PROP_DOCKER_PREFIX = ARTIFACTORY_PREFIX + "docker.";
-
-    String PROP_KANIKO_PREFIX = ARTIFACTORY_PREFIX + "kaniko.";
-
-    String PROP_GO_PREFIX = ARTIFACTORY_PREFIX + "go.";
-
-    /**
-     * The repo key in Artifactory from where to resolve artifacts.
-     */
-    String PROP_RESOLVE_PREFIX = ARTIFACTORY_PREFIX + "resolve.";
-
-    /**
-     * The repo key in Artifactory to where to publish release artifacts.
-     */
-    String PROP_PUBLISH_PREFIX = ARTIFACTORY_PREFIX + "publish.";
-
-    /**
-     * Property for whether to publish the artifacts even if the build is unstable
-     */
-    String PROP_PUBLISH_EVEN_UNSTABLE = ARTIFACTORY_PREFIX + "publish.unstable";
-
-
-    /**
-     * Prefix for properties that are dynamically added to deployment (as matrix params)
-     */
-    String PROP_DEPLOY_PARAM_PROP_PREFIX = ARTIFACTORY_PREFIX + "deploy.";
+    String ARTIFACTORY_PREFIX = "artifactory.";
+    String DEPRECATED_PROP_DEPLOY_PARAM_PROP_PREFIX = ARTIFACTORY_PREFIX + "deploy.";
 
     /**
      * Property for whether to use relaxed ssl check and ignore issues with server certificate
      */
-    String PROP_INSECURE_TLS = ARTIFACTORY_PREFIX + "insecureTls";
+    String PROP_INSECURE_TLS = "insecureTls";
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
@@ -5,9 +5,11 @@ import org.jfrog.build.api.util.Log;
 
 import java.util.Map;
 
+import static org.jfrog.build.extractor.clientConfiguration.ClientProperties.ARTIFACTORY_PREFIX;
+
 /**
  * @author freds
- *         Date: 1/6/11
+ * Date: 1/6/11
  */
 public class PrefixPropertyHandler {
     protected final Map<String, String> props;
@@ -36,16 +38,25 @@ public class PrefixPropertyHandler {
         return prefix;
     }
 
+    public String getDeprecatedPrefix() {
+        return ARTIFACTORY_PREFIX + prefix;
+    }
+
     public String getStringValue(String key) {
         return getStringValue(key, null);
     }
 
     public String getStringValue(String key, String def) {
-        String s = props.get(prefix + key);
-        if (s == null) {
-            s = def;
+        String value = props.get(prefix + key);
+        if (StringUtils.isNotBlank(value)) {
+            return value;
         }
-        return s;
+        value = props.get(ARTIFACTORY_PREFIX + prefix + key);
+        if (StringUtils.isNotBlank(value)) {
+            return value;
+        }
+
+        return def;
     }
 
     public void setStringValue(String key, String value) {
@@ -57,13 +68,18 @@ public class PrefixPropertyHandler {
     }
 
     public Boolean getBooleanValue(String key, Boolean def) {
-        String s = props.get(prefix + key);
+        String value = props.get(prefix + key);
         // TODO: throw exception if not true or false. If prop set to something else
-        Boolean result = (s == null) ? null : Boolean.parseBoolean(s);
-        if (result == null) {
-            result = def;
+        Boolean result = (value == null) ? null : Boolean.parseBoolean(value);
+        if (result != null) {
+            return result;
         }
-        return result;
+        value = props.get(ARTIFACTORY_PREFIX + prefix + key);
+        result = (value == null) ? null : Boolean.parseBoolean(value);
+        if (result != null) {
+            return result;
+        }
+        return def;
     }
 
     public void setBooleanValue(String key, Boolean value) {
@@ -79,16 +95,25 @@ public class PrefixPropertyHandler {
     }
 
     public Integer getIntegerValue(String key, Integer def) {
+        Integer result = getInteger(key, prefix);
+        if (result != null) {
+            return result;
+        }
+        result = getInteger(key, ARTIFACTORY_PREFIX + prefix);
+        if (result != null) {
+            return result;
+        }
+        return def;
+    }
+
+    private Integer getInteger(String key, String targetPrefix) {
         Integer result;
-        String s = props.get(prefix + key);
+        String s = props.get(targetPrefix + key);
         if (s != null && !StringUtils.isNumeric(s)) {
-            log.debug("Property '" + prefix + key + "' is not of numeric value '" + s + "'");
+            log.debug("Property '" + targetPrefix + key + "' is not of numeric value '" + s + "'");
             result = null;
         } else {
             result = (s == null) ? null : Integer.parseInt(s);
-        }
-        if (result == null) {
-            result = def;
         }
         return result;
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
@@ -51,6 +51,8 @@ public class PrefixPropertyHandler {
         if (StringUtils.isNotBlank(value)) {
             return value;
         }
+        // Fallback, try to get value with deprecated key.
+        // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
         value = props.get(ARTIFACTORY_PREFIX + prefix + key);
         if (StringUtils.isNotBlank(value)) {
             return value;
@@ -74,6 +76,8 @@ public class PrefixPropertyHandler {
         if (result != null) {
             return result;
         }
+        // Fallback, try to get value with deprecated key.
+        // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
         value = props.get(ARTIFACTORY_PREFIX + prefix + key);
         result = (value == null) ? null : Boolean.parseBoolean(value);
         if (result != null) {
@@ -99,6 +103,8 @@ public class PrefixPropertyHandler {
         if (result != null) {
             return result;
         }
+        // Fallback, try to get value with deprecated key.
+        // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
         result = getInteger(key, ARTIFACTORY_PREFIX + prefix);
         if (result != null) {
             return result;

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/client/DeploymentUrlUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/client/DeploymentUrlUtilsTest.java
@@ -21,7 +21,7 @@ public class DeploymentUrlUtilsTest {
         props.put(ClientProperties.PROP_DEPLOY_PARAM_PROP_PREFIX + "buildName", "moo");
         props.put(ClientProperties.PROP_DEPLOY_PARAM_PROP_PREFIX + "buildNumber", "1");
         String deploymentUrl = DeploymentUrlUtils.getDeploymentUrl(artifactoryUrl, props);
-        Assert.assertEquals(deploymentUrl, artifactoryUrl + ";buildName=moo;buildNumber=1");
+        Assert.assertEquals(deploymentUrl, artifactoryUrl + ";buildNumber=1;buildName=moo");
     }
 
     public void getDeploymentUrlWithEncodingNeeded() throws UnsupportedEncodingException {
@@ -30,7 +30,7 @@ public class DeploymentUrlUtilsTest {
         props.put(ClientProperties.PROP_DEPLOY_PARAM_PROP_PREFIX + "build Name", "moo");
         props.put(ClientProperties.PROP_DEPLOY_PARAM_PROP_PREFIX + "build Number", "1");
         String deploymentUrl = DeploymentUrlUtils.getDeploymentUrl(artifactoryUrl, props);
-        Assert.assertEquals(deploymentUrl, artifactoryUrl + ";build+Number=1;build+Name=moo");
+        Assert.assertEquals(deploymentUrl, artifactoryUrl + ";build+Name=moo;build+Number=1");
     }
 
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
This PR includes a backward-compatible for older versions, which uses the deprecated property.
Related PR:
* https://github.com/jfrog/jenkins-artifactory-plugin/pull/578