### PR TITLE
Fix compilation by using plugin-publish-plugin major 0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         dependencies {
-            classpath "com.gradle.publish:plugin-publish-plugin:+"
+            classpath "com.gradle.publish:plugin-publish-plugin:0.+"
             classpath "io.github.gradle-nexus:publish-plugin:+"
             classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.24.5"
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
[com.gradle.plugin-publish:1.0.0-rc-1](https://plugins.gradle.org/plugin/com.gradle.plugin-publish/1.0.0-rc-1) contains some breaking changes. Since this is a release-candidate and not an official release, we should stick with major 0 for now.