### PR TITLE
Improve support for Maven projects and fix build-info URL

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoBuilder.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoBuilder.java
@@ -411,7 +411,7 @@ public class BuildInfoBuilder {
         return this;
     }
 
-    public BuildInfoBuilder setProject(String project) {
+    public BuildInfoBuilder project(String project) {
         this.project = project;
         return this;
     }

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -24,8 +24,8 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.BUILD_BROWSE_URL;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.jsonStringToBuildInfo;
-import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.BUILD_BROWSE_URL;
 import static org.jfrog.gradle.plugin.artifactory.Consts.*;
 import static org.testng.Assert.*;
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -10,33 +10,33 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.api.util.CommonUtils;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.BuildInfoConfigProperties;
 import org.jfrog.build.extractor.ci.BuildInfoProperties;
-import org.jfrog.build.api.util.CommonUtils;
-import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.ClientProperties;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Predicate;
 
+import static org.apache.commons.lang3.StringUtils.*;
+import static org.jfrog.build.extractor.clientConfiguration.client.JFrogService.encodeUrl;
+
 /**
  * @author Noam Y. Tenne
  */
 public abstract class BuildInfoExtractorUtils {
 
+    public static final String BUILD_BROWSE_PLATFORM_URL = "/ui/builds";
+    public static final String BUILD_BROWSE_URL = "/webapp/builds";
+    private static final String BUILD_REPO_PARAM = "?buildRepo=";
     private static final int ARTIFACT_TYPE_LENGTH_LIMIT = 64;
 
     public static final Predicate<Object> BUILD_INFO_PREDICATE =
@@ -331,5 +331,84 @@ public abstract class BuildInfoExtractorUtils {
                 }
             }
         }
+    }
+
+    /**
+     * Creates a build info link to the published build. This method is in use also in the Jenkins Artifactory plugin.
+     *
+     * @param url         JFrog Platform or Artifactory URL
+     * @param buildName   Build name of the published build
+     * @param buildNumber Build number of the published build
+     * @param timeStamp   Timestamp (started date time in milliseconds) of the published build
+     * @param project     Project of the published build
+     * @param encode      True if should encode build name and build number
+     * @param platformUrl True if the input url is platform's URL, false if it is Artifactory's URL
+     * @return Link to the published build.
+     */
+    public static String createBuildInfoUrl(String url, String buildName, String buildNumber, String timeStamp,
+                                            String project, boolean encode, boolean platformUrl) {
+        if (platformUrl) {
+            // Platform URL provided. We have everything we need to create the build info URL.
+            return createBuildInfoUrl(url, buildName, buildNumber, timeStamp, project, encode);
+        }
+        if (isNotBlank(project)) {
+            if (endsWith(url, "/artifactory")) {
+                // If the project parameter provided, try to guess the platform URL.
+                return createBuildInfoUrl(removeEnd(url, "/artifactory"), buildName,
+                        buildNumber, timeStamp, project, encode);
+            }
+            // If Artifactory's URL doesn't end with "/artifactory", it is impossible to create the URL.
+            return "";
+        }
+        // Platform URL and project was not provided - use Artifactory 6 style URL
+        return createBuildInfoUrl(url, buildName, buildNumber, encode);
+    }
+
+    /**
+     * Creates a build info link to the published build in JFrog platform (Artifactory V7)
+     *
+     * @param platformUrl - Base platform URL
+     * @param buildName   - Build name of the published build
+     * @param buildNumber - Build number of the published build
+     * @param timeStamp   - Timestamp (started date time in milliseconds) of the published build
+     * @param project     - Build project of the published build
+     * @param encode      - True if should encode build name and build number
+     * @return Link to the published build in JFrog platform e.g. https://myartifactory.com/ui/builds/gradle-cli/1/1619429119501/published?buildRepo=ecosys-build-info
+     */
+    private static String createBuildInfoUrl(String platformUrl, String buildName, String buildNumber, String timeStamp, String project, boolean encode) {
+        if (encode) {
+            buildName = encodeUrl(buildName);
+            buildNumber = encodeUrl(buildNumber);
+        }
+        String timestampUrlPart = isBlank(timeStamp) ? "" : "/" + timeStamp;
+        return String.format("%s/%s/%s%s/%s", platformUrl + BUILD_BROWSE_PLATFORM_URL, buildName, buildNumber,
+                timestampUrlPart, "published" + getBuildRepoQueryParam(project));
+    }
+
+    /**
+     * Return "?buildRepo=<project>-build-info" if project provided or an empty string otherwise.
+     *
+     * @param project - Project of the published build
+     * @return build repo query param or empty string.
+     */
+    private static String getBuildRepoQueryParam(String project) {
+        return isEmpty(project) ? "" : BUILD_REPO_PARAM + encodeUrl(project) + "-build-info";
+    }
+
+    /**
+     * Creates a build info link to the published build in Artifactory (Artifactory V6 or below)
+     *
+     * @param artifactoryUrl - Base Artifactory URL
+     * @param buildName      - Build name of the published build
+     * @param buildNumber    - Build number of the published build
+     * @param encode         - True if should encode build name and build number
+     * @return Link to the published build in Artifactory e.g. https://myartifactory.com/artifactory/webapp/builds/gradle-cli/1
+     */
+    private static String createBuildInfoUrl(String artifactoryUrl, String buildName, String buildNumber, boolean encode) {
+        if (encode) {
+            buildName = encodeUrl(buildName);
+            buildNumber = encodeUrl(buildNumber);
+        }
+        return String.format("%s/%s/%s", artifactoryUrl + BUILD_BROWSE_URL, buildName, buildNumber);
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoBuilder.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoBuilder.java
@@ -1,16 +1,8 @@
 package org.jfrog.build.extractor.builder;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.jfrog.build.api.release.PromotionStatus;
-import org.jfrog.build.extractor.ci.Agent;
-import org.jfrog.build.extractor.ci.BuildAgent;
-import org.jfrog.build.extractor.ci.BuildInfo;
-import org.jfrog.build.extractor.ci.BuildRetention;
-import org.jfrog.build.extractor.ci.Issues;
-import org.jfrog.build.extractor.ci.MatrixParameter;
-import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.extractor.ci.Vcs;
+import org.jfrog.build.extractor.ci.*;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -126,6 +118,17 @@ public class BuildInfoBuilder {
      */
     public BuildInfoBuilder number(String number) {
         this.number = number;
+        return this;
+    }
+
+    /**
+     * Sets the project of the build
+     *
+     * @param project Build project
+     * @return Builder instance
+     */
+    public BuildInfoBuilder project(String project) {
+        this.project = project;
         return this;
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoMavenBuilder.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoMavenBuilder.java
@@ -3,15 +3,7 @@ package org.jfrog.build.extractor.builder;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.release.PromotionStatus;
 import org.jfrog.build.api.util.CommonUtils;
-import org.jfrog.build.extractor.ci.Agent;
-import org.jfrog.build.extractor.ci.Artifact;
-import org.jfrog.build.extractor.ci.BuildAgent;
-import org.jfrog.build.extractor.ci.BuildInfo;
-import org.jfrog.build.extractor.ci.BuildRetention;
-import org.jfrog.build.extractor.ci.Dependency;
-import org.jfrog.build.extractor.ci.Issues;
-import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.extractor.ci.Vcs;
+import org.jfrog.build.extractor.ci.*;
 
 import java.util.Date;
 import java.util.List;
@@ -74,6 +66,17 @@ public class BuildInfoMavenBuilder extends BuildInfoBuilder {
     }
 
     /**
+     * Sets the project of the build
+     *
+     * @param project Build project
+     * @return Builder instance
+     */
+    public BuildInfoMavenBuilder project(String project) {
+        super.project(project);
+        return this;
+    }
+
+    /**
      * Sets the agent of the build
      *
      * @param agent Build agent
@@ -114,6 +117,17 @@ public class BuildInfoMavenBuilder extends BuildInfoBuilder {
      */
     public BuildInfoMavenBuilder startedDate(Date startedDate) {
         super.startedDate(startedDate);
+        return this;
+    }
+
+    /**
+     * Sets the start time in millis of the build
+     *
+     * @param startedMillis Build started time in millis
+     * @return Builder instance
+     */
+    public BuildInfoMavenBuilder startedMillis(long startedMillis) {
+        super.startedMillis(startedMillis);
         return this;
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/BuildInfo.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/BuildInfo.java
@@ -586,7 +586,7 @@ public class BuildInfo extends BaseBuildBean {
     public Build ToBuild() {
         org.jfrog.build.api.builder.BuildInfoBuilder builder = new org.jfrog.build.api.builder.BuildInfoBuilder(name)
                 .number(number)
-                .setProject(project)
+                .project(project)
                 .agent(agent == null ? null : new org.jfrog.build.api.Agent(agent.getName(), agent.getVersion()))
                 .buildAgent(buildAgent == null ? null : new org.jfrog.build.api.BuildAgent(buildAgent.getName(), buildAgent.getVersion()))
                 .started(started)

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetAllBuildNumbers.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetAllBuildNumbers.java
@@ -11,7 +11,7 @@ import org.jfrog.build.extractor.clientConfiguration.client.response.GetAllBuild
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.getProjectQueryParam;
+import static org.jfrog.build.extractor.clientConfiguration.util.UrlUtils.getProjectQueryParam;
 
 public class GetAllBuildNumbers extends JFrogService<GetAllBuildNumbersResponse> {
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetBuildInfo.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetBuildInfo.java
@@ -3,15 +3,15 @@ package org.jfrog.build.extractor.clientConfiguration.client.artifactory.service
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.jfrog.build.api.Build;
-import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.clientConfiguration.client.JFrogService;
 import org.jfrog.build.extractor.clientConfiguration.client.response.GetBuildInfoResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.getProjectQueryParam;
+import static org.jfrog.build.extractor.clientConfiguration.util.UrlUtils.getProjectQueryParam;
 
 public class GetBuildInfo extends JFrogService<BuildInfo> {
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/PublishBuildInfo.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/PublishBuildInfo.java
@@ -1,25 +1,24 @@
 package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.jfrog.build.api.Build;
-import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.JFrogHttpClient;
+import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
 
 import java.io.IOException;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createBuildInfoUrl;
 import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJsonString;
+import static org.jfrog.build.extractor.clientConfiguration.util.UrlUtils.getProjectQueryParam;
 
 public class PublishBuildInfo extends VoidJFrogService {
-    public static final String BUILD_BROWSE_URL = "/webapp/builds";
     private static final String BUILD_REST_URL = "/api/build";
-    public static final String BUILD_BROWSE_PLATFORM_URL = "/ui/builds";
-    private static final String BUILD_PROJECT_PARAM = "?project=";
 
     private final Build build;
     private final String platformUrl;
@@ -29,52 +28,6 @@ public class PublishBuildInfo extends VoidJFrogService {
         super(logger);
         this.build = buildInfo.ToBuild();
         this.platformUrl = platformUrl;
-    }
-
-    public static String getProjectQueryParam(String project, String prefix) {
-        if (StringUtils.isNotEmpty(project)) {
-            return prefix + encodeUrl(project);
-        }
-        return "";
-    }
-
-    public static String getProjectQueryParam(String project) {
-        return getProjectQueryParam(project, BUILD_PROJECT_PARAM);
-    }
-
-    /**
-     * Creates a build info link to the published build in JFrog platform (Artifactory V7)
-     *
-     * @param platformUrl Base platform URL
-     * @param buildName   Build name of the published build
-     * @param buildNumber Build number of the published build
-     * @param timeStamp   Timestamp (started date time in milliseconds) of the published build
-     * @param encode      True if should encode build name and build number
-     * @return Link to the published build in JFrog platform e.g. https://myartifactory.com/ui/builds/gradle-cli/1/1619429119501/published
-     */
-    public static String createBuildInfoUrl(String platformUrl, String buildName, String buildNumber, String timeStamp, String project, boolean encode) {
-        if (encode) {
-            buildName = encodeUrl(buildName);
-            buildNumber = encodeUrl(buildNumber);
-        }
-        return String.format("%s/%s/%s/%s/%s", platformUrl + BUILD_BROWSE_PLATFORM_URL, buildName, buildNumber, timeStamp, "published" + getProjectQueryParam(project));
-    }
-
-    /**
-     * Creates a build info link to the published build in Artifactory (Artifactory V6 or below)
-     *
-     * @param artifactoryUrl Base Artifactory URL
-     * @param buildName      Build name of the published build
-     * @param buildNumber    Build number of the published build
-     * @param encode         True if should encode build name and build number
-     * @return Link to the published build in Artifactory e.g. https://myartifactory.com/artifactory/webapp/builds/gradle-cli/1
-     */
-    public static String createBuildInfoUrl(String artifactoryUrl, String buildName, String buildNumber, boolean encode) {
-        if (encode) {
-            buildName = encodeUrl(buildName);
-            buildNumber = encodeUrl(buildNumber);
-        }
-        return String.format("%s/%s/%s", artifactoryUrl + BUILD_BROWSE_URL, buildName, buildNumber);
     }
 
     @Override
@@ -104,13 +57,16 @@ public class PublishBuildInfo extends VoidJFrogService {
     @Override
     public Void execute(JFrogHttpClient client) throws IOException {
         super.execute(client);
-        String url;
-        if (StringUtils.isNotBlank(platformUrl)) {
-            url = createBuildInfoUrl(platformUrl, build.getName(), build.getNumber(), String.valueOf(build.getStartedMillis()), build.getProject(), true);
+        boolean isPlatformUrl = isNotBlank(platformUrl);
+        String url = isPlatformUrl ? platformUrl : client.getUrl();
+        String buildInfoUrl = createBuildInfoUrl(url, build.getName(), build.getNumber(),
+                String.valueOf(build.getStartedMillis()), build.getProject(), true, isPlatformUrl);
+        if (isNotBlank(buildInfoUrl)) {
+            log.info("Build-info successfully deployed. Browse it in Artifactory under " + buildInfoUrl);
         } else {
-            url = createBuildInfoUrl(client.getUrl(), build.getName(), build.getNumber(), true);
+            log.debug("Couldn't create the build-info URL from Artifactory URL: " + client.getUrl());
+            log.info("Build-info successfully deployed.");
         }
-        log.info("Build-info successfully deployed. Browse it in Artifactory under " + url);
         return result;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SendBuildRetention.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SendBuildRetention.java
@@ -3,14 +3,14 @@ package org.jfrog.build.extractor.clientConfiguration.client.artifactory.service
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
-import org.jfrog.build.extractor.ci.BuildRetention;
 import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.ci.BuildRetention;
 import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
 
 import java.io.IOException;
 
-import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.getProjectQueryParam;
 import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJsonString;
+import static org.jfrog.build.extractor.clientConfiguration.util.UrlUtils.getProjectQueryParam;
 
 public class SendBuildRetention extends VoidJFrogService {
     private static final String RETENTION_REST_URL = "api/build/retention/";

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SendModuleInfo.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SendModuleInfo.java
@@ -5,14 +5,14 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.jfrog.build.api.Build;
-import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
 
 import java.io.IOException;
 
-import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.getProjectQueryParam;
 import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJsonString;
+import static org.jfrog.build.extractor.clientConfiguration.util.UrlUtils.getProjectQueryParam;
 
 public class SendModuleInfo extends VoidJFrogService {
     public static final String APPLICATION_VND_ORG_JFROG_ARTIFACTORY_JSON = "application/vnd.org.jfrog.artifactory+json";

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/StageBuild.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/StageBuild.java
@@ -12,8 +12,8 @@ import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
 
 import java.io.IOException;
 
-import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.PublishBuildInfo.getProjectQueryParam;
 import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJsonString;
+import static org.jfrog.build.extractor.clientConfiguration.util.UrlUtils.getProjectQueryParam;
 
 public class StageBuild extends VoidJFrogService {
     private static final String BUILD_STAGING_STRATEGY_ENDPOINT = "api/build/promote/";

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/UrlUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/UrlUtils.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.jfrog.build.extractor.clientConfiguration.client.JFrogService.encodeUrl;
 
 /**
@@ -15,6 +16,7 @@ import static org.jfrog.build.extractor.clientConfiguration.client.JFrogService.
 public class UrlUtils {
 
     private static final Pattern CREDENTIALS_IN_URL_REGEX = Pattern.compile("(http|https|git)://.+@");
+    private static final String BUILD_PROJECT_PARAM = "?project=";
 
     /**
      * Remove URL credentials information from a given line (log, URL...).
@@ -52,5 +54,26 @@ public class UrlUtils {
                 }
             }
         }
+    }
+
+    /**
+     * Get the project REST query parameter or an empty string, if project is blank.
+     *
+     * @param project - The project key
+     * @param prefix  - The query param prefix
+     * @return the project REST query parameter or an empty string.
+     */
+    public static String getProjectQueryParam(String project, String prefix) {
+        return isEmpty(project) ? "" : prefix + encodeUrl(project);
+    }
+
+    /**
+     * Get the project REST query parameter or an empty string, if project is blank.
+     *
+     * @param project - The project key
+     * @return the project REST query parameter or an empty string.
+     */
+    public static String getProjectQueryParam(String project) {
+        return getProjectQueryParam(project, BUILD_PROJECT_PARAM);
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix https://github.com/jfrog/jenkins-artifactory-plugin/issues/576
Fix https://github.com/jfrog/jenkins-artifactory-plugin/issues/611

To support using build projects in Maven UI jobs in Jenkins Artifactory plugin, this PR does the following:
* Add the project in BuildInfoModelPropertyResolver.
* Fix the created build-info URL when using projects in all cases.
  *  If Artifactory's URL and the project key were provided, the `createBuildInfoUrl` will try to guess the platform URL from Artifactory URL.
  * The URL contained `?project=<project-key>` query param instead of `?buildRepo=<project-key>-build-info` param.