### PR TITLE
Retry on errors 500

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
@@ -155,8 +155,7 @@ public class PreemptiveHttpClient implements AutoCloseable {
 
         @Override
         public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
-            // Code 500 means an unexpected behavior of Artifactory, thus we should not retry.
-            if (response.getStatusLine().getStatusCode() > 500) {
+            if (response.getStatusLine().getStatusCode() >= 500) {
                 HttpClientContext clientContext = HttpClientContext.adapt(context);
                 log.warn("Error occurred for request " + clientContext.getRequest().getRequestLine().toString() +
                         ". Received status code " + response.getStatusLine().getStatusCode() +


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Required for https://github.com/jfrog/build-info/pull/693

Handle intermittent errors caused in Distribution:
> Gradle suite > Gradle test > org.jfrog.build.extractor.clientConfiguration.client.RemoteDistributionManagerTest > asyncDistributionTest FAILED
    java.io.IOException: JFrog service failed. Received 500: {"detail":"Artifactory bad response at url: api/release/store","message":"Artifactory: Cannot invoke \"org.artifactory.repo.ReleaseBundlesRepo.accepts(org.artifactory.repo.RepoPath)\" because \"repo\" is null","status_code":500}