### PR TITLE
Verify artifact type limit and add project support for maven

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoBuilder.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoBuilder.java
@@ -414,6 +414,5 @@ public class BuildInfoBuilder {
     public BuildInfoBuilder setProject(String project) {
         this.project = project;
         return this;
-
     }
 }

--- a/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoMavenBuilder.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoMavenBuilder.java
@@ -66,6 +66,16 @@ public class BuildInfoMavenBuilder extends BuildInfoBuilder {
     }
 
     /**
+     * Sets the project of the build
+     *
+     * @param project Build project
+     */
+    public BuildInfoMavenBuilder setProject(String project) {
+        super.setProject(project);
+        return this;
+    }
+
+    /**
      * Sets the agent of the build
      *
      * @param agent Build agent

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -37,6 +37,8 @@ import java.util.function.Predicate;
  */
 public abstract class BuildInfoExtractorUtils {
 
+    private static final int ARTIFACT_TYPE_LENGTH_LIMIT = 64;
+
     public static final Predicate<Object> BUILD_INFO_PREDICATE =
             new PrefixPredicate(BuildInfoProperties.BUILD_INFO_PREFIX);
 
@@ -277,6 +279,10 @@ public abstract class BuildInfoExtractorUtils {
             if (StringUtils.isNotBlank(extension) && !result.endsWith(extension)) {
                 result = result + "-" + extension;
             }
+        }
+         if (result.length() > ARTIFACT_TYPE_LENGTH_LIMIT) {
+             //  Artifactory limit for type length is 64
+            return type;
         }
         return result;
     }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -280,11 +280,8 @@ public abstract class BuildInfoExtractorUtils {
                 result = result + "-" + extension;
             }
         }
-         if (result.length() > ARTIFACT_TYPE_LENGTH_LIMIT) {
-             //  Artifactory limit for type length is 64
-            return type;
-        }
-        return result;
+        // Artifactory limit for type length is 64
+        return result.length() > ARTIFACT_TYPE_LENGTH_LIMIT ? type : result;
     }
 
     public static String getModuleIdString(String organisation, String name, String version) {


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Verify that the artifact type is less than 64 characters.
If it's longer, don't use classifier or extension as type.

Fixing https://github.com/jfrog/artifactory-maven-plugin/issues/29