### PR TITLE
upgrade httpcore from 4.4.5 to 4.4.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ subprojects {
         implementation("org.apache.httpcomponents:httpclient:4.5.13") {
             exclude module: "commons-codec"
         }
-        implementation 'org.apache.httpcomponents:httpcore:4.4.5'
+        implementation 'org.apache.httpcomponents:httpcore:4.4.13'
         implementation "commons-codec:commons-codec:1.13"
         implementation group: 'com.google.guava', name: 'guava', 'version': '30.0-jre'
         implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: '1.1.1'
@@ -246,7 +246,7 @@ project('build-info-client') {
         implementation("org.apache.httpcomponents:httpclient:4.5.13") {
             exclude module: "commons-codec"
         }
-        implementation 'org.apache.httpcomponents:httpcore:4.4.5'
+        implementation 'org.apache.httpcomponents:httpcore:4.4.13'
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5'
         implementation "commons-codec:commons-codec:1.13"
         sourceSets {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
i see the dependency httpclient is 4.5.13, but httpcore is 4.4.5, i  suggest that their versions should be consistent.