### PR TITLE
When project provided, add projectKey to build info URL

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -37,7 +37,7 @@ public abstract class BuildInfoExtractorUtils {
 
     public static final String BUILD_BROWSE_PLATFORM_URL = "/ui/builds";
     public static final String BUILD_BROWSE_URL = "/webapp/builds";
-    private static final String BUILD_REPO_PARAM = "?buildRepo=";
+    private static final String BUILD_REPO_PARAM_PATTERN = "?buildRepo=%s-build-info&projectKey=%s";
     private static final int ARTIFACT_TYPE_LENGTH_LIMIT = 64;
 
     public static final Predicate<Object> BUILD_INFO_PREDICATE =
@@ -374,7 +374,7 @@ public abstract class BuildInfoExtractorUtils {
      * @param timeStamp   - Timestamp (started date time in milliseconds) of the published build
      * @param project     - Build project of the published build
      * @param encode      - True if should encode build name and build number
-     * @return Link to the published build in JFrog platform e.g. https://myartifactory.com/ui/builds/gradle-cli/1/1619429119501/published?buildRepo=ecosys-build-info
+     * @return Link to the published build in JFrog platform e.g. https://myartifactory.com/ui/builds/gradle-cli/1/1619429119501/published?buildRepo=ecosys-build-info&projectKey=ecosys
      */
     private static String createBuildInfoUrl(String platformUrl, String buildName, String buildNumber, String timeStamp, String project, boolean encode) {
         if (encode) {
@@ -393,7 +393,11 @@ public abstract class BuildInfoExtractorUtils {
      * @return build repo query param or empty string.
      */
     private static String getBuildRepoQueryParam(String project) {
-        return isEmpty(project) ? "" : BUILD_REPO_PARAM + encodeUrl(project) + "-build-info";
+        if (isEmpty(project)) {
+            return "";
+        }
+        String encodedProject = encodeUrl(project);
+        return String.format(BUILD_REPO_PARAM_PATTERN, encodedProject, encodedProject);
     }
 
     /**

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -226,24 +226,24 @@ public class BuildExtractorUtilsTest {
         return new Object[][]{
                 // Platform URL - encoding
                 {"http://127.0.0.1", "na me", "1 2", "123456", "", true, true, "http://127.0.0.1/ui/builds/na%20me/1%202/123456/published"},
-                {"http://127.0.0.1", "na me", "1 2", "123456", "proj", true, true, "http://127.0.0.1/ui/builds/na%20me/1%202/123456/published?buildRepo=proj-build-info"},
+                {"http://127.0.0.1", "na me", "1 2", "123456", "proj", true, true, "http://127.0.0.1/ui/builds/na%20me/1%202/123456/published?buildRepo=proj-build-info&projectKey=proj"},
                 {"http://127.0.0.1", "na me", "1 2", "", "", true, true, "http://127.0.0.1/ui/builds/na%20me/1%202/published"},
 
                 // Platform URL - no encoding
                 {"http://127.0.0.1", "na me", "1 2", "123456", "", false, true, "http://127.0.0.1/ui/builds/na me/1 2/123456/published"},
-                {"http://127.0.0.1", "na me", "1 2", "123456", "proj", false, true, "http://127.0.0.1/ui/builds/na me/1 2/123456/published?buildRepo=proj-build-info"},
+                {"http://127.0.0.1", "na me", "1 2", "123456", "proj", false, true, "http://127.0.0.1/ui/builds/na me/1 2/123456/published?buildRepo=proj-build-info&projectKey=proj"},
                 {"http://127.0.0.1", "na me", "1 2", "", "", false, true, "http://127.0.0.1/ui/builds/na me/1 2/published"},
 
                 // Artifactory URL - encoding
                 {"http://127.0.0.1/artifactory", "na me", "1 2", "123456", "", true, false, "http://127.0.0.1/artifactory/webapp/builds/na%20me/1%202"},
-                {"http://127.0.0.1/artifactory", "na me", "1 2", "123456", "proj", true, false, "http://127.0.0.1/ui/builds/na%20me/1%202/123456/published?buildRepo=proj-build-info"},
+                {"http://127.0.0.1/artifactory", "na me", "1 2", "123456", "proj", true, false, "http://127.0.0.1/ui/builds/na%20me/1%202/123456/published?buildRepo=proj-build-info&projectKey=proj"},
                 {"http://127.0.0.1/artifactory", "na me", "1 2", "", "", true, false, "http://127.0.0.1/artifactory/webapp/builds/na%20me/1%202"},
                 {"http://127.0.0.1/non-artifactory", "na me", "1 2", "123456", "", true, false, "http://127.0.0.1/non-artifactory/webapp/builds/na%20me/1%202"},
                 {"http://127.0.0.1/non-artifactory", "na me", "1 2", "123456", "proj", true, false, ""},
 
                 // Artifactory URL - no encoding
                 {"http://127.0.0.1/artifactory", "na me", "1 2", "123456", "", false, false, "http://127.0.0.1/artifactory/webapp/builds/na me/1 2"},
-                {"http://127.0.0.1/artifactory", "na me", "1 2", "123456", "proj", false, false, "http://127.0.0.1/ui/builds/na me/1 2/123456/published?buildRepo=proj-build-info"},
+                {"http://127.0.0.1/artifactory", "na me", "1 2", "123456", "proj", false, false, "http://127.0.0.1/ui/builds/na me/1 2/123456/published?buildRepo=proj-build-info&projectKey=proj"},
                 {"http://127.0.0.1/artifactory", "na me", "1 2", "", "", false, false, "http://127.0.0.1/artifactory/webapp/builds/na me/1 2"},
                 {"http://127.0.0.1/non-artifactory", "na me", "1 2", "123456", "", false, false, "http://127.0.0.1/non-artifactory/webapp/builds/na me/1 2"},
                 {"http://127.0.0.1/non-artifactory", "na me", "1 2", "123456", "proj", false, false, ""},


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

The build info URL for a given platform URL should be:
`https://myartifactory.com/ui/builds/<build-name>/<build-number>/<timestamp>/published?buildRepo=<project-key>-build-info&projectKey=<project-key>`

However, currently it is:
`https://myartifactory.com/ui/builds/<build-name>/<build-number>/<timestamp>/published?buildRepo=<project-key>-build-info`