### PR TITLE
gradle extractor - Add support for JFrog Projects

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -59,6 +59,9 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         String buildNumber = clientConf.info.getBuildNumber();
         bib.number(buildNumber);
 
+        String buildProject = clientConf.info.getProject();
+        bib.project(buildProject);
+
         String buildStartedIso = clientConf.info.getBuildStarted();
         Date buildStartDate = null;
         try {


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Support JFrog Projects in Gradle