### PR TITLE
Fix missing fields for maven 3.9.0

### DIFF
--- a/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
+++ b/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
@@ -57,6 +57,10 @@
                     <field-name>container</field-name>
                 </requirement>
                 <requirement>
+                    <role>java.util.List</role>
+                    <field-name>configurationValidators</field-name>
+                </requirement>
+                <requirement>
                     <role>org.apache.maven.classrealm.ClassRealmManager</role>
                     <field-name>classRealmManager</field-name>
                 </requirement>
@@ -175,6 +179,11 @@
                     <field-name>loggerFactory</field-name>
                 </requirement>
             </requirements>
+            <requirement>
+                <role>org.eclipse.aether.impl.RemoteRepositoryFilterManager</role>
+                <role-hint>default</role-hint>
+                <field-name>remoteRepositoryFilterManager</field-name>
+            </requirement>
         </component>
         <!-- A class responssible for enforcing metadata resolution from Artifactory, for Maven 3 versions prior to 3.2.1 -->
         <component>
@@ -285,6 +294,16 @@
                     <role>org.eclipse.aether.impl.OfflineController</role>
                     <role-hint>default</role-hint>
                     <field-name>offlineController</field-name>
+                </requirement>
+                <requirement>
+                    <role>org.eclipse.aether.impl.RemoteRepositoryFilterManager</role>
+                    <role-hint>default</role-hint>
+                    <field-name>remoteRepositoryFilterManager</field-name>
+                </requirement>
+                <requirement>
+                    <role>java.util.Map</role>
+                    <role-hint>default</role-hint>
+                    <field-name>artifactResolverPostProcessors</field-name>
                 </requirement>
                 <requirement>
                     <role>org.eclipse.aether.internal.impl.slf4j.Slf4jLoggerFactory</role>


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Fixes this exception:
```
[main] ERROR org.apache.maven.cli.MavenCli - NullPointerException
java.lang.NullPointerException
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:296)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:278)
    at org.jfrog.build.extractor.maven.resolver.ArtifactoryEclipseArtifactResolver.resolveArtifacts (ArtifactoryEclipseArtifactResolver.java:56)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:255)
```