### PR TITLE
Fix missing localPath Info in Artifact/BaseBuildFileBean

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/ArtifactBuilder.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/ArtifactBuilder.java
@@ -40,6 +40,7 @@ public class ArtifactBuilder {
         artifact.setSha1(sha1);
         artifact.setSha256(sha256);
         artifact.setMd5(md5);
+        artifact.setLocalPath(localPath);
         artifact.setRemotePath(remotePath);
         artifact.setProperties(properties);
         return artifact;


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
fixing  https://github.com/jfrog/build-info/issues/603