### PR TITLE
Replace !isEmpty with isNotBlank

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerJavaWrapper.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerJavaWrapper.java
@@ -62,7 +62,7 @@ public class DockerJavaWrapper {
         } else {
             // If open JDK is used and the host is null
             // then instead of a null reference, the host is the string "null".
-            if (!StringUtils.isEmpty(host) && !host.equalsIgnoreCase("null")) {
+            if (StringUtils.isNotBlank(host) && !host.equalsIgnoreCase("null")) {
                 configBuilder.withDockerHost(host);
             }
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
As a result of, https://github.com/jfrog/build-info/pull/580 changes the method `isEmpty` has changed in Lang version 2.0. and It is no longer trims the String.
That functionality is available in isBlank().