### PR TITLE
Improve CI scripts

### DIFF
--- a/release/pipelines.release.yml
+++ b/release/pipelines.release.yml
@@ -48,9 +48,10 @@ pipelines:
             - test -n "$NEXT_GRADLE_DEVELOPMENT_VERSION" -a "$NEXT_GRADLE_DEVELOPMENT_VERSION" != "0.0.0"
 
             # Configure JFrog CLI
-            - curl -fL https://getcli.jfrog.io | bash -s v2 && chmod +x jfrog
-            - ./jfrog c add internal --url=$int_entplus_deployer_url --user=$int_entplus_deployer_user --password=$int_entplus_deployer_apikey
-            - ./jfrog gradlec --use-wrapper --uses-plugin --repo-resolve jcenter --repo-deploy oss-release-local
+            - curl -fL https://getcli.jfrog.io/v2-jf | sh && chmod +x jfrog
+            - ./jf c rm --quiet
+            - ./jf c add internal --url=$int_entplus_deployer_url --user=$int_entplus_deployer_user --password=$int_entplus_deployer_apikey
+            - ./jf gradlec --use-wrapper --uses-plugin --repo-resolve jcenter --repo-deploy oss-release-local
 
             # Update version
             - sed -i -e "/build-info-version=/ s/=.*/=$NEXT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_VERSION/" gradle.properties
@@ -64,14 +65,14 @@ pipelines:
             - >
               ORG_GRADLE_PROJECT_signingKey=$(echo $int_mvn_central_signingKey | base64 -d)
               ORG_GRADLE_PROJECT_signingPassword=$int_mvn_central_signingPassword
-              ./jfrog gradle clean aP -x test -Psign
-              - ./jfrog rt bag && ./jfrog rt bce
-              - ./jfrog rt bp
-            # - ./jfrog rt bs
+              ./jf gradle clean aP -x test -Psign
+            - ./jf rt bag && ./jf rt bce
+            - ./jf rt bp
+            - ./jf rt bs --fail=false
 
             # Distribute release bundle
-            - ./jfrog ds rbc build-info $NEXT_VERSION --spec=./ci/distribution/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION" --sign
-            - ./jfrog ds rbd build-info $NEXT_VERSION --site="releases.jfrog.io"
+            - ./jf ds rbc build-info $NEXT_VERSION --spec=./ci/distribution/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION" --sign
+            - ./jf ds rbd build-info $NEXT_VERSION --site="releases.jfrog.io"
 
             # Publish to Maven Central
             - >

--- a/release/pipelines.snapshot.yml
+++ b/release/pipelines.snapshot.yml
@@ -36,9 +36,10 @@ pipelines:
             - export JFROG_CLI_BUILD_PROJECT=ecosys
 
             # Configure JFrog CLI
-            - curl -fL https://getcli.jfrog.io | bash -s v2 && chmod +x jfrog
-            - ./jfrog c add internal --url=$int_entplus_deployer_url --user=$int_entplus_deployer_user --password=$int_entplus_deployer_apikey
-            - ./jfrog gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-snapshot-local
+            - curl -fL https://getcli.jfrog.io/v2-jf | sh && chmod +x jfrog
+            - ./jf c rm --quiet
+            - ./jf c add internal --url=$int_entplus_deployer_url --user=$int_entplus_deployer_user --password=$int_entplus_deployer_apikey
+            - ./jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-snapshot-local
 
             # Run install and publish
             - >
@@ -46,14 +47,14 @@ pipelines:
               JFROG_CLI_BUILD_NAME=$JFROG_CLI_BUILD_NAME
               JFROG_CLI_BUILD_NUMBER=$JFROG_CLI_BUILD_NUMBER
               JFROG_CLI_BUILD_PROJECT=$JFROG_CLI_BUILD_PROJECT
-              ./jfrog gradle clean aP -x test
-            - ./jfrog rt bag && ./jfrog rt bce
-            - ./jfrog rt bp
-            # - ./jfrog rt bs
+              ./jf gradle clean aP -x test
+            - ./jf rt bag && ./jf rt bce
+            - ./jf rt bp
+            - ./jf rt bs --fail=false
 
             # Distribute release bundle
-            - ./jfrog ds rbc build-info-snapshot $run_number --spec=./release/specs/dev-rbc-filespec.json --spec-vars="version=$run_number" --sign
-            - ./jfrog ds rbd build-info-snapshot $run_number --site="releases.jfrog.io"
+            - ./jf ds rbc build-info-snapshot $run_number --spec=./release/specs/dev-rbc-filespec.json --spec-vars="version=$run_number" --sign
+            - ./jf ds rbd build-info-snapshot $run_number --site="releases.jfrog.io"
 
           onComplete:
             - *UPDATE_COMMIT_STATUS


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

* `jfrog` -> `jf`
* Enable build scan
* Delete entplus_deployer server after downloading jfrog cli