### PR TITLE
Bugfix - Broken AQL request when build is not defined in FilesGroup

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/AqlHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/AqlHelper.java
@@ -62,7 +62,7 @@ public class AqlHelper {
         if (this.filesGroup.getSpecType() == FilesGroup.SpecType.BUILD) {
             artifactsSha1SearchResults = queryResults;
         } else {
-            if (this.buildName != null && this.buildNumber != null) {
+            if (!StringUtils.isBlank(this.buildName) && !StringUtils.isBlank(this.buildNumber)) {
                 artifactsSha1SearchResults = fetchBuildArtifactsSha1();
             } else {
                 artifactsSha1SearchResults = new ArrayList<>();

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/AqlHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/AqlHelper.java
@@ -62,7 +62,11 @@ public class AqlHelper {
         if (this.filesGroup.getSpecType() == FilesGroup.SpecType.BUILD) {
             artifactsSha1SearchResults = queryResults;
         } else {
-            artifactsSha1SearchResults = fetchBuildArtifactsSha1();
+            if (this.buildName != null && this.buildNumber != null) {
+                artifactsSha1SearchResults = fetchBuildArtifactsSha1();
+            } else {
+                artifactsSha1SearchResults = new ArrayList<>();
+            }
         }
 
         List<AqlSearchResult.SearchEntry> results = filterResult(queryResults, artifactsSha1SearchResults);


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
This PR is to fix a bug we've encountered on a group of Jenkins pipelines using the jenkins-artifactory-plugin.  The gist is that a call to download artifacts through the jenkins-artifactory-plugin results in a call to `AqlHelper` with a `FilesGroup` that doesn't have a `build` set.

This causes `fetchBuildArtifactsSha1` to send a broken AQL request to Artifactory, that ultimately times out (in our case, causing a 504).  It used to work when the call went through `PatternAqlHelper`, which did the search but didn't do the additional filtering by build.

I've posted an example input, the rough callstack to get to this point, and the broken AQL that was sent from `fetchBuildArtifactsSha1` below:

```groovy
artifactoryServer.download(
  failNoOp: false,
  spec: """{
    "files": [
      {
        "pattern": "generic-local/subdir/latest/generic-file.txt",
        "target": "out/subdir/",
        "flat": "true",
        "recursive": "false"
      }
    ]
  }"""
)
```

```txt
// in jenkins-artifactory-plugin
org.jfrog.hudson.pipeline.scripted.steps.DownloadStep.Execution::runStep
org.jfrog.hudson.pipeline.common.executors.GenericDownloadExecutor::execute
org.jfrog.hudson.generic.FilesResolverCallable::invoke
// in build-info-extractor
org.jfrog.build.extractor.clientConfiguration.util.spec.SpecsHelper::downloadArtifactsBySpec
org.jfrog.build.extractor.clientConfiguration.util.DependenciesDownloadHelper::downloadDependencies
org.jfrog.build.extractor.clientConfiguration.util.ArtifactorySearcher::SearchByFileSpec
org.jfrog.build.extractor.clientConfiguration.util.AqlHelper::run
org.jfrog.build.extractor.clientConfiguration.util.AqlHelper::fetchBuildArtifactsSha1
```

```txt
POST /artifactory/api/search/aql HTTP/1.1
Content-Type: text/plain; charset=ISO-8859-1
User-Agent: ArtifactoryBuildClient/2.32.3
Accept-Encoding: gzip,deflate

items.find({"artifact.module.build.name": "null","artifact.module.build.number": ""}).include("name","repo","path","actual_sha1")
```

I can confirm that this fix results in the pipelines working, based on a build of jenkins-artifactory-plugin with this updated dependency.  It ultimately skips the call to `fetchBuildArtifactsSha1` if the build name or number isn't provided, since there won't be a useful return result if either isn't present.