### PR TITLE
Remove warning about missing branch

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/GitUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/GitUtils.java
@@ -188,7 +188,7 @@ public class GitUtils {
             String[] splitArr = revisionOrRef.ref.split("/");
             return splitArr[splitArr.length - 1];
         }
-        log.warn("Failed fetching git branch from git directory: " + dotGit);
+        log.debug("Failed fetching git branch from git directory: " + dotGit + ". Might be in detached head.");
         return "";
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
When checking out to a specific hash and reaching a "detached head" state, there is no actual branch to be found. This commit changes the warning to a debug log.