### PR TITLE
Make getChildren and getNodes return DependencyTree

### DIFF
--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
@@ -6,10 +6,7 @@ import org.jfrog.build.api.util.NullLog;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.testng.Assert.*;
 import static org.testng.AssertJUnit.assertEquals;
@@ -37,6 +34,26 @@ public class DependencyTreeTest {
         two.add(three); // 2 -> 3
         two.add(four); // 2 -> 4
         four.add(five); // 4 -> 5
+    }
+
+    @Test
+    public void testGetChildren() {
+        // Check root children
+        List<DependencyTree> rootChildren = root.getChildren();
+        assertTrue(rootChildren.contains(one));
+        assertTrue(rootChildren.contains(two));
+
+        // Check 'one' children
+        assertEquals(new ArrayList<>(), one.getChildren());
+
+        // Check 'two' children
+        List<DependencyTree> twoChildren = two.getChildren();
+        assertTrue(twoChildren.contains(three));
+        assertTrue(twoChildren.contains(four));
+
+        // Check 'four' and 'five' children
+        assertEquals(List.of(five), four.getChildren());
+        assertEquals(new ArrayList<>(), five.getChildren());
     }
 
     @Test

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/scan/DependencyTreeTest.java
@@ -1,10 +1,10 @@
 package org.jfrog.build.extractor.scan;
 
-import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.compress.utils.Sets;
 import org.jfrog.build.api.util.NullLog;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
 import java.util.*;
 
@@ -52,7 +52,7 @@ public class DependencyTreeTest {
         assertTrue(twoChildren.contains(four));
 
         // Check 'four' and 'five' children
-        assertEquals(List.of(five), four.getChildren());
+        assertEquals(Lists.newArrayList(five), four.getChildren());
         assertEquals(new ArrayList<>(), five.getChildren());
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Undo the change here: https://github.com/jfrog/build-info/pull/659/files#diff-0d5319592f114ad883c7ad2d602e0b187f22d6e4a9087788f4551b4cc1d5ba26R130 and yet support Java 11.