### PR TITLE
Bugfix - Gradle defaults props should not ignore deprecated build-inf…

### DIFF
--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Consts.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Consts.java
@@ -30,12 +30,15 @@ public class Consts {
     static final Path GRADLE_EXAMPLE_PUBLISH = PROJECTS_ROOT.resolve("gradle-example-publish");
     static final Path GRADLE_KTS_EXAMPLE_PUBLISH = PROJECTS_ROOT.resolve("gradle-kts-example-publish");
     static final Path GRADLE_EXAMPLE_CI_SERVER = PROJECTS_ROOT.resolve("gradle-example-ci-server");
+    static final Path DEPRECATED_GRADLE_EXAMPLE_CI_SERVER = PROJECTS_ROOT.resolve("gradle-example-ci-server-deprecated");
 
     // CI example paths
     static final Path LIBS_DIR = GRADLE_EXTRACTOR.resolve(Paths.get("build", "libs"));
     static final Path INIT_SCRIPT = GRADLE_EXTRACTOR_SRC.resolve(Paths.get("main", "resources", "initscripttemplate.gradle"));
     static final Path BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER = PROJECTS_ROOT.resolve("buildinfo.properties.deployer");
     static final Path BUILD_INFO_PROPERTIES_SOURCE_RESOLVER = PROJECTS_ROOT.resolve("buildinfo.properties.resolver");
+    static final Path DEPRECATED_BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER = PROJECTS_ROOT.resolve("deprecated.buildinfo.properties.deployer");
+    static final Path DEPRECATED_BUILD_INFO_PROPERTIES_SOURCE_RESOLVER = PROJECTS_ROOT.resolve("deprecated.buildinfo.properties.resolver");
     static final Path BUILD_INFO_PROPERTIES_TARGET = TEST_DIR.toPath().resolve("buildinfo.properties");
 
     // Expected artifacts

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
@@ -110,6 +110,11 @@ public class GradlePluginTest extends IntegrationTestsBase {
         cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
     }
 
+    /**
+     * Gradle extractor may be run by CI servers such as Jenkins. Before the CI server runs the Gradle extractor in order to build the Gradle project,
+     * it generated build-info properties file that contains Gradle extractor's configurations. those generated properties could be deprecated but the Gradle extractor could be the latest version (according to the build.gradle).
+     * This test checks that the deprecated build-info properties are being handled correctly
+     */
     @Test(dataProvider = "gradleVersions")
     public void deprecatedCiServerTest(String gradleVersion) throws IOException {
         // Create test environment

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/GradlePluginTest.java
@@ -97,7 +97,7 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void ciServerTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "", true, true);
+        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "", true, true, BUILD_INFO_PROPERTIES_SOURCE_RESOLVER, BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
@@ -111,10 +111,28 @@ public class GradlePluginTest extends IntegrationTestsBase {
     }
 
     @Test(dataProvider = "gradleVersions")
+    public void deprecatedCiServerTest(String gradleVersion) throws IOException {
+        // Create test environment
+        createTestDir(DEPRECATED_GRADLE_EXAMPLE_CI_SERVER);
+        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "", true, true, DEPRECATED_BUILD_INFO_PROPERTIES_SOURCE_RESOLVER, DEPRECATED_BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
+        Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
+            put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
+        }};
+        // Run Gradle
+        BuildResult buildResult = runGradle(gradleVersion, extendedEnv, true);
+        // Check results
+        // Assert all tasks ended with success outcome
+        assertProjectsSuccess(buildResult);
+        // Cleanup
+        Pair<String, String> buildDetails = getBuildDetails(buildResult);
+        cleanTestBuilds(buildDetails.getLeft(), buildDetails.getRight(), null);
+    }
+
+    @Test(dataProvider = "gradleVersions")
     public void ciServerPublicationsTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", true, true);
+        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", true, true, BUILD_INFO_PROPERTIES_SOURCE_RESOLVER, BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
@@ -131,7 +149,7 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void requestedByTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", false, true);
+        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "mavenJava,customIvyPublication", false, true, BUILD_INFO_PROPERTIES_SOURCE_RESOLVER, BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};
@@ -148,7 +166,7 @@ public class GradlePluginTest extends IntegrationTestsBase {
     public void ciServerResolverOnlyTest(String gradleVersion) throws IOException {
         // Create test environment
         createTestDir(GRADLE_EXAMPLE_CI_SERVER);
-        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "", false, false);
+        generateBuildInfoProperties(getArtifactoryUrl(), getUsername(), getAdminToken(), localRepo1, virtualRepo, "", false, false, BUILD_INFO_PROPERTIES_SOURCE_RESOLVER, BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
         Map<String, String> extendedEnv = new HashMap<String, String>(envVars) {{
             put(BuildInfoConfigProperties.PROP_PROPS_FILE, BUILD_INFO_PROPERTIES_TARGET.toString());
         }};

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -89,11 +89,11 @@ public class Utils {
      * @param setDeployer      - Set deployer details in file
      * @throws IOException - In case of any IO error
      */
-    static void generateBuildInfoProperties(String contextUrl, String username, String password, String localRepo, String virtualRepo, String publications, boolean publishBuildInfo, boolean setDeployer) throws IOException {
-        String content = generateBuildInfoPropertiesForServer(contextUrl, username, password, localRepo, virtualRepo, publications, publishBuildInfo, BUILD_INFO_PROPERTIES_SOURCE_RESOLVER);
+    static void generateBuildInfoProperties(String contextUrl, String username, String password, String localRepo, String virtualRepo, String publications, boolean publishBuildInfo, boolean setDeployer,Path buildInfoPropertiesSourceResolver,Path buildInfoPropertiesSourceDeployer) throws IOException {
+        String content = generateBuildInfoPropertiesForServer(contextUrl, username, password, localRepo, virtualRepo, publications, publishBuildInfo, buildInfoPropertiesSourceResolver);
         if (setDeployer) {
             content += "\n";
-            content += generateBuildInfoPropertiesForServer(contextUrl, username, password, localRepo, virtualRepo, publications, publishBuildInfo, BUILD_INFO_PROPERTIES_SOURCE_DEPLOYER);
+            content += generateBuildInfoPropertiesForServer(contextUrl, username, password, localRepo, virtualRepo, publications, publishBuildInfo, buildInfoPropertiesSourceDeployer);
         }
         Files.write(BUILD_INFO_PROPERTIES_TARGET, content.getBytes(StandardCharsets.UTF_8));
     }

--- a/build-info-extractor-gradle/src/test/resources/integration/deprecated.buildinfo.properties.deployer
+++ b/build-info-extractor-gradle/src/test/resources/integration/deprecated.buildinfo.properties.deployer
@@ -1,0 +1,10 @@
+# Deployer settings
+artifactory.publish.publications=${publications}
+artifactory.publish.contextUrl=${contextUrl}
+artifactory.publish.repoKey=${localRepo}
+artifactory.publish.username=${username}
+artifactory.publish.password=${password}
+artifactory.publish.unstable=false
+artifactory.publish.buildInfo=true
+artifactory.publish.maven=true
+artifactory.publish.ivy=true

--- a/build-info-extractor-gradle/src/test/resources/integration/deprecated.buildinfo.properties.resolver
+++ b/build-info-extractor-gradle/src/test/resources/integration/deprecated.buildinfo.properties.resolver
@@ -1,0 +1,5 @@
+# Resolver settings
+artifactory.resolve.contextUrl=${contextUrl}
+artifactory.resolve.repoKey=${virtualRepo}
+artifactory.resolve.username=${username}
+artifactory.resolve.password=${password}

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/build.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/build.gradle
@@ -1,0 +1,91 @@
+def javaProjects() {
+  subprojects.findAll { new File(it.projectDir, 'src').directory }
+}
+
+allprojects {
+  group = 'org.jfrog.test.gradle.publish'
+  version = currentVersion
+  status = 'Integration'
+  repositories {
+    maven {
+      url "${System.env.BITESTS_PLATFORM_URL}/artifactory/${System.env.BITESTS_ARTIFACTORY_VIRTUAL_REPO}"
+      credentials {
+        username "${System.env.BITESTS_PLATFORM_USERNAME}"
+        password "${System.env.BITESTS_PLATFORM_ADMIN_TOKEN}"
+      }
+    }
+  }
+}
+
+artifactoryPublish.skip = true
+
+project('services') {
+  artifactoryPublish.skip = true
+}
+
+subprojects {
+  apply plugin: 'java'
+  apply plugin: 'maven'
+
+  manifest {
+    attributes 'provider': 'gradle'
+  }
+  configurations {
+    published
+  }
+  dependencies {
+    testImplementation 'junit:junit:4.7'
+  }
+  artifacts {
+    published file("$rootDir/gradle.properties")
+  }
+}
+
+configurations {
+  published
+}
+
+artifactory {
+  clientConfig.setIncludeEnvVars(true)
+  clientConfig.info.addEnvironmentProperty('test.adding.dynVar', new java.util.Date().toString())
+
+  contextUrl = "JENKINS_OVERRIDES_THIS_FIELD"
+  publish {
+    repository {
+      repoKey = "JENKINS_OVERRIDES_THIS_FIELD" // The Artifactory repository key to publish to
+      username = "JENKINS_OVERRIDES_THIS_FIELD" // The publisher user name
+      password = "JENKINS_OVERRIDES_THIS_FIELD" // The publisher password
+      // This is an optional section for configuring Ivy publication (when publishIvy = true).
+      ivy {
+        ivyLayout = '[organization]/[module]/ivy-[revision].xml'
+        artifactLayout = '[organization]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]'
+        mavenCompatible = true
+        //Convert any dots in an [organization] layout value to path separators, similar to Maven's groupId-to-path conversion. True if not specified
+      }
+    }
+    defaults {
+      // Reference to Gradle configurations defined in the build script.
+      // This is how we tell the Artifactory Plugin which artifacts should be
+      // published to Artifactory.
+      publishConfigs('archives', 'published')
+      // Properties to be attached to the published artifacts.
+      properties = ['qa.level': 'basic', 'dev.team': 'core']
+      // You can also attach properties to published artifacts according to
+      // the following notation:
+      // <configuration name> <artifact spec>
+      // The <configuration name> should be the name of the relevant Gradle Configuration or 'all'
+      // (for all configurations).
+      // Artifact spec has the following structure:
+      // group:artifact:version:classifier@ext
+      // Any element in the artifact spec notation can contain the * and ? wildcards.
+      // For example:
+      // org.acme:*:1.0.?_*:*@tgz
+      properties {
+        all '*:*:1.*:*@*', key1: 'val1', key2: 'val2'
+        all 'org.jfrog.*:*:1.*:*@jar*', key3: 'val3', key4: 'val4'
+      }
+      publishPom = true // Publish generated POM files to Artifactory (true by default)
+      publishIvy = true // Publish generated Ivy descriptor files to Artifactory (true by default)
+    }
+  }
+}

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/gradle.properties
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/gradle.properties
@@ -1,0 +1,1 @@
+currentVersion=1.0-SNAPSHOT

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/settings.gradle
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/settings.gradle
@@ -1,0 +1,1 @@
+include "shared", "api", "services:webservice"

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/shared/src/main/java/org/gradle/shared/Person.java
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/shared/src/main/java/org/gradle/shared/Person.java
@@ -1,0 +1,26 @@
+package org.gradle.shared;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class Person {
+    private String name;
+
+    public Person(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String readProperty() throws IOException {
+        Properties properties = new Properties();
+        properties.load(getClass().getClassLoader().getResourceAsStream("org/gradle/shared/main.properties"));
+        return properties.getProperty("main");
+    }
+}

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/shared/src/main/java/org/gradle/shared/package-info.java
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/shared/src/main/java/org/gradle/shared/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * These are the shared classes.
+ */
+package org.gradle.shared;

--- a/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/shared/src/main/resources/org/gradle/shared/main.properties
+++ b/build-info-extractor-gradle/src/test/resources/integration/gradle-example-ci-server-deprecated/shared/src/main/resources/org/gradle/shared/main.properties
@@ -1,0 +1,1 @@
+main=mainValue

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -923,15 +923,11 @@ public class ArtifactoryClientConfiguration {
             if (calculatedMatrixParams != null) {
                 return calculatedMatrixParams;
             }
-            // Try to get value using the deprecated key.
-            // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
-            // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
-            // in that case, we must honor the deprecated keys first.
-            //
-            // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
-            // those will override gradle defaults.
+            // First, get value using deprecated key.
+            // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
             Map<String, String> result = getResolveMatrixParams(getDeprecatedMatrixParamPrefix());
             if (result.size() == 0) {
+                // Fallback to none deprecated key.
                 result = getResolveMatrixParams(getMatrixParamPrefix());
             }
             this.calculatedMatrixParams = ImmutableMap.copyOf(result);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -923,9 +923,16 @@ public class ArtifactoryClientConfiguration {
             if (calculatedMatrixParams != null) {
                 return calculatedMatrixParams;
             }
-            Map<String, String> result = getResolveMatrixParams(getMatrixParamPrefix());
+            // Try to get value using the deprecated key.
+            // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
+            // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
+            // in that case, we must honor the deprecated keys first.
+            //
+            // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
+            // those will override gradle defaults.
+            Map<String, String> result = getResolveMatrixParams(getDeprecatedMatrixParamPrefix());
             if (result.size() == 0) {
-                result = getResolveMatrixParams(getDeprecatedMatrixParamPrefix());
+                result = getResolveMatrixParams(getMatrixParamPrefix());
             }
             this.calculatedMatrixParams = ImmutableMap.copyOf(result);
             return calculatedMatrixParams;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
@@ -47,13 +47,20 @@ public class PrefixPropertyHandler {
     }
 
     public String getStringValue(String key, String def) {
-        String value = props.get(prefix + key);
+        // Try to get value using the deprecated key.
+        // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
+        // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
+        // in that case, we must honor the deprecated keys first.
+        //
+        // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
+        // those will override gradle defaults.
+        String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
         if (StringUtils.isNotBlank(value)) {
             return value;
         }
         // Fallback, try to get value with deprecated key.
         // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
-        value = props.get(ARTIFACTORY_PREFIX + prefix + key);
+        value = props.get(prefix + key);
         if (StringUtils.isNotBlank(value)) {
             return value;
         }
@@ -70,15 +77,20 @@ public class PrefixPropertyHandler {
     }
 
     public Boolean getBooleanValue(String key, Boolean def) {
-        String value = props.get(prefix + key);
+        // Try to get value using the deprecated key.
+        // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
+        // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
+        // in that case, we must honor the deprecated keys first.
+        //
+        // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
+        // those will override gradle defaults.
+        String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
         // TODO: throw exception if not true or false. If prop set to something else
         Boolean result = (value == null) ? null : Boolean.parseBoolean(value);
         if (result != null) {
             return result;
         }
-        // Fallback, try to get value with deprecated key.
-        // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
-        value = props.get(ARTIFACTORY_PREFIX + prefix + key);
+        value = props.get(prefix + key);
         result = (value == null) ? null : Boolean.parseBoolean(value);
         if (result != null) {
             return result;
@@ -99,13 +111,19 @@ public class PrefixPropertyHandler {
     }
 
     public Integer getIntegerValue(String key, Integer def) {
-        Integer result = getInteger(key, prefix);
+        // Try to get value using the deprecated key.
+        // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
+        // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
+        // in that case, we must honor the deprecated keys first.
+        //
+        // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
+        // those will override gradle defaults.
+        Integer result = getInteger(key, ARTIFACTORY_PREFIX + prefix);
         if (result != null) {
             return result;
         }
-        // Fallback, try to get value with deprecated key.
-        // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
-        result = getInteger(key, ARTIFACTORY_PREFIX + prefix);
+        // Fallback, try to get the regular key.
+         result = getInteger(key, prefix);
         if (result != null) {
             return result;
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
@@ -47,19 +47,13 @@ public class PrefixPropertyHandler {
     }
 
     public String getStringValue(String key, String def) {
-        // Try to get value using the deprecated key.
-        // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
-        // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
-        // in that case, we must honor the deprecated keys first.
-        //
-        // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
-        // those will override gradle defaults.
+        // First, get value using deprecated key.
+        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
         String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
         if (StringUtils.isNotBlank(value)) {
             return value;
         }
-        // Fallback, try to get value with deprecated key.
-        // This may happen if a newer version of Build-Info is used old CI which generates the deprecated properties.
+        // Fallback to none deprecated key.
         value = props.get(prefix + key);
         if (StringUtils.isNotBlank(value)) {
             return value;
@@ -77,19 +71,15 @@ public class PrefixPropertyHandler {
     }
 
     public Boolean getBooleanValue(String key, Boolean def) {
-        // Try to get value using the deprecated key.
-        // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
-        // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
-        // in that case, we must honor the deprecated keys first.
-        //
-        // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
-        // those will override gradle defaults.
+        // First, get value using deprecated key.
+        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
         String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
         // TODO: throw exception if not true or false. If prop set to something else
         Boolean result = (value == null) ? null : Boolean.parseBoolean(value);
         if (result != null) {
             return result;
         }
+        // Fallback to none deprecated key.
         value = props.get(prefix + key);
         result = (value == null) ? null : Boolean.parseBoolean(value);
         if (result != null) {
@@ -111,18 +101,13 @@ public class PrefixPropertyHandler {
     }
 
     public Integer getIntegerValue(String key, Integer def) {
-        // Try to get value using the deprecated key.
-        // This check must be first because we may have both types of property keys in props, deprecated and none deprecated.
-        // This may happen when the deprecated keys are added from the build-info properties file and the none deprecated keys added by Gradle as defaults.
-        // in that case, we must honor the deprecated keys first.
-        //
-        // In addition, when none deprecated keys are being used, and the build info properties file contains the up to date keys,
-        // those will override gradle defaults.
+        // First, get value using deprecated key.
+        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
         Integer result = getInteger(key, ARTIFACTORY_PREFIX + prefix);
         if (result != null) {
             return result;
         }
-        // Fallback, try to get the regular key.
+        // Fallback to none deprecated key.
          result = getInteger(key, prefix);
         if (result != null) {
             return result;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
@@ -47,18 +47,10 @@ public class PrefixPropertyHandler {
     }
 
     public String getStringValue(String key, String def) {
-        // First, get value using deprecated key.
-        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
-        String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
+        String value = getValueWithFallback(key);
         if (StringUtils.isNotBlank(value)) {
             return value;
         }
-        // Fallback to none deprecated key.
-        value = props.get(prefix + key);
-        if (StringUtils.isNotBlank(value)) {
-            return value;
-        }
-
         return def;
     }
 
@@ -71,17 +63,8 @@ public class PrefixPropertyHandler {
     }
 
     public Boolean getBooleanValue(String key, Boolean def) {
-        // First, get value using deprecated key.
-        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
-        String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
-        // TODO: throw exception if not true or false. If prop set to something else
+        String value = getValueWithFallback(key);
         Boolean result = (value == null) ? null : Boolean.parseBoolean(value);
-        if (result != null) {
-            return result;
-        }
-        // Fallback to none deprecated key.
-        value = props.get(prefix + key);
-        result = (value == null) ? null : Boolean.parseBoolean(value);
         if (result != null) {
             return result;
         }
@@ -101,31 +84,36 @@ public class PrefixPropertyHandler {
     }
 
     public Integer getIntegerValue(String key, Integer def) {
-        // First, get value using deprecated key.
-        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
-        Integer result = getInteger(key, ARTIFACTORY_PREFIX + prefix);
-        if (result != null) {
-            return result;
-        }
-        // Fallback to none deprecated key.
-         result = getInteger(key, prefix);
+        Integer result = getInteger(key);
         if (result != null) {
             return result;
         }
         return def;
     }
 
-    private Integer getInteger(String key, String targetPrefix) {
+    private Integer getInteger(String key) {
         Integer result;
-        String s = props.get(targetPrefix + key);
+        String s = getValueWithFallback(key);
         if (s != null && !StringUtils.isNumeric(s)) {
-            log.debug("Property '" + targetPrefix + key + "' is not of numeric value '" + s + "'");
+            log.debug("Property '" + key + "' is not of numeric value '" + s + "'");
             result = null;
         } else {
             result = (s == null) ? null : Integer.parseInt(s);
         }
         return result;
     }
+
+    private String getValueWithFallback(String key) {
+        // First, get value using deprecated key.
+        // This check must be first, otherwise, build.gradle properties will override the CI (e.g Jenkins / teamcity) properties.
+        String value = props.get(ARTIFACTORY_PREFIX + prefix + key);
+        if (StringUtils.isNotBlank(value)) {
+            return value;
+        }
+        // Fallback to none deprecated key.
+        return props.get(prefix + key);
+    }
+
 
     public void setIntegerValue(String key, Integer value) {
         if (value == null) {


### PR DESCRIPTION
…o properties

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Build-info properties file may include deprecated properties that have 'artifactory' as their prefix. since Gradle may generate defaults to the none deprecated keys we need to look for the deprecated keys first.

Resolves:
* https://github.com/jfrog/build-info/issues/592