### PR TITLE
Set the connection request timeout

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClientBuilder.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClientBuilder.java
@@ -181,6 +181,7 @@ public class PreemptiveHttpClientBuilder {
                 .custom()
                 .setSocketTimeout(timeoutMilliSeconds)
                 .setConnectTimeout(timeoutMilliSeconds)
+                .setConnectionRequestTimeout(timeoutMilliSeconds)
                 .setCircularRedirectsAllowed(true)
                 .build();
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Set the connection request timeout to avoid infinite timeout during connection requests.