### PR TITLE
Move hasLoop to DependencyTree.java

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoDependencyTree.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoDependencyTree.java
@@ -90,7 +90,7 @@ public class GoDependencyTree {
      */
     private static void populateDependencyTree(DependencyTree currNode, String currNameVersionString,
                                                Map<String, List<String>> allDependencies, Log logger) {
-        if (hasLoop(currNode, logger)) {
+        if (currNode.hasLoop(logger)) {
             return;
         }
         List<String> currDependencies = allDependencies.get(currNameVersionString);
@@ -103,21 +103,5 @@ public class GoDependencyTree {
             currNode.add(DependencyTree);
             populateDependencyTree(DependencyTree, dependency, allDependencies, logger);
         }
-    }
-
-    /**
-     * Return true if the node contains a loop.
-     *
-     * @param node - The dependency tree node
-     * @return true if the node contains a loop
-     */
-    private static boolean hasLoop(DependencyTree node, Log logger) {
-        for (DependencyTree parent = (DependencyTree) node.getParent(); parent != null; parent = (DependencyTree) parent.getParent()) {
-            if (Objects.equals(node.getUserObject(), parent.getUserObject())) {
-                logger.debug("Loop detected in " + node.getUserObject());
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
@@ -3,6 +3,7 @@ package org.jfrog.build.extractor.scan;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.api.util.Log;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.util.*;
@@ -229,5 +230,21 @@ public class DependencyTree extends DefaultMutableTreeNode {
                 .filter(Objects::nonNull)
                 .findAny()
                 .orElse(null);
+    }
+
+    /**
+     * Return true if the node contains a loop.
+     *
+     * @param logger - The logger
+     * @return true if the node contains a loop
+     */
+    public boolean hasLoop(Log logger) {
+        for (DependencyTree parent = (DependencyTree) getParent(); parent != null; parent = (DependencyTree) parent.getParent()) {
+            if (Objects.equals(getUserObject(), parent.getUserObject())) {
+                logger.debug("Loop detected in " + getUserObject());
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
@@ -2,6 +2,7 @@ package org.jfrog.build.extractor.scan;
 
 import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.compress.utils.Sets;
+import org.jfrog.build.api.util.NullLog;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -202,6 +203,24 @@ public class DependencyTreeTest {
         assertNotNull(root.find("4"));
         assertNotNull(root.find("5"));
         assertNull(root.find("non-existent"));
+    }
+
+    @Test
+    public void testHasLoop() {
+        // Make sure the test dependency doesn't have loops
+        assertFalse(root.hasLoop(new NullLog()));
+
+        // Build a dependency tree with a loop: 1 -> 2 -> 3 -> 1
+        DependencyTree one = new DependencyTree("1");
+        DependencyTree two = new DependencyTree("2");
+        DependencyTree three = new DependencyTree("3");
+        DependencyTree anotherOne = new DependencyTree("1");
+        one.add(two);
+        two.add(three);
+        three.add(anotherOne);
+
+        // Make sure the dependency tree has a loop
+        assertTrue(anotherOne.hasLoop(new NullLog()));
     }
 
     /**


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Move `hasLoop` to DependencyTree.java in order to reuse it in the Intellij IDEA plugin.