### PR TITLE
Bugfix - Limit 'mvn deploy' to work with only install/deploy phases

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -52,6 +52,8 @@ import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getModuleIdString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getTypeString;
 import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.addDefaultPublisherAttributes;
+import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.PUBLISH_ARTIFACTS;
+import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.PUBLISH_BUILD_INFO;
 
 /**
  * Will be called for every project/module in the Maven project.
@@ -739,10 +741,13 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             event.getSession().getUserProperties().put("maven.deploy.skip", Boolean.TRUE.toString());
             return;
         }
-        // Skip the artifact deployment behavior if the goals do not contain install phases.
+        // Skip the artifact deployment behavior if the goals do not contain install or deploy phases.
         if (!goals.contains("install")) {
             conf.publisher.setPublishArtifacts(false);
             conf.publisher.setPublishBuildInfo(false);
+
+            conf.publisher.setLegacyBooleanValue(PUBLISH_ARTIFACTS, false);
+            conf.publisher.setLegacyBooleanValue(PUBLISH_BUILD_INFO, false);
         }
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PrefixPropertyHandler.java
@@ -79,6 +79,14 @@ public class PrefixPropertyHandler {
         }
     }
 
+    public void setLegacyBooleanValue(String key, Boolean value) {
+        if (value == null) {
+            props.remove(getDeprecatedPrefix() + key);
+        } else {
+            props.put(getDeprecatedPrefix() + key, value.toString());
+        }
+    }
+
     public Integer getIntegerValue(String key) {
         return getIntegerValue(key, null);
     }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Followup #626 

**Unreleased bug**: `getBooleanValue` reads first the legacy values and then the new values. To limit Maven deployment to install and deploy phases we should override the legacy values too.