### PR TITLE
Bugfix - Missing Gradle build-info props on artifacts

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelper.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelper.java
@@ -56,7 +56,7 @@ public abstract class TaskHelper {
             addProps(defaultProps, artifactoryTask.getProperties());
             // Add the publisher properties
             ArtifactoryClientConfiguration.PublisherHandler publisher =
-                    ArtifactoryPluginUtil.getPublisherHandler(project);
+                    ArtifactoryPluginUtil.getPublisherHandler(project.getRootProject());
             if (publisher != null) {
                 defaultProps.putAll(publisher.getMatrixParams());
             }

--- a/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
+++ b/build-info-extractor-gradle/src/test/java/org/jfrog/gradle/plugin/artifactory/Utils.java
@@ -150,6 +150,10 @@ public class Utils {
         BuildInfo buildInfo = getBuildInfo(artifactoryManager, buildResult);
         assertNotNull(buildInfo);
         checkBuildInfoModules(buildInfo, 3, expectModuleArtifacts ? 5 : 4);
+
+        // Check build info properties on published Artifacts
+        PropertySearchResult artifacts = artifactoryManager.searchArtifactsByProperties(String.format("build.name=%s;build.number=%s", buildInfo.getName(), buildInfo.getNumber()));
+        assertTrue(artifacts.getResults().size() >= 12);
     }
 
     static void assertProjectsSuccess(BuildResult buildResult) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Using the Artifactory convention in allProjects{ ... } may cause the artifacts not to have build info properties, such as build.name and build.number:

```groovy
allProjects {
  artifactory {
  // ...
  }
}
```
Notice - it is not recommended and not documented to put the artifactory convention in the "allProjects" scope. It should be in the root project:
```groovy
allProjects {
  // ...
}
artifactory {
  // ...
}
```