### PR TITLE
Configure proxy when publishing build info

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/DeployTask.java
@@ -130,6 +130,7 @@ public class DeployTask extends DefaultTask {
                     accRoot.publisher.getPassword(),
                     new GradleClientLogger(log))) {
 
+                configureProxy(accRoot, artifactoryManager);
                 if (isPublishBuildInfo(accRoot)) {
                     // If export property set always save the file before sending it to artifactory
                     exportBuildInfo(buildInfo, getExportFile(accRoot));


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Resolves #628 