### PR TITLE
Allow skip VCS stamping in Go

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -114,10 +114,14 @@ public class GoDriver implements Serializable {
      *
      * @param verbose      - True if should print the results to the log
      * @param ignoreErrors - True if errors should be ignored
+     * @param dontBuildVcs - Skip VCS stamping - can be used only on Go >= 1.18
      * @throws IOException - in case of any I/O error.
      */
-    public CommandResults getUsedModules(boolean verbose, boolean ignoreErrors) throws IOException {
+    public CommandResults getUsedModules(boolean verbose, boolean ignoreErrors, boolean dontBuildVcs) throws IOException {
         List<String> argsList = new ArrayList<>(GO_LIST_USED_MODULES_CMD);
+        if (dontBuildVcs) {
+            argsList.add(1, "-buildvcs=false");
+        }
         if (ignoreErrors) {
             argsList.add(1, "-e");
         }

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoRun.java
@@ -138,7 +138,7 @@ public class GoRun extends GoCommand {
     private void populateModuleAndDeps() throws Exception {
         backupModAndSumFiles();
         try {
-            DependencyTree dependencyTree = createDependencyTree(goDriver, logger, true);
+            DependencyTree dependencyTree = createDependencyTree(goDriver, logger, true, false);
             moduleName = dependencyTree.toString();
 
             String cachePath = getCachePath();

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -45,14 +45,14 @@ public class GoDriverTest {
             driver.modTidy(false, false);
 
             // Run "go list -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
-            CommandResults results = driver.getUsedModules(false, false);
+            CommandResults results = driver.getUsedModules(false, false, true);
             Set<String> actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n"))
                     .map(String::trim)
                     .collect(Collectors.toSet());
             assertEquals(actualUsedModules, EXPECTED_USED_MODULES);
 
             // Run "go list -e -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
-            results = driver.getUsedModules(false, true);
+            results = driver.getUsedModules(false, true, true);
             actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n"))
                     .map(String::trim)
                     .collect(Collectors.toSet());
@@ -77,10 +77,10 @@ public class GoDriverTest {
             driver.modTidy(false, true);
 
             // Run "go list -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
-            Assert.assertThrows(() -> driver.getUsedModules(false, false));
+            Assert.assertThrows(() -> driver.getUsedModules(false, false, true));
 
             // Run "go list -e -f {{with .Module}}{{.Path}} {{.Version}}{{end}} all"
-            CommandResults results = driver.getUsedModules(false, true);
+            CommandResults results = driver.getUsedModules(false, true, true);
             Set<String> actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n"))
                     .map(String::trim)
                     .collect(Collectors.toSet());

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoDependencyTreeTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoDependencyTreeTest.java
@@ -1,0 +1,83 @@
+package org.jfrog.build.extractor.go.extractor;
+
+import com.google.common.collect.Sets;
+import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.extractor.scan.DependencyTree;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.jfrog.build.extractor.go.extractor.GoDependencyTree.populateDependenciesMap;
+import static org.jfrog.build.extractor.go.extractor.GoDependencyTree.populateDependencyTree;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author yahavi
+ **/
+public class GoDependencyTreeTest {
+
+    @Test
+    public void testPopulateDependenciesMap() {
+        // Output of 'go mod graph'.
+        String[] dependenciesGraph = new String[]{
+                "my/pkg/name1 github.com/jfrog/directDep1@v0.1",
+                "my/pkg/name1 github.com/jfrog/directDep2@v0.2",
+                "my/pkg/name1 github.com/jfrog/directDep3@v0.3",
+                "github.com/jfrog/directDep1@v0.1 github.com/jfrog/indirectDep1-1@v1.1",
+                // github.com/jfrog/indirectDep2-1@v1.2 does not appear in the used modules set:
+                "github.com/jfrog/directDep1@v0.1 github.com/jfrog/indirectDep2-1@v1.2",
+                "github.com/jfrog/directDep1@v0.1 github.com/jfrog/indirectDep2-1@v1.3",
+                "github.com/jfrog/directDep2@v0.2 github.com/jfrog/indirectDep1-2@v2.1",
+                "github.com/jfrog/indirectDep1-1@v1.1 github.com/jfrog/indirectIndirectDep1-1-1@v1.1.1"
+        };
+        Set<String> usedModules = Sets.newHashSet("github.com/jfrog/directDep1@v0.1",
+                "github.com/jfrog/directDep2@v0.2",
+                "github.com/jfrog/directDep3@v0.3",
+                "github.com/jfrog/indirectDep1-1@v1.1",
+                "github.com/jfrog/indirectDep2-1@v1.3",
+                "github.com/jfrog/indirectDep1-2@v2.1",
+                "github.com/jfrog/indirectIndirectDep1-1-1@v1.1.1");
+        // Run method.
+        Map<String, List<String>> expectedAllDependencies = getAllDependenciesForTest();
+        Map<String, List<String>> actualAllDependencies = new HashMap<>();
+        populateDependenciesMap(dependenciesGraph, usedModules, actualAllDependencies);
+        // Validate result.
+        assertEquals(expectedAllDependencies, actualAllDependencies);
+    }
+
+    @Test
+    public void testPopulateDependencyTree() {
+        Map<String, Integer> expected = new HashMap<String, Integer>() {{
+            put("github.com/jfrog/directDep1:0.1", 2);
+            put("github.com/jfrog/directDep2:0.2", 1);
+            put("github.com/jfrog/directDep3:0.3", 0);
+        }};
+        Map<String, List<String>> allDependencies = getAllDependenciesForTest();
+        DependencyTree rootNode = new DependencyTree();
+        populateDependencyTree(rootNode, "my/pkg/name1", allDependencies, new NullLog());
+
+        Vector<DependencyTree> children = rootNode.getChildren();
+        assertEquals(children.size(), expected.size());
+        for (DependencyTree current : children) {
+            assertTrue(expected.containsKey(current.toString()));
+            assertEquals(current.getChildren().size(), expected.get(current.toString()).intValue());
+        }
+    }
+
+    private Map<String, List<String>> getAllDependenciesForTest() {
+        return new HashMap<String, List<String>>() {{
+            put("my/pkg/name1", Arrays.asList(
+                    "github.com/jfrog/directDep1@v0.1",
+                    "github.com/jfrog/directDep2@v0.2",
+                    "github.com/jfrog/directDep3@v0.3"));
+            put("github.com/jfrog/directDep1@v0.1", List.of(
+                    "github.com/jfrog/indirectDep1-1@v1.1",
+                    "github.com/jfrog/indirectDep2-1@v1.3"));
+            put("github.com/jfrog/directDep2@v0.2", Collections.singletonList(
+                    "github.com/jfrog/indirectDep1-2@v2.1"));
+            put("github.com/jfrog/indirectDep1-1@v1.1", Collections.singletonList(
+                    "github.com/jfrog/indirectIndirectDep1-1-1@v1.1.1"));
+        }};
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Dependency for: https://github.com/jfrog/ide-plugins-common/pull/93

This fix is for the JFrog IDEA plugin and potentially for the Go build-info extractor - 
Allow providing the dontBuildVcs flag, which can be used to skip VCS stamping to bypass the following error:
> IOException: error obtaining VCS status: exit status 128 Use -buildvcs=false to disable VCS stamping. error obtaining VCS status: exit status 128 Use -buildvcs=false to disable VCS stamping.