### PR TITLE
Add build info json save to target directory

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildDeploymentHelper.java
@@ -41,6 +41,11 @@ public class BuildDeploymentHelper {
         logger.debug("Build Info Recorder: publication fork count: " + clientConf.publisher.getPublishForkCount());
         logger.debug("Build Info Recorder: publish build info: " + clientConf.publisher.isPublishBuildInfo());
 
+        if (clientConf.publisher.isPublishBuildInfo() || StringUtils.isNotBlank(clientConf.info.getGeneratedBuildInfoFilePath())) {
+            // Used by bamboo-artifactory-plugin.
+            saveBuildInfoToFile(buildInfo, clientConf, basedir);
+        }
+
         if (!StringUtils.isEmpty(clientConf.info.getGeneratedBuildInfoFilePath())) {
             try {
                 BuildInfoExtractorUtils.saveBuildInfoToFile(buildInfo, new File(clientConf.info.getGeneratedBuildInfoFilePath()));

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.jfrog.build.api.util.FileChecksumCalculator.*;
+import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.DEFAULT_NUGET_PROTOCOL;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class NugetRun extends PackageManagerExtractor {
@@ -103,7 +104,7 @@ public class NugetRun extends PackageManagerExtractor {
         this.nugetCmdArgs = StringUtils.isBlank(nugetCmdArgs) ? StringUtils.EMPTY : nugetCmdArgs;
         this.username = username;
         this.password = password;
-        this.apiProtocol = apiProtocol;
+        this.apiProtocol = StringUtils.isBlank(apiProtocol) ? DEFAULT_NUGET_PROTOCOL : apiProtocol;
         this.module = module;
     }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
This save is needed for bamboo-artifactory-plugin