### PR TITLE
Fix Docker Manifest path for collecting build-info

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
@@ -256,17 +256,19 @@ public class DockerUtils {
     }
 
     /**
-     * @param imagePath - path to an image in artifactory without proxy e.g. image/image-tag.
+     * @param imagePath - path to an image in artifactory without proxy e.g. hello-world/latest.
      * @param repo      - The repository to use for searching.
      * @param cmd       - docker push cmd/ docker pull cmd.
      * @return All possible paths in Artifactory in order to find image manifest using proxy.
      */
     public static List<String> getArtManifestPath(String imagePath, String repo, CommandType cmd) {
         ArrayList<String> paths = new ArrayList<>();
-        // Assuming reverse proxy e.g. ecosysjfrog-docker-local.jfrog.io.
+        // If the docker tag is reverse proxy, e.g. ecosysjfrog-docker-local.jfrog.io/hello-world:latest
+        // then the correct path is: repo = docker-local, imagePath = hello-world:latest
         paths.add(repo + "/" + imagePath);
 
-        // Assuming proxy-less e.g. orgab.jfrog.team/docker-local.
+        // If the docker tag is proxy-less e.g. orgab.jfrog.team/docker-local/hello-world:latest
+        // hen the correct path is: imagePath = docker-local/hello-world/latest
         paths.add(imagePath);
 
         int totalSlash = org.apache.commons.lang3.StringUtils.countMatches(imagePath, "/");

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerUtils.java
@@ -256,9 +256,9 @@ public class DockerUtils {
     }
 
     /**
-     * @param imagePath - path to an image in artifactory without proxy e.g. image/image-tag
-     * @param repo      - target repo to search
-     * @param cmd       - docker push cmd/ docker pull cmd
+     * @param imagePath - path to an image in artifactory without proxy e.g. image/image-tag.
+     * @param repo      - The repository to use for searching.
+     * @param cmd       - docker push cmd/ docker pull cmd.
      * @return All possible paths in Artifactory in order to find image manifest using proxy.
      */
     public static List<String> getArtManifestPath(String imagePath, String repo, CommandType cmd) {
@@ -277,7 +277,7 @@ public class DockerUtils {
         paths.add(repo + "/library/" + imagePath);
 
         // Assume proxy-less - this time with 'library' as part of the path.
-        int secondSlash = StringUtils.ordinalIndexOf(imagePath, "/", 2);
+        int secondSlash = StringUtils.ordinalIndexOf(imagePath, "/", 1);
         paths.add(repo + "/library/" + imagePath.substring(secondSlash + 1));
 
         return paths;

--- a/build-info-extractor-docker/src/test/java/org/jfrog/build/extractor/docker/extractor/DockerUtilsTest.java
+++ b/build-info-extractor-docker/src/test/java/org/jfrog/build/extractor/docker/extractor/DockerUtilsTest.java
@@ -1,0 +1,26 @@
+package org.jfrog.build.extractor.docker.extractor;
+
+import org.jfrog.build.extractor.docker.DockerUtils;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.testng.Assert.assertEqualsNoOrder;
+
+@Test
+public class DockerUtilsTest {
+    @Test
+    public void getArtManifestPathTest() {
+        String ImagePath = "hello-world:latest";
+        String repository = "docker-local";
+        DockerUtils.CommandType cmdType = DockerUtils.CommandType.Push;
+        List<String> results = DockerUtils.getArtManifestPath(ImagePath, repository, cmdType);
+        assertEqualsNoOrder(results.toArray(), Stream.of("docker-local/hello-world:latest", "hello-world:latest").toArray());
+
+        cmdType = DockerUtils.CommandType.Pull;
+        ImagePath = "docker-local/hello-world:latest";
+        results = DockerUtils.getArtManifestPath(ImagePath, repository, cmdType);
+        assertEqualsNoOrder(results.toArray(), Stream.of("docker-local/docker-local/hello-world:latest", "docker-local/hello-world:latest", "docker-local/library/docker-local/hello-world:latest", "docker-local/library/hello-world:latest").toArray());
+    }
+}

--- a/build-info-extractor-docker/src/test/java/org/jfrog/build/extractor/docker/extractor/DockerUtilsTest.java
+++ b/build-info-extractor-docker/src/test/java/org/jfrog/build/extractor/docker/extractor/DockerUtilsTest.java
@@ -12,15 +12,15 @@ import static org.testng.Assert.assertEqualsNoOrder;
 public class DockerUtilsTest {
     @Test
     public void getArtManifestPathTest() {
-        String ImagePath = "hello-world:latest";
+        String imagePath = "hello-world:latest";
         String repository = "docker-local";
         DockerUtils.CommandType cmdType = DockerUtils.CommandType.Push;
-        List<String> results = DockerUtils.getArtManifestPath(ImagePath, repository, cmdType);
+        List<String> results = DockerUtils.getArtManifestPath(imagePath, repository, cmdType);
         assertEqualsNoOrder(results.toArray(), Stream.of("docker-local/hello-world:latest", "hello-world:latest").toArray());
 
         cmdType = DockerUtils.CommandType.Pull;
-        ImagePath = "docker-local/hello-world:latest";
-        results = DockerUtils.getArtManifestPath(ImagePath, repository, cmdType);
+        imagePath = "docker-local/hello-world:latest";
+        results = DockerUtils.getArtManifestPath(imagePath, repository, cmdType);
         assertEqualsNoOrder(results.toArray(), Stream.of("docker-local/docker-local/hello-world:latest", "docker-local/hello-world:latest", "docker-local/library/docker-local/hello-world:latest", "docker-local/library/hello-world:latest").toArray());
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
The function `getArtManifestPath` generates four potential paths to search docker manifests in Artifactory
The 'Assume proxy-less' path is being generated incorrectly.