### PR TITLE
Allow ignoring errors in "go mod tidy"

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -19,9 +19,9 @@ import java.util.Map;
 public class GoDriver implements Serializable {
     private static final List<String> GO_LIST_USED_MODULES_CMD =
             Arrays.asList("list", "-f", "\"{{with .Module}}{{.Path}} {{.Version}}{{end}}\"", "all");
+    private static final List<String> GO_MOD_TIDY_CMD = Arrays.asList("mod", "tidy");
     private static final String GO_MOD_GRAPH_CMD = "mod graph";
     private static final String GO_LIST_MODULE_CMD = "list -m";
-    private static final String GO_MOD_TIDY_CMD = "mod tidy";
     private static final String GO_VERSION_CMD = "version";
 
     private static final long serialVersionUID = 1L;
@@ -82,21 +82,46 @@ public class GoDriver implements Serializable {
      * [module-name] [dependency's-module-name]@v[dependency-module-version]
      * * For transitive dependencies:
      * [dependency's-module-name]@v[dependency-module-version] [dependency's-module-name]@v[dependency-module-version]
+     *
+     * @param verbose - True if should print the results to the log
+     * @throws IOException - in case of any I/O error.
      */
     public CommandResults modGraph(boolean verbose) throws IOException {
         return runCmd(GO_MOD_GRAPH_CMD, verbose);
     }
 
-    public void modTidy(boolean verbose) throws IOException {
-        runCmd(GO_MOD_TIDY_CMD, verbose);
+    /**
+     * If ignoreErrors=false, run: go mod tidy
+     * If ignoreErrors=true, run: go mod tidy -e
+     *
+     * @param verbose      - True if should print the results to the log
+     * @param ignoreErrors - True if errors should be ignored
+     * @throws IOException - in case of any I/O error.
+     */
+    public void modTidy(boolean verbose, boolean ignoreErrors) throws IOException {
+        List<String> argsList = new ArrayList<>(GO_MOD_TIDY_CMD);
+        if (ignoreErrors) {
+            argsList.add("-e");
+        }
+        runCmd(argsList, verbose);
     }
 
-    public CommandResults getUsedModules(boolean prompt, boolean ignoreErrors) throws IOException {
+    /**
+     * If ignoreErrors=false, run:
+     * go list -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all
+     * If ignoreErrors=false, run:
+     * go list -e -f "{{with .Module}}{{.Path}} {{.Version}}{{end}}" all
+     *
+     * @param verbose      - True if should print the results to the log
+     * @param ignoreErrors - True if errors should be ignored
+     * @throws IOException - in case of any I/O error.
+     */
+    public CommandResults getUsedModules(boolean verbose, boolean ignoreErrors) throws IOException {
         List<String> argsList = new ArrayList<>(GO_LIST_USED_MODULES_CMD);
         if (ignoreErrors) {
             argsList.add(1, "-e");
         }
-        return runCmd(argsList, prompt);
+        return runCmd(argsList, verbose);
     }
 
     public String getModuleName() throws IOException {

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -31,6 +31,11 @@ public class GoDriverTest {
             "golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c",
             "rsc.io/quote v1.5.2");
 
+    /**
+     * Test "go mod tidy" and "go list".
+     *
+     * @throws IOException in case of any I/O exception.
+     */
     @Test
     public void testTidyListUsedModules() throws IOException {
         File projectDir = Files.createTempDirectory("").toFile();
@@ -57,6 +62,11 @@ public class GoDriverTest {
         }
     }
 
+    /**
+     * Test "go mod tidy" and "go list" on a project with errors.
+     *
+     * @throws IOException in case of any I/O exception.
+     */
     @Test
     public void testTidyListUsedModulesErroneous() throws IOException {
         File projectDir = Files.createTempDirectory("").toFile();

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.executor.CommandResults;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -21,20 +22,22 @@ import static org.testng.Assert.assertEquals;
  * @author yahavi
  **/
 public class GoDriverTest {
-    private static final Path PROJECT_ORIGIN = Paths.get(".").toAbsolutePath().normalize()
-            .resolve(Paths.get("src", "test", "resources", "org", "jfrog", "build", "extractor", "project1"));
+    private static final Path BASE_PATH = Paths.get(".").toAbsolutePath().normalize()
+            .resolve(Paths.get("src", "test", "resources", "org", "jfrog", "build", "extractor"));
+    private static final Path PROJECT_1 = BASE_PATH.resolve("project1");
+    private static final Path ERRONEOUS = BASE_PATH.resolve("project1-err");
     private static final Set<String> EXPECTED_USED_MODULES = Sets.newHashSet("github.com/jfrog/dependency",
             "rsc.io/sampler v1.3.0",
             "golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c",
             "rsc.io/quote v1.5.2");
 
     @Test
-    public void testListUsedModules() throws IOException {
+    public void testTidyListUsedModules() throws IOException {
         File projectDir = Files.createTempDirectory("").toFile();
         try {
-            FileUtils.copyDirectory(PROJECT_ORIGIN.toFile(), projectDir);
+            FileUtils.copyDirectory(PROJECT_1.toFile(), projectDir);
             GoDriver driver = new GoDriver(null, System.getenv(), projectDir, new NullLog());
-            driver.modTidy(false);
+            driver.modTidy(false, false);
 
             // Run "go list -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
             CommandResults results = driver.getUsedModules(false, false);
@@ -46,6 +49,29 @@ public class GoDriverTest {
             // Run "go list -e -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
             results = driver.getUsedModules(false, true);
             actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n"))
+                    .map(String::trim)
+                    .collect(Collectors.toSet());
+            assertEquals(actualUsedModules, EXPECTED_USED_MODULES);
+        } finally {
+            FileUtils.deleteDirectory(projectDir);
+        }
+    }
+
+    @Test
+    public void testTidyListUsedModulesErroneous() throws IOException {
+        File projectDir = Files.createTempDirectory("").toFile();
+        try {
+            FileUtils.copyDirectory(ERRONEOUS.toFile(), projectDir);
+            GoDriver driver = new GoDriver(null, System.getenv(), projectDir, new NullLog());
+            Assert.assertThrows(() -> driver.modTidy(false, false));
+            driver.modTidy(false, true);
+
+            // Run "go list -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
+            Assert.assertThrows(() -> driver.getUsedModules(false, false));
+
+            // Run "go list -e -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
+            CommandResults results = driver.getUsedModules(false, true);
+            Set<String> actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n"))
                     .map(String::trim)
                     .collect(Collectors.toSet());
             assertEquals(actualUsedModules, EXPECTED_USED_MODULES);

--- a/build-info-extractor-go/src/test/resources/org/jfrog/build/extractor/project1-err/go.mod
+++ b/build-info-extractor-go/src/test/resources/org/jfrog/build/extractor/project1-err/go.mod
@@ -1,0 +1,10 @@
+module github.com/jfrog/dependency
+
+go 1.17
+
+require rsc.io/quote v1.5.2
+
+require (
+	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+	rsc.io/sampler v1.3.0 // indirect
+)

--- a/build-info-extractor-go/src/test/resources/org/jfrog/build/extractor/project1-err/main.go
+++ b/build-info-extractor-go/src/test/resources/org/jfrog/build/extractor/project1-err/main.go
@@ -1,0 +1,12 @@
+package erroneous
+
+import (
+	nonExist "127.0.0.1/non-exist"
+	"fmt"
+	"rsc.io/quote"
+)
+
+func PrintHello() {
+	fmt.Println(quote.Hello())
+	nonExist.hello()
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolves https://github.com/jfrog/jfrog-idea-plugin/issues/208

Allow adding `-e` parameter to `go mod tidy`.