### PR TITLE
Skip null matrix values in buildMatrixParamsString

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DeploymentUrlUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DeploymentUrlUtils.java
@@ -72,6 +72,9 @@ public abstract class DeploymentUrlUtils {
         if (matrixParams != null && !matrixParams.isEmpty()) {
             for (String propertyKey : matrixParams.keySet()) {
                 for (String multiPropertyValue : matrixParams.get(propertyKey)) {
+                    if (multiPropertyValue == null) {
+                        continue;
+                    }
                     // Due to known bug in Artifactory, in order to support multi values properties
                     // we add a statement to each value separately.
                     for (String propertyValue : multiPropertyValue.split(",")) {


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix https://github.com/jfrog/teamcity-artifactory-plugin/issues/127