### PR TITLE
Fix Gradle tests

### DIFF
--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -176,7 +176,7 @@ public class Utils {
                 assertNotNull(requestedBy);
                 assertEquals(requestedBy.length, 1);
                 assertEquals(requestedBy[0].length, 2);
-                assertEquals(requestedBy[0][0], "commons-lang:commons-lang:2.4");
+                assertEquals(requestedBy[0][0], "org.apache.commons:commons-lang3:3.12.0");
                 assertEquals(requestedBy[0][1], "org.jfrog.test.gradle.publish:api:1.0-SNAPSHOT");
             }
         }

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server/api/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server/api/build.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     implementation project(':shared')
-    implementation module("commons-lang:commons-lang:2.4") {
+    implementation module("org.apache.commons:commons-lang3:3.12.0") {
         dependency("commons-io:commons-io:1.2")
     }
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server/services/webservice/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server/services/webservice/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'war'
 
 dependencies {
-    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'org.apache.commons:commons-lang3:3.12.0@jar'
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
     implementation project(':api')
 }

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-publish/api/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-publish/api/build.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     implementation project(':shared')
-    implementation module("commons-lang:commons-lang:2.4") {
+    implementation module("org.apache.commons:commons-lang3:3.12.0") {
         dependency("commons-io:commons-io:1.2")
     }
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-publish/services/webservice/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-publish/services/webservice/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'war'
 
 dependencies {
-    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'org.apache.commons:commons-lang3:3.12.0@jar'
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
     implementation project(':api')
 }

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example/api/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example/api/build.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     implementation project(':shared')
-    implementation module("commons-lang:commons-lang:2.4") {
+    implementation module("org.apache.commons:commons-lang3:3.12.0") {
         dependency("commons-io:commons-io:1.2")
     }
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example/services/webservice/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example/services/webservice/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'org.apache.commons:commons-lang3:3.12.0@jar'
     implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
     implementation project(':api')
 }

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-kts-example-publish/api/build.gradle.kts
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-kts-example-publish/api/build.gradle.kts
@@ -2,7 +2,7 @@ val spi: Configuration by configurations.creating
 
 dependencies {
     implementation(project(":shared"))
-    implementation("commons-lang:commons-lang:2.4")
+    implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("commons-io:commons-io:1.2")
     implementation("org.apache.wicket", "wicket", "1.3.7")
 

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-kts-example-publish/services/webservice/build.gradle.kts
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-kts-example-publish/services/webservice/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     implementation(project(":shared"))
     implementation("commons-collections:commons-collections:3.2@jar")
     implementation("commons-io:commons-io:1.2")
-    implementation("commons-lang:commons-lang:2.4@jar")
+    implementation("org.apache.commons:commons-lang3:3.12.0@jar")
     implementation("org.apache.wicket", "wicket", "1.3.7")
     implementation(project(":api"))
 }

--- a/build-info-parent/pom.xml
+++ b/build-info-parent/pom.xml
@@ -53,9 +53,9 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.4</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Followup https://github.com/jfrog/build-info/pull/580

Currently, the Gradle tests are failing since they use commons-lang:2.4. 
Complete the migration from 2.4 to 3.12.