### PR TITLE
Remove the need for setting up a dummy repository

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/ArtifactoryProjectBuilder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/ArtifactoryProjectBuilder.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.maven;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
@@ -9,37 +10,64 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.jfrog.build.extractor.maven.resolver.ResolutionHelper;
+import org.sonatype.aether.repository.RepositoryPolicy;
 
 import javax.inject.Named;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.jfrog.build.api.BuildInfoConfigProperties.PROP_ARTIFACTORY_RESOLUTION_ENABLED;
 
 @Named
-@Component( role = DefaultProjectBuilder.class, hint = "default")
+@Component(role = DefaultProjectBuilder.class, hint = "default")
 public class ArtifactoryProjectBuilder extends DefaultProjectBuilder {
+
+    @Requirement
+    private ResolutionHelper resolutionHelper;
 
     @Override
     public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive, ProjectBuildingRequest request) throws ProjectBuildingException {
         if (Boolean.parseBoolean(System.getProperties().getProperty(PROP_ARTIFACTORY_RESOLUTION_ENABLED))
                 || Boolean.parseBoolean(System.getenv(PROP_ARTIFACTORY_RESOLUTION_ENABLED))) {
-            // We're setting a dummy repository to the list of repositories, which has both snapshot and release policies enabled.
+            if (!resolutionHelper.isInitialized()) {
+                Properties allMavenProps = new Properties();
+                allMavenProps.putAll(request.getSystemProperties());
+                allMavenProps.putAll(request.getUserProperties());
+                resolutionHelper.init(allMavenProps);
+            }
+
+            // We're setting the resolver repositories to the list of repositories.
             // This repository replaces the central repository.
             // This ensures that parent poms with snapshot versions can be downloaded from Artifactory.
-            request.setRemoteRepositories(getDummyRepo());
+            List<ArtifactRepository> repositories = getRepositories();
+            request.setRemoteRepositories(repositories);
+            request.setPluginArtifactRepositories(repositories);
         }
         return super.build(pomFiles, recursive, request);
     }
 
-    private List<ArtifactRepository> getDummyRepo() {
-        ArtifactRepository repo = new MavenArtifactRepository("dummy",
-                "http://ArtifactoryDummyRepo./dummy",
-                new DefaultRepositoryLayout(),
-                new ArtifactRepositoryPolicy(),
-                new ArtifactRepositoryPolicy());
-        return new ArrayList<ArtifactRepository>(Collections.singletonList(repo));
+    private List<ArtifactRepository> getRepositories() {
+        String releaseRepoUrl = resolutionHelper.getRepoReleaseUrl();
+        String snapshotRepoUrl = resolutionHelper.getRepoSnapshotUrl();
+
+        List<ArtifactRepository> repositories = new ArrayList<>();
+        if (StringUtils.isNotBlank(snapshotRepoUrl)) {
+            ArtifactRepositoryPolicy snapshotPolicy = new ArtifactRepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
+            ArtifactRepositoryPolicy releasePolicy = new ArtifactRepositoryPolicy(false, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
+            repositories.add(new MavenArtifactRepository("artifactory-snapshot", snapshotRepoUrl, new DefaultRepositoryLayout(), snapshotPolicy, releasePolicy));
+        }
+        if (StringUtils.isNotBlank(releaseRepoUrl)) {
+            boolean snapshotPolicyEnabled = StringUtils.isBlank(snapshotRepoUrl);
+            String repositoryId = snapshotPolicyEnabled ? "artifactory-release-snapshot" : "artifactory-release";
+
+            ArtifactRepositoryPolicy snapshotPolicy = new ArtifactRepositoryPolicy(snapshotPolicyEnabled, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
+            ArtifactRepositoryPolicy releasePolicy = new ArtifactRepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
+            repositories.add(new MavenArtifactRepository(repositoryId, releaseRepoUrl, new DefaultRepositoryLayout(), snapshotPolicy, releasePolicy));
+        }
+        return repositories;
     }
 }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/ArtifactoryProjectBuilder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/ArtifactoryProjectBuilder.java
@@ -51,14 +51,37 @@ public class ArtifactoryProjectBuilder extends DefaultProjectBuilder {
     }
 
     private List<ArtifactRepository> getRepositories() {
+        List<ArtifactRepository> repositories = new ArrayList<>();
+
         String releaseRepoUrl = resolutionHelper.getRepoReleaseUrl();
         String snapshotRepoUrl = resolutionHelper.getRepoSnapshotUrl();
 
-        List<ArtifactRepository> repositories = new ArrayList<>();
+        org.apache.maven.artifact.repository.Authentication authentication = null;
+        if (StringUtils.isNotBlank(resolutionHelper.getRepoUsername())) {
+            authentication = new org.apache.maven.artifact.repository.Authentication(resolutionHelper.getRepoUsername(), resolutionHelper.getRepoPassword());
+        }
+        org.apache.maven.repository.Proxy proxy = null;
+        if (StringUtils.isNotBlank(resolutionHelper.getProxyHost())) {
+            proxy = new org.apache.maven.repository.Proxy();
+            proxy.setHost(resolutionHelper.getProxyHost());
+            proxy.setPort(resolutionHelper.getProxyPort());
+            proxy.setUserName(resolutionHelper.getProxyUsername());
+            proxy.setPassword(resolutionHelper.getProxyPassword());
+        }
+
         if (StringUtils.isNotBlank(snapshotRepoUrl)) {
             ArtifactRepositoryPolicy snapshotPolicy = new ArtifactRepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
             ArtifactRepositoryPolicy releasePolicy = new ArtifactRepositoryPolicy(false, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
-            repositories.add(new MavenArtifactRepository("artifactory-snapshot", snapshotRepoUrl, new DefaultRepositoryLayout(), snapshotPolicy, releasePolicy));
+            MavenArtifactRepository repository = new MavenArtifactRepository("artifactory-snapshot", snapshotRepoUrl, new DefaultRepositoryLayout(), snapshotPolicy, releasePolicy);
+
+            if (authentication != null) {
+                repository.setAuthentication(authentication);
+            }
+            if (proxy != null) {
+                repository.setProxy(proxy);
+            }
+
+            repositories.add(repository);
         }
         if (StringUtils.isNotBlank(releaseRepoUrl)) {
             boolean snapshotPolicyEnabled = StringUtils.isBlank(snapshotRepoUrl);
@@ -66,7 +89,16 @@ public class ArtifactoryProjectBuilder extends DefaultProjectBuilder {
 
             ArtifactRepositoryPolicy snapshotPolicy = new ArtifactRepositoryPolicy(snapshotPolicyEnabled, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
             ArtifactRepositoryPolicy releasePolicy = new ArtifactRepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_DAILY, RepositoryPolicy.CHECKSUM_POLICY_WARN);
-            repositories.add(new MavenArtifactRepository(repositoryId, releaseRepoUrl, new DefaultRepositoryLayout(), snapshotPolicy, releasePolicy));
+            MavenArtifactRepository repository = new MavenArtifactRepository(repositoryId, releaseRepoUrl, new DefaultRepositoryLayout(), snapshotPolicy, releasePolicy);
+
+            if (authentication != null) {
+                repository.setAuthentication(authentication);
+            }
+            if (proxy != null) {
+                repository.setProxy(proxy);
+            }
+
+            repositories.add(repository);
         }
         return repositories;
     }


### PR DESCRIPTION
This PR is the continuation of the original PR https://github.com/jfrog/build-info/pull/683 that was reverted because of authentication issues.

This PR adds setting authentication and proxy details if configured, the one missing bit looking at the provided issues in comment https://github.com/jfrog/build-info/pull/683#issuecomment-1451437279

Background info:

The dummy repository is added to allow for the resolution of depedencies using the jfrog cli resolver configuration for Maven. Some maven build plugins, like the org.codehaus.mojo:versions-maven-plugin will try to resolve artifacts using this dummy repository but will always fail.

This PR implements a solution that allows maven build plugins to resolve artifacts using the jfrog cli resolver configuration by configuring the snapshot and release resolver repositories just like the [ArtifactoryEclipseResolversHelper](https://github.com/jfrog/build-info/blob/f1bd977cbe51e64bce88d39f0be12b3e7422e744/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipseResolversHelper.java#L50) and [ArtifactorySonatypeResolversHelper](https://github.com/jfrog/build-info/blob/f1bd977cbe51e64bce88d39f0be12b3e7422e744/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactorySonatypeResolversHelper.java#L44) do.
Instead of configuring a dummy and "hoping" it gets proxied to resolver repositories.