### PR TITLE
Bugfix - Add missing sha2 on uploaded files

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
@@ -112,6 +112,7 @@ public class SpecsHelper {
             artifactBuilder
                     .md5(detail.getMd5())
                     .sha1(detail.getSha1())
+                    .sha256(detail.getSha256())
                     .type(ext)
                     .localPath(detail.getFile().getAbsolutePath())
                     .remotePath(detail.getArtifactPath())

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 
 import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
 import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.SHA256_ALGORITHM;
 import static org.jfrog.build.extractor.clientConfiguration.util.PathsUtils.removeUnescapedChar;
 
 /**
@@ -47,16 +48,16 @@ public class UploadSpecHelper {
         // calculate the sha1 checksum and add it to the deploy artifactsToDeploy
         Map<String, String> checksums;
         try {
-            checksums = FileChecksumCalculator.calculateChecksums(artifactFile, MD5_ALGORITHM, SHA1_ALGORITHM);
+            checksums = FileChecksumCalculator.calculateChecksums(artifactFile, MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw new NoSuchAlgorithmException(
-                    String.format("Could not find checksum algorithm for %s or %s.", MD5_ALGORITHM, SHA1_ALGORITHM), e);
+                    String.format("Could not find checksum algorithm for %s or %s or %s.", MD5_ALGORITHM, SHA1_ALGORITHM, SHA256_ALGORITHM), e);
         }
         DeployDetails.Builder builder = new DeployDetails.Builder()
                 .file(artifactFile)
                 .artifactPath(path)
                 .targetRepository(getRepositoryKey(uploadTarget))
-                .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM))
+                .md5(checksums.get(MD5_ALGORITHM)).sha1(checksums.get(SHA1_ALGORITHM)).sha256(checksums.get(SHA256_ALGORITHM))
                 .explode(BooleanUtils.toBoolean(explode))
                 .addProperties(SpecsHelper.getPropertiesMap(props))
                 .packageType(DeployDetails.PackageType.GENERIC);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
The sha256 property is missing in the upload command.
Related: https://github.com/jfrog/jenkins-artifactory-plugin/pull/615