### PR TITLE
Add PreemptiveHttpClient execute with context

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
@@ -61,6 +61,10 @@ public class PreemptiveHttpClient implements AutoCloseable {
 
     public CloseableHttpResponse execute(HttpUriRequest request) throws IOException {
         HttpClientContext clientContext = HttpClientContext.create();
+        return execute(request, clientContext);
+    }
+
+    public CloseableHttpResponse execute(HttpUriRequest request, HttpClientContext clientContext) throws IOException {
         if (StringUtils.isNotEmpty(accessToken)) {
             clientContext.setUserToken(accessToken);
         } else {


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Adds the option to pass a context object to the PreemptiveHttpClient's execute function.
The context object contains a lot of information about the processed request.
It can be used to detect HTTP redirection.