### PR TITLE
Gradle - Support insecure TLS

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -249,6 +249,10 @@ public class ArtifactoryClientConfiguration {
         return root.getBooleanValue(PROP_INSECURE_TLS, false);
     }
 
+    public void setInsecureTls(boolean enabled) {
+        root.setBooleanValue(PROP_INSECURE_TLS, enabled);
+    }
+
     public Integer getSocketTimeout() {
         return root.getIntegerValue(PROP_SO_TIMEOUT);
     }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Allow insecureTls configuration in the Gradle Artifactory plugin.

Usage:
```groovy
artifactory {
    clientConfig.insecureTls = true
}
```