### PR TITLE
Bugfix - Add repository to artifacts' path

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
@@ -114,7 +114,7 @@ public class SpecsHelper {
                     .sha1(detail.getSha1())
                     .type(ext)
                     .localPath(detail.getFile().getAbsolutePath())
-                    .remotePath(detail.getArtifactPath())
+                    .remotePath(detail.getTargetRepository() + "/" +detail.getArtifactPath())
                     .build();
             result.add(artifactBuilder.build());
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Module's artifact is missing the repository name in the 'path' property.