### PR TITLE
Filter out unused dependencies in Go builds

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -35,16 +35,16 @@ public class GoDriver implements Serializable {
         this.logger = logger;
     }
 
-    public CommandResults runCmd(String args, boolean prompt) throws IOException {
+    public CommandResults runCmd(String args, boolean verbose) throws IOException {
         List<String> argsList = new ArrayList<>(Arrays.asList(args.split(" ")));
-        return runCmd(argsList, prompt);
+        return runCmd(argsList, verbose);
     }
 
     /**
      * Run go client cmd with goArs.
      * Write stdout + stderr to logger, and return the command's result.
      */
-    public CommandResults runCmd(List<String> args, boolean prompt) throws IOException {
+    public CommandResults runCmd(List<String> args, boolean verbose) throws IOException {
         CommandResults goCmdResult;
         try {
             goCmdResult = commandExecutor.exeCommand(workingDirectory, args, null, logger);
@@ -55,7 +55,7 @@ public class GoDriver implements Serializable {
         if (!goCmdResult.isOk()) {
             throw new IOException(goCmdResult.getErr());
         }
-        if (prompt) {
+        if (verbose) {
             logger.info(goCmdResult.getErr() + goCmdResult.getRes());
         }
         return goCmdResult;
@@ -71,16 +71,24 @@ public class GoDriver implements Serializable {
         }
     }
 
-    public CommandResults version(boolean prompt) throws IOException {
-        return runCmd(GO_VERSION_CMD, prompt);
+    public CommandResults version(boolean verbose) throws IOException {
+        return runCmd(GO_VERSION_CMD, verbose);
     }
 
-    public CommandResults modGraph(boolean prompt) throws IOException {
-        return runCmd(GO_MOD_GRAPH_CMD, prompt);
+    /**
+     * Run go mod graph.
+     * The output format is:
+     * * For direct dependencies:
+     * <module-name> <dependency's-module-name>@v<dependency-module-version>
+     * * For transitive dependencies:
+     * <dependency's-module-name>@v<dependency-module-version> <dependency's-module-name>@v<dependency-module-version>
+     */
+    public CommandResults modGraph(boolean verbose) throws IOException {
+        return runCmd(GO_MOD_GRAPH_CMD, verbose);
     }
 
-    public void modTidy(boolean prompt) throws IOException {
-        runCmd(GO_MOD_TIDY_CMD, prompt);
+    public void modTidy(boolean verbose) throws IOException {
+        runCmd(GO_MOD_TIDY_CMD, verbose);
     }
 
     public CommandResults getUsedModules(boolean prompt, boolean ignoreErrors) throws IOException {

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoDependencyTree.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoDependencyTree.java
@@ -1,0 +1,124 @@
+package org.jfrog.build.extractor.go.extractor;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.executor.CommandResults;
+import org.jfrog.build.extractor.go.GoDriver;
+import org.jfrog.build.extractor.scan.DependencyTree;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * @author yahavi
+ **/
+public class GoDependencyTree {
+
+    /**
+     * Create Go dependency tree of actually used dependencies.
+     *
+     * @param goDriver - Go driver
+     * @param logger   - The logger
+     * @param verbose  - verbose logging
+     * @return Go dependency tree
+     * @throws IOException in case of any I/O error.
+     */
+    public static DependencyTree createDependencyTree(GoDriver goDriver, Log logger, boolean verbose) throws IOException {
+        // Run go mod graph.
+        CommandResults goGraphResult = goDriver.modGraph(verbose);
+        String[] dependenciesGraph = goGraphResult.getRes().split("\\r?\\n");
+
+        // Run go list -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all
+        CommandResults usedModulesResults;
+        try {
+            usedModulesResults = goDriver.getUsedModules(false, false);
+        } catch (IOException e) {
+            // Errors occurred during running "go list". Run again and this time ignore errors.
+            usedModulesResults = goDriver.getUsedModules(false, true);
+            logger.warn("Errors occurred during building the Go dependency tree. The dependency tree may be incomplete:" +
+                    System.lineSeparator() + ExceptionUtils.getRootCauseMessage(e));
+        }
+        Set<String> usedDependencies = Arrays.stream(usedModulesResults.getRes().split("\\r?\\n"))
+                .map(String::trim)
+                .map(usedModule -> usedModule.replace(" ", "@"))
+                .collect(Collectors.toSet());
+
+        // Create root node.
+        String rootPackageName = goDriver.getModuleName();
+        DependencyTree rootNode = new DependencyTree(rootPackageName);
+        rootNode.setMetadata(true);
+
+        // Build dependency tree.
+        Map<String, List<String>> dependenciesMap = new HashMap<>();
+        populateDependenciesMap(dependenciesGraph, usedDependencies, dependenciesMap);
+        populateDependencyTree(rootNode, rootPackageName, dependenciesMap, logger);
+
+        return rootNode;
+    }
+
+    /**
+     * Populate the parent to children map with dependencies which are actually in use in the project.
+     *
+     * @param dependenciesGraph - Results of "go mod graph"
+     * @param usedDependencies  - Results of "go list -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all"
+     * @param dependenciesMap   - Dependencies parent to children map results
+     */
+    private static void populateDependenciesMap(String[] dependenciesGraph, Set<String> usedDependencies, Map<String, List<String>> dependenciesMap) {
+        for (String entry : dependenciesGraph) {
+            if (StringUtils.isAllBlank(entry)) {
+                continue;
+            }
+            String[] parsedEntry = entry.split("\\s");
+            if (!usedDependencies.contains(parsedEntry[1])) {
+                // Module is not in use
+                continue;
+            }
+            List<String> pkgDeps = dependenciesMap.computeIfAbsent(parsedEntry[0], k -> new ArrayList<>());
+            pkgDeps.add(parsedEntry[1]);
+        }
+    }
+
+    /**
+     * Recursively populate the dependency tree.
+     *
+     * @param currNode              - The current node
+     * @param currNameVersionString - Current dependency in form of <name>@v<version>
+     * @param allDependencies       - Dependency to children map
+     * @param logger                - The logger
+     */
+    private static void populateDependencyTree(DependencyTree currNode, String currNameVersionString,
+                                               Map<String, List<String>> allDependencies, Log logger) {
+        if (hasLoop(currNode, logger)) {
+            return;
+        }
+        List<String> currDependencies = allDependencies.get(currNameVersionString);
+        if (currDependencies == null) {
+            return;
+        }
+        for (String dependency : currDependencies) {
+            String[] dependencyNameVersion = dependency.split("@v");
+            DependencyTree DependencyTree = new DependencyTree(dependencyNameVersion[0] + ":" + dependencyNameVersion[1]);
+            currNode.add(DependencyTree);
+            populateDependencyTree(DependencyTree, dependency, allDependencies, logger);
+        }
+    }
+
+    /**
+     * Return true if the node contains a loop.
+     *
+     * @param node - The dependency tree node
+     * @return true if the node contains a loop
+     */
+    private static boolean hasLoop(DependencyTree node, Log logger) {
+        for (DependencyTree parent = (DependencyTree) node.getParent(); parent != null; parent = (DependencyTree) parent.getParent()) {
+            if (Objects.equals(node.getUserObject(), parent.getUserObject())) {
+                logger.debug("Loop detected in " + node.getUserObject());
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoDependencyTree.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoDependencyTree.java
@@ -120,5 +120,4 @@ public class GoDependencyTree {
         }
         return false;
     }
-
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Run `go list -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all` to filter unused dependencies in Go builds.
Most of the code copied from https://github.com/jfrog/ide-plugins-common/blob/1.11.0/src/main/java/com/jfrog/ide/common/go/GoTreeBuilder.java#L103. After the release we should delete duplicated code in ide-plugins-common.