### PR TITLE
Bugfix - Cve should have an empty constructor

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Cve.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Cve.java
@@ -11,6 +11,11 @@ public class Cve {
     private String cvssV1;
     private String cvssV2;
 
+    @SuppressWarnings("unused")
+    public Cve() {
+    }
+
+    @SuppressWarnings("unused")
     public Cve(String cveId, String cvssV1, String cvssV2) {
         this.cveId = cveId;
         this.cvssV1 = cvssV1;


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

The Cve class is used by the JFrog IDEA plugin's cache. An attempt to deserialize a cache object will fail with the following error:
> com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `org.jfrog.build.extractor.scan.Cve` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)