### PR TITLE
Add allowInsecureProtocol flag for http-configured Artifactory Repositories on Gradle

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoBuilder.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/builder/BuildInfoBuilder.java
@@ -2,6 +2,7 @@ package org.jfrog.build.api.builder;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.*;
+import org.jfrog.build.api.Module;
 import org.jfrog.build.api.release.PromotionStatus;
 
 import java.text.SimpleDateFormat;

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/dsl/ResolverConfig.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/dsl/ResolverConfig.groovy
@@ -83,6 +83,10 @@ class ResolverConfig {
             }
         }
 
+        def setAllowInsecureProtocol(boolean allow) {
+            ResolverConfig.this.resolver.setAllowInsecureProtocol(allow);
+        }
+
         def setMavenCompatible(boolean mavenCompatible) {
             ResolverConfig.this.resolver.setM2Compatible(mavenCompatible)
         }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -235,6 +235,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
                     password = resolverConf.password
                 }
             }
+            allowInsecureProtocol = resolverConf.allowInsecureProtocol
         }
     }
 
@@ -248,6 +249,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
                     password = resolverConf.password
                 }
             }
+            allowInsecureProtocol = resolverConf.allowInsecureProtocol
         }
         if (ivyRepo.metaClass.respondsTo(ivyRepo, 'patternLayout')) {
             // Gradle 5 an above

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperConfigurations.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelperConfigurations.java
@@ -14,7 +14,6 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.plugins.MavenPluginConvention;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.Upload;
 import org.jfrog.build.api.util.FileChecksumCalculator;
@@ -192,7 +191,7 @@ public class TaskHelperConfigurations extends TaskHelper {
             artifactoryTask.mavenDescriptor = null;
         } else {
             artifactoryTask.mavenDescriptor = new File(
-                    project.getConvention().getPlugin(MavenPluginConvention.class).getMavenPomDir(),
+                    project.getProjectDir(),
                     "pom-default.xml");
             dependsOn(installTask);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoBuilder.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoBuilder.java
@@ -3,6 +3,7 @@ package org.jfrog.build.extractor.builder;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.release.PromotionStatus;
 import org.jfrog.build.extractor.ci.*;
+import org.jfrog.build.extractor.ci.Module;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoMavenBuilder.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/BuildInfoMavenBuilder.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.release.PromotionStatus;
 import org.jfrog.build.api.util.CommonUtils;
 import org.jfrog.build.extractor.ci.*;
+import org.jfrog.build.extractor.ci.Module;
 
 import java.util.Date;
 import java.util.List;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -42,6 +42,7 @@ import static org.jfrog.build.extractor.ci.IssuesTrackerFields.AGGREGATION_BUILD
 import static org.jfrog.build.extractor.ci.IssuesTrackerFields.ISSUES_TRACKER_NAME;
 import static org.jfrog.build.extractor.ci.IssuesTrackerFields.ISSUES_TRACKER_VERSION;
 import static org.jfrog.build.extractor.ModuleParallelDeployHelper.DEFAULT_DEPLOYMENT_THREADS;
+import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.ALLOWINSECUREPROTOCOL;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.ARTIFACT_SPECS;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.CONTEXT_URL;
 import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationFields.DOCKER_HOST;
@@ -807,6 +808,14 @@ public class ArtifactoryClientConfiguration {
 
         public Boolean isMaven() {
             return getBooleanValue(MAVEN, null);
+        }
+
+        public void setAllowInsecureProtocol(boolean enabled) {
+            setBooleanValue(ALLOWINSECUREPROTOCOL, enabled);
+        }
+
+        public Boolean isAllowInsecureProtocol() {
+            return getBooleanValue(ALLOWINSECUREPROTOCOL, null);
         }
 
         public void setIvy(Boolean enabled) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -10,6 +10,7 @@ public interface ClientConfigurationFields {
     String PORT = "port";
     String PASSWORD = "password";
     String MAVEN = "maven";
+    String ALLOWINSECUREPROTOCOL = "allowinsecureprotocol";
     String IVY = "ivy";
     String IVY_M2_COMPATIBLE = "ivy.m2compatible";
     String IVY_ART_PATTERN = "ivy.artPattern";

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/DependencyTree.java
@@ -126,13 +126,13 @@ public class DependencyTree extends DefaultMutableTreeNode {
      */
     @SuppressWarnings({"WeakerAccess", "unchecked"})
     public Vector<DependencyTree> getChildren() {
-        return children != null ? children : new Vector<>();
+        return children != null ? (Vector)children : new Vector<>();
     }
 
     @JsonProperty(value = "nodes")
     @SuppressWarnings({"unchecked", "unused"})
     public List<DependencyTree> getNodes() {
-        return children;
+        return (Vector)children;
     }
 
     /**

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -5,6 +5,7 @@ import org.jfrog.build.extractor.builder.BuildInfoBuilder;
 import org.jfrog.build.extractor.builder.DependencyBuilder;
 import org.jfrog.build.extractor.builder.ModuleBuilder;
 import org.jfrog.build.extractor.ci.*;
+import org.jfrog.build.extractor.ci.Module;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryManagerTest.java
@@ -7,6 +7,7 @@ import org.jfrog.build.api.release.Promotion;
 import org.jfrog.build.api.release.PromotionStatus;
 import org.jfrog.build.extractor.builder.BuildInfoBuilder;
 import org.jfrog.build.extractor.ci.*;
+import org.jfrog.build.extractor.ci.Module;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,22 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-        dependencies {
-            classpath "com.gradle.publish:plugin-publish-plugin:0.+"
-            classpath "io.github.gradle-nexus:publish-plugin:+"
-            classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.24.5"
-        }
+        maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://releases.jfrog.io/artifactory/oss-snapshot-local" }
+    }
+    dependencies {
+        classpath "com.gradle.publish:plugin-publish-plugin:1.0.0"
+        classpath "io.github.gradle-nexus:publish-plugin:+"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.24.5"
     }
 }
 
 plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
     id 'idea'
+    id 'com.gradle.plugin-publish' version '1.0.0'
+    id 'java-gradle-plugin'
+    id 'maven-publish'
 }
 
 apply plugin: "com.jfrog.artifactory"
@@ -44,8 +46,6 @@ allprojects {
     group = 'org.jfrog.buildinfo'
 
     repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://releases.jfrog.io/artifactory/oss-snapshot-local" }
     }
 }
 
@@ -59,7 +59,6 @@ def extractorProjects() {
 
 subprojects {
     apply plugin: 'groovy'
-    apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.artifactory'
     apply plugin: 'signing'
 
@@ -109,6 +108,7 @@ subprojects {
         from {
             configurations.uberJar.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
         }
+        duplicatesStrategy = 'INCLUDE'
         exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
         with jar
         archiveClassifier.set('uber')
@@ -259,7 +259,7 @@ project('build-info-client') {
 
         processResources {
             from(sourceSets.main.resources.srcDirs) {
-                include '**/*bi.client.properties'
+                include '**/*bi.client.properties' duplicatesStrategy DuplicatesStrategy.INCLUDE
                 filter(ReplaceTokens, tokens: ['project.version': project.version.toString()])
             }
         }
@@ -302,8 +302,6 @@ project('build-info-extractor-ivy') {
 }
 
 project('build-info-extractor-gradle') {
-    apply plugin: 'com.gradle.plugin-publish'
-    apply plugin: 'java-gradle-plugin'
     description = 'JFrog Build-Info Gradle Extractor'
 
     sourceSets.test.resources {
@@ -311,6 +309,7 @@ project('build-info-extractor-gradle') {
     }
 
     dependencies {
+        implementation project(":build-info-extractor")
         implementation gradleApi()
         implementation fileTree(dir: "${gradle.gradleHomeDir}/lib/plugins", include: '**/*.jar')
         //workaround for GRADLE-1699
@@ -321,27 +320,21 @@ project('build-info-extractor-gradle') {
         testImplementation gradleTestKit()
     }
 
-    gradlePlugin {
-        testSourceSets sourceSets.test
-    }
-
     pluginBundle {
         website = 'https://www.jfrog.com/confluence/display/JFROG/Gradle+Artifactory+Plugin'
         vcsUrl = 'https://github.com/jfrog/build-info'
         description = 'JFrog Gradle plugin for Build Info extraction and Artifactory publishing.'
         tags = ['Artifactory']
+    }
 
+    gradlePlugin {
+        testSourceSets sourceSets.test
         plugins {
             artifactoryPlugin {
                 id = 'com.jfrog.artifactory'
                 displayName = 'Gradle Artifactory plugin'
+                implementationClass = "com.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin"
             }
-        }
-
-        mavenCoordinates {
-            groupId = project.getGroup()
-            artifactId = project.getName()
-            version = project.property("build-info-extractor-gradle-version")
         }
     }
 
@@ -355,7 +348,7 @@ project('build-info-extractor-maven3') {
     description = 'JFrog Build-Info Maven 3 Extractor'
 
     dependencies {
-        implementation 'org.jdom:jdom:1.1.1',
+        implementation 'org.jdom:jdom2:2.0.6.1',
                 'org.codehaus.groovy:groovy-all:2.4.21',
                 'plexus:plexus-container-default:1.0-alpha-6',
                 'org.sonatype.aether:aether-api:1.13.1',

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'groovy'
 dependencies {
-  compile gradleApi()
-  compile localGroovy()
+  implementation gradleApi()
+  implementation localGroovy()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Hi! My current enterprise still has an HTTP Artifactory which I was not able to push to using the latest version, so I added the feature as a pass-through to the configured Gradle Repository. I was not able to get the tests working as I got a "Task with path 'pluginUnderTestMetadata' not found in project ':build-info-extractor-gradle'.", if anyone knows what that's about I'm okay with fixing it.