### PR TITLE
Fix maven late deploy

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -525,7 +525,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             if (artifactFile != null && artifactFile.isFile()) {
                 boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                 addArtifactToBuildInfo(artifact, pathConflicts, excludeArtifactsFromBuild, module);
-                if (conf.publisher.generateDeployArtifactsMap()) {
+                if (conf.publisher.shouldAddDeployableArtifacts()) {
                     addDeployableArtifact(artifact, artifactFile, pathConflicts, groupId, artifactId, artifactVersion, artifactClassifier, artifactExtension);
                 }
             }
@@ -558,7 +558,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
                 if (pomFile != null && pomFile.isFile()) {
                     boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                     addArtifactToBuildInfo(pomArtifact, pathConflicts, excludeArtifactsFromBuild, module);
-                    if (conf.publisher.generateDeployArtifactsMap()) {
+                    if (conf.publisher.shouldAddDeployableArtifacts()) {
                         addDeployableArtifact(pomArtifact, pomFile, pathConflicts, nonPomArtifact.getGroupId(), nonPomArtifact.getArtifactId(), nonPomArtifact.getVersion(), nonPomArtifact.getClassifier(), "pom");
                     }
                 }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -525,7 +525,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             if (artifactFile != null && artifactFile.isFile()) {
                 boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                 addArtifactToBuildInfo(artifact, pathConflicts, excludeArtifactsFromBuild, module);
-                if (conf.publisher.isPublishArtifacts()) {
+                if (conf.publisher.generateDeployArtifactsMap()) {
                     addDeployableArtifact(artifact, artifactFile, pathConflicts, groupId, artifactId, artifactVersion, artifactClassifier, artifactExtension);
                 }
             }
@@ -558,7 +558,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
                 if (pomFile != null && pomFile.isFile()) {
                     boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                     addArtifactToBuildInfo(pomArtifact, pathConflicts, excludeArtifactsFromBuild, module);
-                    if (conf.publisher.isPublishArtifacts()) {
+                    if (conf.publisher.generateDeployArtifactsMap()) {
                         addDeployableArtifact(pomArtifact, pomFile, pathConflicts, nonPomArtifact.getGroupId(), nonPomArtifact.getArtifactId(), nonPomArtifact.getVersion(), nonPomArtifact.getClassifier(), "pom");
                     }
                 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -79,7 +79,7 @@ import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationF
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.EVEN_UNSTABLE;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.EXCLUDE_PATTERNS;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.FILTER_EXCLUDED_ARTIFACTS_FROM_BUILD;
-import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.GENERATE_DEPLOY_ARTIFACTS_MAP;
+import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.ADD_DEPLOYABLE_ARTIFACTS;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.GO_PUBLISHED_VERSION;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.HOST;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.INCLUDE_PATTERNS;
@@ -455,8 +455,8 @@ public class ArtifactoryClientConfiguration {
             return getBooleanValue(PUBLISH_ARTIFACTS, true);
         }
 
-        public Boolean generateDeployArtifactsMap() {
-            return getBooleanValue(GENERATE_DEPLOY_ARTIFACTS_MAP, true);
+        public Boolean shouldAddDeployableArtifacts() {
+            return getBooleanValue(ADD_DEPLOYABLE_ARTIFACTS, true);
         }
 
         public void setPublishBuildInfo(Boolean enabled) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -79,6 +79,7 @@ import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationF
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.EVEN_UNSTABLE;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.EXCLUDE_PATTERNS;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.FILTER_EXCLUDED_ARTIFACTS_FROM_BUILD;
+import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.GENERATE_DEPLOY_ARTIFACTS_MAP;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.GO_PUBLISHED_VERSION;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.HOST;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.INCLUDE_PATTERNS;
@@ -452,6 +453,10 @@ public class ArtifactoryClientConfiguration {
 
         public Boolean isPublishArtifacts() {
             return getBooleanValue(PUBLISH_ARTIFACTS, true);
+        }
+
+        public Boolean generateDeployArtifactsMap() {
+            return getBooleanValue(GENERATE_DEPLOY_ARTIFACTS_MAP, true);
         }
 
         public void setPublishBuildInfo(Boolean enabled) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -45,4 +45,6 @@ public interface ClientConfigurationFields {
     String EVEN_UNSTABLE = "unstable";
     String CONTEXT_URL = "contextUrl";
     String PUBLICATIONS = "publications";
+    String GENERATE_DEPLOY_ARTIFACTS_MAP = "generate.deploy.artifacts.map";
+
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -45,6 +45,5 @@ public interface ClientConfigurationFields {
     String EVEN_UNSTABLE = "unstable";
     String CONTEXT_URL = "contextUrl";
     String PUBLICATIONS = "publications";
-    String GENERATE_DEPLOY_ARTIFACTS_MAP = "generate.deploy.artifacts.map";
-
+    String ADD_DEPLOYABLE_ARTIFACTS = "add.deployable.artifacts";
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
`isPublishArtifacts` disable build-info from generating `deployable.artifacts.json`.
This file is used by maven late artifacts deploy to know which artifact to deploy to where.

This PR replace isPublishArtifacts by adding a new property instead.

Related PR: https://github.com/jfrog/build-info-go/pull/26