### PR TITLE
Calculate SHA256 in Gradle builds

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/util/FileChecksumCalculator.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/util/FileChecksumCalculator.java
@@ -9,6 +9,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * File checksum calculator class
@@ -17,18 +18,17 @@ import java.util.Map;
  */
 public abstract class FileChecksumCalculator {
 
+    private static final AtomicBoolean ACCP_INITIALIZED = new AtomicBoolean();
     public static final String SHA256_ALGORITHM = "SHA-256";
     public static final String SHA1_ALGORITHM = "SHA1";
     public static final String MD5_ALGORITHM = "MD5";
     private static final int BUFFER_SIZE = 32768;
-    private static boolean accpInitialized;
 
     /**
      * Installs the AmazonCorrettoCryptoProvider provider as the highest-priority (i.e. default) provider systemwide.
      */
     private static void initAmazonCorrettoCryptoProvider() {
         AmazonCorrettoCryptoProvider.install();
-        accpInitialized = true;
     }
 
     /**
@@ -82,7 +82,7 @@ public abstract class FileChecksumCalculator {
      */
     private static Map<String, String> calculate(File fileToCalculate, String... algorithms)
             throws NoSuchAlgorithmException, IOException {
-        if (!accpInitialized) {
+        if (ACCP_INITIALIZED.compareAndSet(false, true)) {
             initAmazonCorrettoCryptoProvider();
         }
         Map<String, MessageDigest> digestMap = new HashMap<>();

--- a/build-info-api/src/test/java/org/jfrog/build/api/FileChecksumCalculatorTest.java
+++ b/build-info-api/src/test/java/org/jfrog/build/api/FileChecksumCalculatorTest.java
@@ -7,13 +7,12 @@ import org.testng.annotations.Test;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -23,6 +22,9 @@ import static org.testng.Assert.assertEquals;
  */
 @Test
 public class FileChecksumCalculatorTest {
+    private static final String expectedSha256 = "3b538cc62b700a0af5cb4b80515d511bc9ee67efe48d124005d36a7d37ad5b4b";
+    private static final String expectedSha1 = "a27d18807577048b59908c4accf425f4eb406220";
+    private static final String expectedMd5 = "0a3a30871aa677d0670d4a14125acf24";
 
     /**
      * Tests the behavior of the checksum calculator when given a null file
@@ -74,58 +76,13 @@ public class FileChecksumCalculatorTest {
      * Tests the behavior of the calculator when given a valid file
      */
     public void testValidFile() throws IOException, NoSuchAlgorithmException {
-
         File tempFile = File.createTempFile("moo", "test");
-        BufferedWriter out = new BufferedWriter(new FileWriter(tempFile));
-        out.write("This is a test file");
-        out.close();
-        Map<String, String> checksumsMap = FileChecksumCalculator.calculateChecksums(tempFile, "md5", "sha1");
-        String md5 = getChecksum("md5", tempFile);
-        String sha1 = getChecksum("sha1", tempFile);
-        assertEquals(checksumsMap.get("md5"), md5, "Unexpected test file MD5 checksum value.");
-        assertEquals(checksumsMap.get("sha1"), sha1, "Unexpected test file SHA1 checksum value.");
-    }
-
-    /**
-     * Returns the checksum of the given file
-     *
-     * @param algorithm  Algorithm to calculate by
-     * @param fileToRead File to calculate
-     * @return Checksum value
-     * @throws NoSuchAlgorithmException Thrown if MD5 or SHA1 aren't supported
-     * @throws IOException              Thrown if any error occurs while reading the file or calculating the checksum
-     */
-    private String getChecksum(String algorithm, File fileToRead) throws NoSuchAlgorithmException, IOException {
-        MessageDigest digest = MessageDigest.getInstance(algorithm);
-        FileInputStream inputStream = new FileInputStream(fileToRead);
-
-        byte[] buffer = new byte[32768];
-        try {
-            int size = inputStream.read(buffer, 0, 32768);
-
-            while (size >= 0) {
-                digest.update(buffer, 0, size);
-                size = inputStream.read(buffer, 0, 32768);
-            }
-        } finally {
-            if (inputStream != null) {
-                inputStream.close();
-            }
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(tempFile))) {
+            out.write("API/FileChecksumCalculatorTest - This is a test file");
         }
-
-        byte[] bytes = digest.digest();
-        if (bytes.length != 16 && bytes.length != 20) {
-            int bitLength = bytes.length * 8;
-            throw new IllegalArgumentException("Unrecognised length for binary data: " + bitLength + " bits");
-        }
-        StringBuilder sb = new StringBuilder();
-        for (byte aBinaryData : bytes) {
-            String t = Integer.toHexString(aBinaryData & 0xff);
-            if (t.length() == 1) {
-                sb.append("0");
-            }
-            sb.append(t);
-        }
-        return sb.toString().trim();
+        Map<String, String> checksumsMap = FileChecksumCalculator.calculateChecksums(tempFile, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
+        assertEquals(checksumsMap.get(MD5_ALGORITHM), expectedMd5, "Unexpected test file MD5 checksum value.");
+        assertEquals(checksumsMap.get(SHA1_ALGORITHM), expectedSha1, "Unexpected test file SHA1 checksum value.");
+        assertEquals(checksumsMap.get(SHA256_ALGORITHM), expectedSha256, "Unexpected test file SHA1 checksum value.");
     }
 }

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoCommand.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoCommand.java
@@ -19,8 +19,6 @@ import java.nio.file.Path;
  */
 abstract class GoCommand extends PackageManagerExtractor {
 
-    protected static final String SHA1 = "SHA1";
-    protected static final String MD5 = "MD5";
     protected static final String LOCAL_GO_MOD_FILENAME = "go.mod";
     protected static final String GO_CLIENT_CMD = "go";
     private static final long serialVersionUID = 1L;

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
@@ -32,8 +32,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
@@ -195,14 +194,14 @@ public class GoPublish extends GoCommand {
      */
     private Artifact deploy(ArtifactoryManager artifactoryManager, File deployedFile, String extension) throws Exception {
         String artifactName = version + "." + extension;
-        Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(deployedFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+        Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(deployedFile, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
         String remotePath = moduleName + "/@v";
         DeployDetails deployDetails = new DeployDetails.Builder()
                 .file(deployedFile)
                 .targetRepository(deploymentRepo)
                 .addProperties(properties)
                 .artifactPath(remotePath + "/" + artifactName)
-                .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
+                .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(checksums.get(SHA256_ALGORITHM))
                 .packageType(DeployDetails.PackageType.GO)
                 .build();
 
@@ -211,6 +210,7 @@ public class GoPublish extends GoCommand {
         return new ArtifactBuilder(moduleName + ":" + artifactName)
                 .md5(response.getChecksums().getMd5())
                 .sha1(response.getChecksums().getSha1())
+                .sha256(response.getChecksums().getSha256())
                 .remotePath(remotePath)
                 .build();
     }

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
@@ -6,14 +6,14 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.builder.ModuleType;
-import org.jfrog.build.extractor.builder.ArtifactBuilder;
-import org.jfrog.build.extractor.builder.ModuleBuilder;
-import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.extractor.ci.Artifact;
-import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.api.util.FileChecksumCalculator;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ArtifactoryUploadResponse;
+import org.jfrog.build.extractor.builder.ArtifactBuilder;
+import org.jfrog.build.extractor.builder.ModuleBuilder;
+import org.jfrog.build.extractor.ci.Artifact;
+import org.jfrog.build.extractor.ci.BuildInfo;
+import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -27,16 +27,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
@@ -198,14 +195,14 @@ public class GoPublish extends GoCommand {
      */
     private Artifact deploy(ArtifactoryManager artifactoryManager, File deployedFile, String extension) throws Exception {
         String artifactName = version + "." + extension;
-        Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(deployedFile, MD5, SHA1);
+        Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(deployedFile, MD5_ALGORITHM, SHA1_ALGORITHM);
         String remotePath = moduleName + "/@v";
         DeployDetails deployDetails = new DeployDetails.Builder()
                 .file(deployedFile)
                 .targetRepository(deploymentRepo)
                 .addProperties(properties)
                 .artifactPath(remotePath + "/" + artifactName)
-                .md5(checksums.get(MD5)).sha1(checksums.get(SHA1))
+                .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
                 .packageType(DeployDetails.PackageType.GO)
                 .build();
 

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
@@ -30,8 +30,7 @@ import java.util.Map;
 
 import static java.lang.Character.isUpperCase;
 import static java.lang.Character.toLowerCase;
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 
@@ -218,10 +217,10 @@ public class GoRun extends GoCommand {
         String cachedPkgPath = cachePath + convertModuleNameToCachePathConvention(moduleName) + File.separator + "@v" + File.separator + moduleVersion + ".zip";
         File moduleZip = new File(cachedPkgPath);
         if (moduleZip.exists()) {
-            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(moduleZip, MD5_ALGORITHM, SHA1_ALGORITHM);
+            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(moduleZip, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
             Dependency dependency = new DependencyBuilder()
                     .id(moduleName + ':' + moduleVersion)
-                    .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
+                    .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(checksums.get(SHA256_ALGORITHM))
                     .type("zip")
                     .build();
             dependenciesList.add(dependency);

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
@@ -3,13 +3,13 @@ package org.jfrog.build.extractor.go.extractor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.builder.ModuleType;
+import org.jfrog.build.api.util.FileChecksumCalculator;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.builder.DependencyBuilder;
 import org.jfrog.build.extractor.builder.ModuleBuilder;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.api.util.FileChecksumCalculator;
-import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -30,6 +30,8 @@ import java.util.Map;
 
 import static java.lang.Character.isUpperCase;
 import static java.lang.Character.toLowerCase;
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 
@@ -216,10 +218,10 @@ public class GoRun extends GoCommand {
         String cachedPkgPath = cachePath + convertModuleNameToCachePathConvention(moduleName) + File.separator + "@v" + File.separator + moduleVersion + ".zip";
         File moduleZip = new File(cachedPkgPath);
         if (moduleZip.exists()) {
-            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(moduleZip, MD5, SHA1);
+            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(moduleZip, MD5_ALGORITHM, SHA1_ALGORITHM);
             Dependency dependency = new DependencyBuilder()
                     .id(moduleName + ':' + moduleVersion)
-                    .md5(checksums.get(MD5)).sha1(checksums.get(SHA1))
+                    .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
                     .type("zip")
                     .build();
             dependenciesList.add(dependency);

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperConfigurations.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperConfigurations.java
@@ -31,6 +31,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
+
 /**
  * @author Fred Simon
  */
@@ -245,8 +247,8 @@ public class TaskHelperConfigurations extends TaskHelper {
                 .packageType(DeployDetails.PackageType.GRADLE);
         try {
             Map<String, String> checksums =
-                    FileChecksumCalculator.calculateChecksums(artifactoryTask.ivyDescriptor, "MD5", "SHA1");
-            artifactBuilder.md5(checksums.get("MD5")).sha1(checksums.get("SHA1"));
+                    FileChecksumCalculator.calculateChecksums(artifactoryTask.ivyDescriptor, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
+            artifactBuilder.md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(SHA256_ALGORITHM);
         } catch (Exception e) {
             throw new GradleException(
                     "Failed to calculate checksums for artifact: " + artifactoryTask.ivyDescriptor.getAbsolutePath(), e);
@@ -277,8 +279,8 @@ public class TaskHelperConfigurations extends TaskHelper {
                 .packageType(DeployDetails.PackageType.GRADLE);
         try {
             Map<String, String> checksums =
-                    FileChecksumCalculator.calculateChecksums(artifactoryTask.mavenDescriptor, "MD5", "SHA1");
-            artifactBuilder.md5(checksums.get("MD5")).sha1(checksums.get("SHA1"));
+                    FileChecksumCalculator.calculateChecksums(artifactoryTask.mavenDescriptor, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
+            artifactBuilder.md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(SHA256_ALGORITHM);
         } catch (Exception e) {
             throw new GradleException(
                     "Failed to calculate checksums for artifact: " + artifactoryTask.mavenDescriptor.getAbsolutePath(), e);
@@ -394,8 +396,8 @@ public class TaskHelperConfigurations extends TaskHelper {
                 .file(file)
                 .packageType(DeployDetails.PackageType.GRADLE);
         try {
-            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(file, "MD5", "SHA1");
-            deployDetailsBuilder.md5(checksums.get("MD5")).sha1(checksums.get("SHA1"));
+            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
+            deployDetailsBuilder.md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(SHA256_ALGORITHM);
         } catch (Exception e) {
             throw new GradleException("Failed to calculate checksums for artifact: " + file.getAbsolutePath(), e);
         }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperPublications.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperPublications.java
@@ -37,6 +37,8 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.Callable;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
+
 
 /**
  * @author Fred Simon
@@ -353,8 +355,8 @@ public class TaskHelperPublications extends TaskHelper {
                 .packageType(DeployDetails.PackageType.GRADLE);
         try {
             Map<String, String> checksums =
-                    FileChecksumCalculator.calculateChecksums(file, "MD5", "SHA1");
-            artifactBuilder.md5(checksums.get("MD5")).sha1(checksums.get("SHA1"));
+                    FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
+            artifactBuilder.md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(checksums.get(SHA256_ALGORITHM));
         } catch (Exception e) {
             throw new GradleException(
                     "Failed to calculate checksums for artifact: " + file.getAbsolutePath(), e);

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/trigger/ArtifactoryBuildInfoTrigger.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/trigger/ArtifactoryBuildInfoTrigger.java
@@ -38,6 +38,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
 
@@ -49,8 +51,6 @@ import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
  */
 public class ArtifactoryBuildInfoTrigger implements Trigger {
 
-    private static final String MD5 = "MD5";
-    private static final String SHA1 = "SHA1";
     private final Filter filter;
     private BuildContext ctx;
     private String eventName;
@@ -121,12 +121,12 @@ public class ArtifactoryBuildInfoTrigger implements Trigger {
                         File file = artifactsReport.getLocalFile();
                         Map<String, String> checksums;
                         try {
-                            checksums = FileChecksumCalculator.calculateChecksums(file, MD5, SHA1);
+                            checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM);
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
-                        String md5 = checksums.get(MD5);
-                        String sha1 = checksums.get(SHA1);
+                        String md5 = checksums.get(MD5_ALGORITHM);
+                        String sha1 = checksums.get(SHA1_ALGORITHM);
                         dependencyBuilder.md5(md5).sha1(sha1);
                         dependency = dependencyBuilder.build();
                         moduleDependencies.add(dependency);
@@ -203,8 +203,8 @@ public class ArtifactoryBuildInfoTrigger implements Trigger {
 
         File artifactFile = new File(file);
         Map<String, String> checksums = calculateFileChecksum(artifactFile);
-        String md5 = checksums.get(MD5);
-        String sha1 = checksums.get(SHA1);
+        String md5 = checksums.get(MD5_ALGORITHM);
+        String sha1 = checksums.get(SHA1_ALGORITHM);
         artifactBuilder.md5(md5).sha1(sha1);
         Artifact artifact = artifactBuilder.build();
         if (excludeArtifactsFromBuild && PatternMatcher.pathConflicts(fullPath, patterns)) {
@@ -272,7 +272,7 @@ public class ArtifactoryBuildInfoTrigger implements Trigger {
     private Map<String, String> calculateFileChecksum(File file) {
         Map<String, String> checksums;
         try {
-            checksums = FileChecksumCalculator.calculateChecksums(file, MD5, SHA1);
+            checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/trigger/ArtifactoryBuildInfoTrigger.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/trigger/ArtifactoryBuildInfoTrigger.java
@@ -38,8 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
 
@@ -121,13 +120,14 @@ public class ArtifactoryBuildInfoTrigger implements Trigger {
                         File file = artifactsReport.getLocalFile();
                         Map<String, String> checksums;
                         try {
-                            checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM);
+                            checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
                         String md5 = checksums.get(MD5_ALGORITHM);
                         String sha1 = checksums.get(SHA1_ALGORITHM);
-                        dependencyBuilder.md5(md5).sha1(sha1);
+                        String sha256 = checksums.get(SHA256_ALGORITHM);
+                        dependencyBuilder.md5(md5).sha1(sha1).sha256(sha256);
                         dependency = dependencyBuilder.build();
                         moduleDependencies.add(dependency);
                         project.log(
@@ -205,7 +205,8 @@ public class ArtifactoryBuildInfoTrigger implements Trigger {
         Map<String, String> checksums = calculateFileChecksum(artifactFile);
         String md5 = checksums.get(MD5_ALGORITHM);
         String sha1 = checksums.get(SHA1_ALGORITHM);
-        artifactBuilder.md5(md5).sha1(sha1);
+        String sha256 = checksums.get(SHA256_ALGORITHM);
+        artifactBuilder.md5(md5).sha1(sha1).sha256(sha256);
         Artifact artifact = artifactBuilder.build();
         if (excludeArtifactsFromBuild && PatternMatcher.pathConflicts(fullPath, patterns)) {
             module.getExcludedArtifacts().add(artifact);
@@ -272,7 +273,7 @@ public class ArtifactoryBuildInfoTrigger implements Trigger {
     private Map<String, String> calculateFileChecksum(File file) {
         Map<String, String> checksums;
         try {
-            checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM);
+            checksums = FileChecksumCalculator.calculateChecksums(file, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
@@ -19,11 +19,10 @@ import org.jfrog.build.extractor.retention.Utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 
 /**
  * @author Noam Y. Tenne
@@ -160,9 +159,9 @@ public class BuildDeploymentHelper {
     private void setArtifactChecksums(File artifactFile, Artifact artifact) {
         if ((artifactFile != null) && (artifactFile.isFile())) {
             try {
-                Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(artifactFile, "md5", "sha1");
-                artifact.setMd5(checksums.get("md5"));
-                artifact.setSha1(checksums.get("sha1"));
+                Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(artifactFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+                artifact.setMd5(checksums.get(MD5_ALGORITHM));
+                artifact.setSha1(checksums.get(SHA1_ALGORITHM));
             } catch (Exception e) {
                 logger.error("Could not set checksum values on '" + artifact.getName() + "': " + e.getMessage(), e);
             }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
@@ -21,8 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 
 /**
  * @author Noam Y. Tenne
@@ -142,6 +141,7 @@ public class BuildDeploymentHelper {
                                 file(file).
                                 md5(artifact.getMd5()).
                                 sha1(artifact.getSha1()).
+                                sha256(artifact.getSha256()).
                                 addProperties(deployable.getProperties()).
                                 targetRepository(deployable.getTargetRepository()).
                                 packageType(DeployDetails.PackageType.MAVEN).
@@ -159,9 +159,10 @@ public class BuildDeploymentHelper {
     private void setArtifactChecksums(File artifactFile, Artifact artifact) {
         if ((artifactFile != null) && (artifactFile.isFile())) {
             try {
-                Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(artifactFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+                Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(artifactFile, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
                 artifact.setMd5(checksums.get(MD5_ALGORITHM));
                 artifact.setSha1(checksums.get(SHA1_ALGORITHM));
+                artifact.setSha256(checksums.get(SHA256_ALGORITHM));
             } catch (Exception e) {
                 logger.error("Could not set checksum values on '" + artifact.getName() + "': " + e.getMessage(), e);
             }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -48,8 +48,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
 
@@ -668,9 +667,10 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         if ((dependencyFile != null) && (dependencyFile.isFile())) {
             try {
                 Map<String, String> checksumsMap
-                        = FileChecksumCalculator.calculateChecksums(dependencyFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+                        = FileChecksumCalculator.calculateChecksums(dependencyFile, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
                 dependencyBuilder.md5(checksumsMap.get(MD5_ALGORITHM));
                 dependencyBuilder.sha1(checksumsMap.get(SHA1_ALGORITHM));
+                dependencyBuilder.sha256(checksumsMap.get(SHA256_ALGORITHM));
             } catch (NoSuchAlgorithmException | IOException e) {
                 logger.error("Could not set checksum values on '" + dependencyBuilder.build().getId() + "': "
                         + e.getMessage(), e);

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -14,16 +14,16 @@ import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.jfrog.build.api.builder.ModuleType;
+import org.jfrog.build.api.util.CommonUtils;
+import org.jfrog.build.api.util.FileChecksumCalculator;
+import org.jfrog.build.extractor.BuildInfoExtractor;
+import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.builder.ArtifactBuilder;
 import org.jfrog.build.extractor.builder.BuildInfoMavenBuilder;
 import org.jfrog.build.extractor.builder.DependencyBuilder;
 import org.jfrog.build.extractor.builder.ModuleBuilder;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.BuildInfoConfigProperties;
-import org.jfrog.build.api.util.CommonUtils;
-import org.jfrog.build.api.util.FileChecksumCalculator;
-import org.jfrog.build.extractor.BuildInfoExtractor;
-import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
@@ -45,15 +45,11 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
 
@@ -672,9 +668,9 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         if ((dependencyFile != null) && (dependencyFile.isFile())) {
             try {
                 Map<String, String> checksumsMap
-                        = FileChecksumCalculator.calculateChecksums(dependencyFile, "md5", "sha1");
-                dependencyBuilder.md5(checksumsMap.get("md5"));
-                dependencyBuilder.sha1(checksumsMap.get("sha1"));
+                        = FileChecksumCalculator.calculateChecksums(dependencyFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+                dependencyBuilder.md5(checksumsMap.get(MD5_ALGORITHM));
+                dependencyBuilder.sha1(checksumsMap.get(SHA1_ALGORITHM));
             } catch (NoSuchAlgorithmException | IOException e) {
                 logger.error("Could not set checksum values on '" + dependencyBuilder.build().getId() + "': "
                         + e.getMessage(), e);
@@ -729,6 +725,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         currentModuleDependencies.remove();
         resolvedArtifacts.clear();
     }
+
     /**
      * Skip the default maven deploy behaviour.
      */

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
@@ -34,8 +34,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class NugetRun extends PackageManagerExtractor {
@@ -417,10 +416,10 @@ public class NugetRun extends PackageManagerExtractor {
             }
         }
         if (found) {
-            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(nupkg, MD5_ALGORITHM, SHA1_ALGORITHM);
+            Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(nupkg, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
             Dependency dependency = new DependencyBuilder()
                     .id(pkg.getId() + ':' + pkg.getVersion())
-                    .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
+                    .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(checksums.get(SHA256_ALGORITHM))
                     .build();
             return dependency;
         }
@@ -449,10 +448,10 @@ public class NugetRun extends PackageManagerExtractor {
             }
             File nupkg = new File(assets.getPackagesPath(), library.getNupkgFilePath());
             if (nupkg.exists()) {
-                Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(nupkg, MD5_ALGORITHM, SHA1_ALGORITHM);
+                Map<String, String> checksums = FileChecksumCalculator.calculateChecksums(nupkg, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
                 Dependency dependency = new DependencyBuilder()
                         .id(pkgKey.replace('/', ':'))
-                        .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
+                        .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(checksums.get(SHA256_ALGORITHM))
                         .build();
                 dependenciesList.add(dependency);
             } else {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/deploy/DeployDetails.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/deploy/DeployDetails.java
@@ -191,6 +191,11 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
             return this;
         }
 
+        public Builder sha256(String sha256) {
+            deployDetails.sha256 = sha256;
+            return this;
+        }
+
         public Builder sha1(String sha1) {
             deployDetails.sha1 = sha1;
             return this;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
@@ -26,8 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.Upload.MD5_HEADER_NAME;
 import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.Upload.SHA1_HEADER_NAME;
 
@@ -227,7 +226,7 @@ public class DependenciesDownloaderHelper {
     protected Map<String, String> downloadFile(String downloadPath, String fileDestination) throws IOException {
         File downloadedFile = downloader.getArtifactoryManager().downloadToFile(downloadPath, fileDestination);
         try {
-            return FileChecksumCalculator.calculateChecksums(downloadedFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+            return FileChecksumCalculator.calculateChecksums(downloadedFile, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(String.format("Could not find checksum algorithm: %s", e.getLocalizedMessage()), e);
         }
@@ -393,6 +392,8 @@ public class DependenciesDownloaderHelper {
         return new DependencyBuilder()
                 .md5(md5)
                 .sha1(sha1)
+                // Checksum verification for sha256 is disabled for now
+                .sha256(checksumsMap.get(SHA256_ALGORITHM))
                 .id(filePath.substring(filePath.lastIndexOf(File.separatorChar) + 1))
                 .localPath(fileDestination)
                 .remotePath(remotePath)
@@ -430,6 +431,7 @@ public class DependenciesDownloaderHelper {
     }
 
     protected static class ArtifactMetaData {
+        private String sha256;
         private String sha1;
         private String md5;
         private long size;
@@ -441,6 +443,14 @@ public class DependenciesDownloaderHelper {
 
         public void setSize(long size) {
             this.size = size;
+        }
+
+        public String getSha256() {
+            return this.sha256;
+        }
+
+        public void setSha256(String sha256) {
+            this.sha256 = sha256;
         }
 
         public String getSha1() {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
@@ -9,36 +9,25 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
-import org.jfrog.build.extractor.builder.DependencyBuilder;
-import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.api.dependency.DownloadableArtifact;
 import org.jfrog.build.api.dependency.pattern.PatternType;
 import org.jfrog.build.api.search.AqlSearchResult;
 import org.jfrog.build.api.util.FileChecksumCalculator;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.api.util.ZipUtils;
+import org.jfrog.build.extractor.builder.DependencyBuilder;
+import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.filespecs.FileSpec;
 import org.jfrog.filespecs.entities.FilesGroup;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.SequenceInputStream;
-import java.io.StringWriter;
+import java.io.*;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.Upload.MD5_HEADER_NAME;
 import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.Upload.SHA1_HEADER_NAME;
 
@@ -48,9 +37,6 @@ import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.s
  * @author Shay Yaakov
  */
 public class DependenciesDownloaderHelper {
-
-    public static final String SHA1_ALGORITHM_NAME = "sha1";
-    public static final String MD5_ALGORITHM_NAME = "md5";
 
     private final DependenciesDownloader downloader;
     private final Log log;
@@ -241,7 +227,7 @@ public class DependenciesDownloaderHelper {
     protected Map<String, String> downloadFile(String downloadPath, String fileDestination) throws IOException {
         File downloadedFile = downloader.getArtifactoryManager().downloadToFile(downloadPath, fileDestination);
         try {
-            return FileChecksumCalculator.calculateChecksums(downloadedFile, MD5_ALGORITHM_NAME, SHA1_ALGORITHM_NAME);
+            return FileChecksumCalculator.calculateChecksums(downloadedFile, MD5_ALGORITHM, SHA1_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(String.format("Could not find checksum algorithm: %s", e.getLocalizedMessage()), e);
         }
@@ -401,8 +387,8 @@ public class DependenciesDownloaderHelper {
 
     private Dependency validateChecksumsAndBuildDependency(Map<String, String> checksumsMap, ArtifactMetaData artifactMetaData, String filePath, String fileDestination, String remotePath)
             throws IOException {
-        String md5 = validateMd5Checksum(artifactMetaData.getMd5(), checksumsMap.get(MD5_ALGORITHM_NAME));
-        String sha1 = validateSha1Checksum(artifactMetaData.getSha1(), checksumsMap.get(SHA1_ALGORITHM_NAME));
+        String md5 = validateMd5Checksum(artifactMetaData.getMd5(), checksumsMap.get(MD5_ALGORITHM));
+        String sha1 = validateSha1Checksum(artifactMetaData.getSha1(), checksumsMap.get(SHA1_ALGORITHM));
 
         return new DependencyBuilder()
                 .md5(md5)

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderImpl.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderImpl.java
@@ -2,11 +2,11 @@ package org.jfrog.build.extractor.clientConfiguration.util;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.api.dependency.DownloadableArtifact;
 import org.jfrog.build.api.util.CommonUtils;
 import org.jfrog.build.api.util.FileChecksumCalculator;
 import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 
 import java.io.File;
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloaderHelper.MD5_ALGORITHM_NAME;
-import static org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloaderHelper.SHA1_ALGORITHM_NAME;
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 
 /**
  * Created by diman on 12/03/2017.
@@ -59,7 +59,7 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
     public Map<String, String> saveDownloadedFile(InputStream is, String filePath) throws IOException {
         File dest = DependenciesDownloaderHelper.saveInputStreamToFile(is, filePath);
         try {
-            return FileChecksumCalculator.calculateChecksums(dest, MD5_ALGORITHM_NAME, SHA1_ALGORITHM_NAME);
+            return FileChecksumCalculator.calculateChecksums(dest, MD5_ALGORITHM, SHA1_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(String.format("Could not find checksum algorithm: %s", e.getLocalizedMessage()), e);
         }
@@ -77,10 +77,10 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
         }
 
         try {
-            Map<String, String> checksumsMap = FileChecksumCalculator.calculateChecksums(dest, MD5_ALGORITHM_NAME, SHA1_ALGORITHM_NAME);
+            Map<String, String> checksumsMap = FileChecksumCalculator.calculateChecksums(dest, MD5_ALGORITHM, SHA1_ALGORITHM);
             boolean isExists = checksumsMap != null &&
-                    StringUtils.isNotBlank(md5) && StringUtils.equals(md5, checksumsMap.get(MD5_ALGORITHM_NAME)) &&
-                    StringUtils.isNotBlank(sha1) && StringUtils.equals(sha1, checksumsMap.get(SHA1_ALGORITHM_NAME));
+                    StringUtils.isNotBlank(md5) && StringUtils.equals(md5, checksumsMap.get(MD5_ALGORITHM)) &&
+                    StringUtils.isNotBlank(sha1) && StringUtils.equals(sha1, checksumsMap.get(SHA1_ALGORITHM));
             if (isExists) {
                 return true;
             }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderImpl.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderImpl.java
@@ -17,8 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 
 /**
  * Created by diman on 12/03/2017.
@@ -59,7 +58,7 @@ public class DependenciesDownloaderImpl implements DependenciesDownloader {
     public Map<String, String> saveDownloadedFile(InputStream is, String filePath) throws IOException {
         File dest = DependenciesDownloaderHelper.saveInputStreamToFile(is, filePath);
         try {
-            return FileChecksumCalculator.calculateChecksums(dest, MD5_ALGORITHM, SHA1_ALGORITHM);
+            return FileChecksumCalculator.calculateChecksums(dest, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(String.format("Could not find checksum algorithm: %s", e.getLocalizedMessage()), e);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.clientConfiguration.util.PathsUtils.removeUnescapedChar;
 
 /**
@@ -25,17 +27,14 @@ import static org.jfrog.build.extractor.clientConfiguration.util.PathsUtils.remo
  */
 public class UploadSpecHelper {
 
-    private static final String SHA1 = "SHA1";
-    private static final String MD5 = "MD5";
-
     /**
      * Create a DeployDetails from the given properties
      *
-     * @param targetPath target of the created artifact in Artifactory
-     * @param artifactFile the artifact to deploy
-     * @param uploadTarget target repository in Artifactory
-     * @param explode explode archive
-     * @param props properties to attach to the deployed file
+     * @param targetPath      target of the created artifact in Artifactory
+     * @param artifactFile    the artifact to deploy
+     * @param uploadTarget    target repository in Artifactory
+     * @param explode         explode archive
+     * @param props           properties to attach to the deployed file
      * @param buildProperties a map of properties to add to the DeployDetails objects
      */
     public static DeployDetails buildDeployDetails(String targetPath, File artifactFile,
@@ -48,16 +47,16 @@ public class UploadSpecHelper {
         // calculate the sha1 checksum and add it to the deploy artifactsToDeploy
         Map<String, String> checksums;
         try {
-            checksums = FileChecksumCalculator.calculateChecksums(artifactFile, SHA1, MD5);
+            checksums = FileChecksumCalculator.calculateChecksums(artifactFile, MD5_ALGORITHM, SHA1_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw new NoSuchAlgorithmException(
-                    String.format("Could not find checksum algorithm for %s or %s.", SHA1, MD5), e);
+                    String.format("Could not find checksum algorithm for %s or %s.", MD5_ALGORITHM, SHA1_ALGORITHM), e);
         }
         DeployDetails.Builder builder = new DeployDetails.Builder()
                 .file(artifactFile)
                 .artifactPath(path)
                 .targetRepository(getRepositoryKey(uploadTarget))
-                .md5(checksums.get(MD5)).sha1(checksums.get(SHA1))
+                .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
                 .explode(BooleanUtils.toBoolean(explode))
                 .addProperties(SpecsHelper.getPropertiesMap(props))
                 .packageType(DeployDetails.PackageType.GENERIC);
@@ -95,7 +94,8 @@ public class UploadSpecHelper {
 
     /**
      * Gets the relative path of a given file to the workspace path.
-     * @param absolutePath the file's absolute path
+     *
+     * @param absolutePath  the file's absolute path
      * @param workspacePath path to the job's workspace
      * @return the relative path of a given file to the workspace path
      */
@@ -129,7 +129,7 @@ public class UploadSpecHelper {
     }
 
     protected static String getUploadPath(File file, Pattern pathPattern, String targetPath, boolean isFlat,
-                                        boolean isAbsolutePath, File workspaceDir, boolean isTargetDirectory) {
+                                          boolean isAbsolutePath, File workspaceDir, boolean isTargetDirectory) {
         String sourcePath;
         String fileTargetPath = targetPath;
         if (isTargetDirectory && !isFlat) {
@@ -168,11 +168,12 @@ public class UploadSpecHelper {
     /**
      * Returns base directory path with slash in the end.
      * The base directory is the path where the file collection starts from.
-     *
+     * <p>
      * Base directory is the last directory that not contains wildcards in case of regexp=false.
      * In case of regexp=true the base directory will be the last existing directory that not contains a regex char.
+     *
      * @param workspaceDir the workspaceDir directory
-     * @param pattern the pattern provided by the user
+     * @param pattern      the pattern provided by the user
      * @return String that represents the base directory
      */
     public static String getWildcardBaseDir(File workspaceDir, String pattern) {
@@ -191,11 +192,12 @@ public class UploadSpecHelper {
     /**
      * Returns base directory path with slash in the end.
      * The base directory is the path where the file collection starts from.
-     *
+     * <p>
      * Base directory is the last directory that not contains wildcards in case of regexp=false.
      * In case of regexp=true the base directory will be the last existing directory that not contains a regex char.
+     *
      * @param workspaceDir the workspaceDir directory
-     * @param pattern the pattern provided by the user
+     * @param pattern      the pattern provided by the user
      * @return String that represents the base directory
      */
     public static String getRegexBaseDir(File workspaceDir, String pattern) throws FileNotFoundException {
@@ -214,9 +216,10 @@ public class UploadSpecHelper {
     /**
      * The user can provide pattern that will contain static path (without wildcards) that will become part of the base directory.
      * this method removes the part of the pattern that exists in the base directory.
+     *
      * @param workspaceDir the workspaceDir directory
-     * @param pattern the provided by the user pattern
-     * @param baseDir the calculated base directory
+     * @param pattern      the provided by the user pattern
+     * @param baseDir      the calculated base directory
      * @return new calculated pattern based on the provided patern and base directory
      */
     public static String prepareRegexPattern(File workspaceDir, String pattern, String baseDir) {
@@ -233,9 +236,10 @@ public class UploadSpecHelper {
     /**
      * The user can provide pattern that will contain static path (without wildcards) that will become part of the base directory.
      * this method removes the part of the pattern that exists in the base directory.
+     *
      * @param workspaceDir the workspaceDir directory
-     * @param pattern the provided by the user pattern
-     * @param baseDir the calculated base directory
+     * @param pattern      the provided by the user pattern
+     * @param baseDir      the calculated base directory
      * @return new calculated pattern based on the provided patern and base directory
      */
     public static String prepareWildcardPattern(File workspaceDir, String pattern, String baseDir) {
@@ -326,6 +330,7 @@ public class UploadSpecHelper {
 
     /**
      * Remove repository's name from a given Spec's target
+     *
      * @param path target path in Artifactory
      * @return the local path inside the repository
      */
@@ -345,7 +350,7 @@ public class UploadSpecHelper {
      * in case of regexp=true escape chars will be prepended to regex chars in the checkout directory path.
      *
      * @param workspaceDir the workspaceDir directory
-     * @param pattern the provided by the user patter, can be absolute or relative
+     * @param pattern      the provided by the user patter, can be absolute or relative
      * @return the absolute path of pattern
      */
     private static String getRegexpAbsolutePattern(File workspaceDir, String pattern) {
@@ -363,7 +368,7 @@ public class UploadSpecHelper {
      * in case of regexp=true escape chars will be prepended to regex chars in the checkout directory path.
      *
      * @param workspaceDir the workspaceDir directory
-     * @param pattern the provided by the user patter, can be absolute or relative
+     * @param pattern      the provided by the user patter, can be absolute or relative
      * @return the absolute path of pattern
      */
     private static String getWildcardAbsolutePattern(File workspaceDir, String pattern) {
@@ -376,6 +381,7 @@ public class UploadSpecHelper {
 
     /**
      * Returns the last existing directory of the provided baseDire that not contains a regex characters.
+     *
      * @param baseDir the path to search in
      * @return the last existing directory of the provided baseDire that not contains a regex characters
      */
@@ -392,13 +398,13 @@ public class UploadSpecHelper {
     }
 
     private static String removeParenthesis(String baseDir) {
-        baseDir = removeUnescapedChar(baseDir ,"(".charAt(0));
-        baseDir = removeUnescapedChar(baseDir ,")".charAt(0));
+        baseDir = removeUnescapedChar(baseDir, "(".charAt(0));
+        baseDir = removeUnescapedChar(baseDir, ")".charAt(0));
         return baseDir;
     }
 
     private static String escapeParentheses(String path) {
-        return path.replace("(", "\\(").replace(")","\\)");
+        return path.replace("(", "\\(").replace(")", "\\)");
     }
 
     private static String cleanRegexpPattern(String absolutePattern, String baseDir) {
@@ -420,6 +426,7 @@ public class UploadSpecHelper {
      * This method removes parenthesis that was not opened in the string.
      * In other words, every ')' char that has no '(' in front of it (regardless of the text in between them) will be deleted.
      * For example, "aaa)bbb(c(ddd)e)ff)" will return "aaabbb(c(ddd)e)ff".
+     *
      * @param pattern the string to remove from
      * @return string without unopened parenthesis
      */

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/DownloadTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/DownloadTest.java
@@ -2,10 +2,10 @@ package org.jfrog.build.extractor.clientConfiguration.util;
 
 import org.apache.commons.io.FileUtils;
 import org.jfrog.build.IntegrationTestsBase;
-import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.api.dependency.DownloadableArtifact;
 import org.jfrog.build.api.dependency.pattern.PatternType;
 import org.jfrog.build.api.util.FileChecksumCalculator;
+import org.jfrog.build.extractor.ci.Dependency;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.filespecs.FileSpec;
 import org.jfrog.filespecs.entities.FilesGroup;
@@ -23,10 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
 import static org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloaderHelper.ArtifactMetaData;
-import static org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloaderHelper.MD5_ALGORITHM_NAME;
 import static org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloaderHelper.MIN_SIZE_FOR_CONCURRENT_DOWNLOAD;
-import static org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloaderHelper.SHA1_ALGORITHM_NAME;
 
 /**
  * Integration tests for the DependenciesDownloader classes.
@@ -69,8 +69,8 @@ public class DownloadTest extends IntegrationTestsBase {
         }
 
         // Verify the downloaded file.
-        Assert.assertEquals(uploadedChecksum.get(MD5_ALGORITHM_NAME), downloadedChecksum.get(MD5_ALGORITHM_NAME));
-        Assert.assertEquals(uploadedChecksum.get(SHA1_ALGORITHM_NAME), downloadedChecksum.get(SHA1_ALGORITHM_NAME));
+        Assert.assertEquals(uploadedChecksum.get(MD5_ALGORITHM), downloadedChecksum.get(MD5_ALGORITHM));
+        Assert.assertEquals(uploadedChecksum.get(SHA1_ALGORITHM), downloadedChecksum.get(SHA1_ALGORITHM));
     }
 
     @Test(dataProvider = "testDownloadFilesProvider")
@@ -83,15 +83,15 @@ public class DownloadTest extends IntegrationTestsBase {
         String url = repoUrl + "/" + fileName;
 
         ArtifactMetaData artifactMetaData = dependenciesDownloaderHelper.downloadArtifactMetaData(url);
-        Assert.assertEquals(artifactMetaData.getMd5(), uploadedChecksum.get(MD5_ALGORITHM_NAME));
-        Assert.assertEquals(artifactMetaData.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM_NAME));
+        Assert.assertEquals(artifactMetaData.getMd5(), uploadedChecksum.get(MD5_ALGORITHM));
+        Assert.assertEquals(artifactMetaData.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM));
         Assert.assertEquals(artifactMetaData.getSize(), fileSize);
 
         DownloadableArtifact downloadableArtifact = new DownloadableArtifact(repoUrl, targetDirPath, fileName, "", fileName, PatternType.NORMAL);
         Dependency dependency = dependenciesDownloaderHelper.downloadArtifact(downloadableArtifact, artifactMetaData, url, fileName);
         Assert.assertEquals(dependency.getId(), fileName);
-        Assert.assertEquals(dependency.getMd5(), uploadedChecksum.get(MD5_ALGORITHM_NAME));
-        Assert.assertEquals(dependency.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM_NAME));
+        Assert.assertEquals(dependency.getMd5(), uploadedChecksum.get(MD5_ALGORITHM));
+        Assert.assertEquals(dependency.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM));
         Assert.assertEquals((new File(targetDirPath + fileName)).length(), fileSize);
     }
 
@@ -105,16 +105,16 @@ public class DownloadTest extends IntegrationTestsBase {
         String url = repoUrl + "/" + fileName;
 
         ArtifactMetaData artifactMetaData = dependenciesDownloaderHelper.downloadArtifactMetaData(url);
-        Assert.assertEquals(artifactMetaData.getMd5(), uploadedChecksum.get(MD5_ALGORITHM_NAME));
-        Assert.assertEquals(artifactMetaData.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM_NAME));
+        Assert.assertEquals(artifactMetaData.getMd5(), uploadedChecksum.get(MD5_ALGORITHM));
+        Assert.assertEquals(artifactMetaData.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM));
         Assert.assertEquals(artifactMetaData.getSize(), fileSize);
         artifactMetaData.setSize(0); // When content-length is missing
 
         DownloadableArtifact downloadableArtifact = new DownloadableArtifact(repoUrl, targetDirPath, fileName, "", fileName, PatternType.NORMAL);
         Dependency dependency = dependenciesDownloaderHelper.downloadArtifact(downloadableArtifact, artifactMetaData, url, fileName);
         Assert.assertEquals(dependency.getId(), fileName);
-        Assert.assertEquals(dependency.getMd5(), uploadedChecksum.get(MD5_ALGORITHM_NAME));
-        Assert.assertEquals(dependency.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM_NAME));
+        Assert.assertEquals(dependency.getMd5(), uploadedChecksum.get(MD5_ALGORITHM));
+        Assert.assertEquals(dependency.getSha1(), uploadedChecksum.get(SHA1_ALGORITHM));
         Assert.assertEquals((new File(targetDirPath + fileName)).length(), fileSize);
     }
 
@@ -173,14 +173,14 @@ public class DownloadTest extends IntegrationTestsBase {
 
                 // Create file and calculate checksum
                 File file = createRandomFile(tempWorkspace.getPath() + File.pathSeparatorChar + fileName, fileSize);
-                Map<String, String> checksum = FileChecksumCalculator.calculateChecksums(file, SHA1_ALGORITHM_NAME, MD5_ALGORITHM_NAME);
+                Map<String, String> checksum = FileChecksumCalculator.calculateChecksums(file, SHA1_ALGORITHM, MD5_ALGORITHM);
 
                 DeployDetails deployDetails = new DeployDetails.Builder()
                         .file(file)
                         .artifactPath(TEST_REPO_PATH + "/" + fileName)
                         .targetRepository(localRepo1)
-                        .md5(checksum.get(MD5_ALGORITHM_NAME))
-                        .sha1(checksum.get(SHA1_ALGORITHM_NAME))
+                        .md5(checksum.get(MD5_ALGORITHM))
+                        .sha1(checksum.get(SHA1_ALGORITHM))
                         .explode(false)
                         .packageType(DeployDetails.PackageType.GENERIC)
                         .build();

--- a/build.gradle
+++ b/build.gradle
@@ -230,9 +230,9 @@ evaluationDependsOnChildren()
 project('build-info-api') {
     description = 'JFrog Build-Info API'
     dependencies {
+        implementation group: 'software.amazon.cryptools', name: 'AmazonCorrettoCryptoProvider', version: '1.6.1', classifier: 'linux-x86_64'
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5'
-        implementation 'software.amazon.cryptools:AmazonCorrettoCryptoProvider:1.+:linux-x86_64'
         implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,7 @@ project('build-info-api') {
     dependencies {
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5'
+        implementation 'software.amazon.cryptools:AmazonCorrettoCryptoProvider:1.+:linux-x86_64'
         implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

* Add sha256 field in Gradle builds.
* Use global costs for "MD5", "SHA1", and "SHA256".
* Use [Amazon Corretto Crypto Provider](https://github.com/corretto/amazon-corretto-crypto-provider) library to get accelerated checksum calculations on Linux64 machines. In another machines, it will fall back to the default Java-native behavior - see for example https://github.com/corretto/amazon-corretto-crypto-provider/issues/41#issuecomment-738963540