### PR TITLE
Only the deploy goal should upload artifacts

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -708,7 +708,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     }
 
     /**
-     * Only Maven deploy / install goals are supposed to upload artifacts to artifactory.
+     * Only Maven deploy goal are supposed to upload artifacts to artifactory.
      * Other than that, we don't upload artifacts.
      */
     private void setDeploymentPolicy(ExecutionEvent event) {
@@ -716,10 +716,8 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         // Override the default Maven deploy behavior with Artifactory.
         if (goals.contains("deploy")) {
             event.getSession().getUserProperties().put("maven.deploy.skip", Boolean.TRUE.toString());
-            return;
-        }
-        // Skip the artifact deployment behavior if the goals do not contain install or deploy phases.
-        if (!goals.contains("install")) {
+        } else {
+            // Skip the artifact deployment behavior if the goals do not contain the deploy phase.
             conf.publisher.setPublishArtifacts(false);
             conf.publisher.setPublishBuildInfo(false);
 


### PR DESCRIPTION
The build info recorder will upload artifacts if either the deploy or install goals are used, but deployments should only be done when the deploy goal is used.

Using install to deploy artifacts to Artifactory results in unexpected behaviour and can lead to build failures and artifact corruption.

This PR restores the deploy behaviour to the expected goals of Maven.