### PR TITLE
CommandExecutor - Support executable path with spaces

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -32,7 +32,7 @@ public class CommandExecutor implements Serializable {
      * @param env            - Environment variables to use during execution.
      */
     public CommandExecutor(String executablePath, Map<String, String> env) {
-        this.executablePath = executablePath;
+        this.executablePath = escapeSpacesInPath(executablePath);
         Map<String, String> finalEnvMap = new HashMap<>(System.getenv());
         if (env != null) {
             Map<String, String> fixedEnvMap = new HashMap<>(env);
@@ -59,6 +59,19 @@ public class CommandExecutor implements Serializable {
             path = path.replaceAll(";", File.pathSeparator) + ":/usr/local/bin";
         }
         env.replace("PATH", path);
+    }
+
+    /**
+     * Escape spaces in the input executable path and trim leading and trailing whitespaces.
+     *
+     * @param executablePath - the executable path to process
+     * @return escaped and trimmed executable path.
+     */
+    private static String escapeSpacesInPath(String executablePath) {
+        if (executablePath == null) {
+            return null;
+        }
+        return executablePath.trim().replaceAll(" ", SystemUtils.IS_OS_WINDOWS ? "^ " : "\\\\ ");
     }
 
     /**

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -76,10 +76,11 @@ public class CommandExecutorTest {
             assertTrue(executableFile.setExecutable(true));
             FileUtils.writeStringToFile(executableFile, "echo \"I have spoken\"", StandardCharsets.UTF_8);
 
+            // Run executable in "Kuiil space/ship.bat" with no arguments and make sure it prints "I have spoken"
             CommandExecutor commandExecutor = new CommandExecutor(executableFile.getAbsolutePath(), null);
-            CommandResults results = commandExecutor.exeCommand(null, Lists.newArrayList(executableFile.getAbsolutePath()), new ArrayList<>(), null);
+            CommandResults results = commandExecutor.exeCommand(null, new ArrayList<>(), new ArrayList<>(), null);
             assertTrue(results.isOk(), results.getErr());
-            assertEquals(results.getRes().trim(), "I have spoken");
+            assertTrue(results.getRes().contains("I have spoken"));
         } finally {
             FileUtils.forceDelete(tmpDir.toFile());
         }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -1,12 +1,16 @@
 package org.jfrog.build.extractor.executor;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,6 +63,22 @@ public class CommandExecutorTest {
             assertTrue(results.isOk(), results.getErr() + results.getRes());
         } catch (InterruptedException | IOException e) {
             fail(ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+    @Test
+    public void testExeCommandWithSpaces() throws IOException, InterruptedException {
+        Path tmpDir = Files.createTempDirectory("testEscapeSpacesInPath");
+        try {
+            Path testDir = Files.createDirectories(tmpDir.resolve("Kuiil space"));
+            File executableFile = Files.createFile(testDir.resolve("ship.bat")).toFile();
+            assertTrue(executableFile.setExecutable(true));
+
+            CommandExecutor commandExecutor = new CommandExecutor(executableFile.getAbsolutePath(), null);
+            CommandResults results = commandExecutor.exeCommand(null, new ArrayList<>(), new ArrayList<>(), null);
+            assertTrue(results.isOk(), results.getErr());
+        } finally {
+            FileUtils.forceDelete(tmpDir.toFile());
         }
     }
 }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -9,6 +9,7 @@ import org.testng.collections.Lists;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -73,10 +74,12 @@ public class CommandExecutorTest {
             Path testDir = Files.createDirectories(tmpDir.resolve("Kuiil space"));
             File executableFile = Files.createFile(testDir.resolve("ship.bat")).toFile();
             assertTrue(executableFile.setExecutable(true));
+            FileUtils.writeStringToFile(executableFile, "echo \"I have spoken\"", StandardCharsets.UTF_8);
 
             CommandExecutor commandExecutor = new CommandExecutor(executableFile.getAbsolutePath(), null);
-            CommandResults results = commandExecutor.exeCommand(null, new ArrayList<>(), new ArrayList<>(), null);
+            CommandResults results = commandExecutor.exeCommand(null, Lists.newArrayList(executableFile.getAbsolutePath()), new ArrayList<>(), null);
             assertTrue(results.isOk(), results.getErr());
+            assertEquals(results.getRes().trim(), "I have spoken");
         } finally {
             FileUtils.forceDelete(tmpDir.toFile());
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Resolve an issue in the JFrog IDEA plugin whereby Go executable path is under `C:\program files` directory in Windows.