### PR TITLE
Bugfix - Use the correct plugins endpoints

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ExecuteUserPlugin.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ExecuteUserPlugin.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import static org.jfrog.build.extractor.UrlUtils.appendParamsToUrl;
 
 public class ExecuteUserPlugin extends VoidJFrogService {
-    public static final String EXECUTE_USER_PLUGIN_ENDPOINT = "api/storage/";
+    public static final String EXECUTE_USER_PLUGIN_ENDPOINT = "api/plugins/execute/";
 
     private final String executionName;
     private final Map<String, String> requestParams;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetUserPluginInfo.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/GetUserPluginInfo.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 public class GetUserPluginInfo extends JFrogService<Map<String, List<Map>>> {
-    public static final String USER_PLUGIN_ENDPOINT = "api/storage/";
+    public static final String USER_PLUGIN_ENDPOINT = "api/plugins/";
 
     @SuppressWarnings("unchecked")
     public GetUserPluginInfo(Log log) {


### PR DESCRIPTION
This wrong endpoints seem to have been used since
67cefb286471634b88e104efe2543ad088010471.

https://github.com/jfrog/jenkins-artifactory-plugin/issues/659

- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
