### PR TITLE
Filter build-info and modules properties

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -178,7 +178,6 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
 
         BuildInfo buildInfo = bib.build();
         PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
-        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo, clientConf.getLog());
         log.debug("buildInfoBuilder = " + buildInfo);
 
         return buildInfo;

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -176,13 +176,11 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
             bib.addRunParameters(matrixParameter);
         }
 
-        log.debug("buildInfoBuilder = " + bib);
-        // for backward compatibility for Artifactory 2.2.3
         BuildInfo buildInfo = bib.build();
-        if (parentName != null && parentNumber != null) {
-            buildInfo.setParentBuildId(parentName);
-        }
         PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
+        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo);
+        log.debug("buildInfoBuilder = " + buildInfo);
+
         return buildInfo;
     }
 }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -177,7 +177,7 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
         }
 
         BuildInfo buildInfo = bib.build();
-        PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
+        PackageManagerUtils.collectAndFilterEnvIfNeeded(clientConf, buildInfo);
         log.debug("buildInfoBuilder = " + buildInfo);
 
         return buildInfo;

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/GradleBuildInfoExtractor.java
@@ -178,7 +178,7 @@ public class GradleBuildInfoExtractor implements BuildInfoExtractor<Project> {
 
         BuildInfo buildInfo = bib.build();
         PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
-        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo);
+        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo, clientConf.getLog());
         log.debug("buildInfoBuilder = " + buildInfo);
 
         return buildInfo;

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
@@ -348,7 +348,7 @@ public class ArtifactoryBuildListener implements BuildListener {
         }
 
         BuildInfo buildInfo = builder.build();
-        PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
+        PackageManagerUtils.collectAndFilterEnvIfNeeded(clientConf, buildInfo);
         String contextUrl = clientConf.publisher.getContextUrl();
         String username = clientConf.publisher.getUsername();
         String password = clientConf.publisher.getPassword();

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
@@ -15,6 +15,8 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.UnknownElement;
 import org.apache.tools.ant.taskdefs.Ant;
+import org.jfrog.build.context.BuildContext;
+import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.builder.BuildInfoBuilder;
 import org.jfrog.build.extractor.ci.Agent;
 import org.jfrog.build.extractor.ci.BuildAgent;
@@ -25,8 +27,6 @@ import org.jfrog.build.extractor.ci.IssueTracker;
 import org.jfrog.build.extractor.ci.Issues;
 import org.jfrog.build.extractor.ci.MatrixParameter;
 import org.jfrog.build.extractor.ci.Vcs;
-import org.jfrog.build.context.BuildContext;
-import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
@@ -349,7 +349,7 @@ public class ArtifactoryBuildListener implements BuildListener {
 
         BuildInfo buildInfo = builder.build();
         PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
-        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo);
+        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo, clientConf.getLog());
         String contextUrl = clientConf.publisher.getContextUrl();
         String username = clientConf.publisher.getUsername();
         String password = clientConf.publisher.getPassword();

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
@@ -349,6 +349,7 @@ public class ArtifactoryBuildListener implements BuildListener {
 
         BuildInfo buildInfo = builder.build();
         PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
+        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo);
         String contextUrl = clientConf.publisher.getContextUrl();
         String username = clientConf.publisher.getUsername();
         String password = clientConf.publisher.getPassword();

--- a/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
+++ b/build-info-extractor-ivy/src/main/java/org/jfrog/build/extractor/listener/ArtifactoryBuildListener.java
@@ -349,7 +349,6 @@ public class ArtifactoryBuildListener implements BuildListener {
 
         BuildInfo buildInfo = builder.build();
         PackageManagerUtils.collectEnvIfNeeded(clientConf, buildInfo);
-        PackageManagerUtils.filterBuildInfoProperties(clientConf, buildInfo, clientConf.getLog());
         String contextUrl = clientConf.publisher.getContextUrl();
         String username = clientConf.publisher.getUsername();
         String password = clientConf.publisher.getPassword();

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -674,8 +674,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             long time = finish.getTime() - session.getRequest().getStartTime().getTime();
 
             BuildInfo buildInfo = buildInfoBuilder.durationMillis(time).build();
-            PackageManagerUtils.collectEnvIfNeeded(conf, buildInfo);
-            PackageManagerUtils.filterBuildInfoProperties(conf, buildInfo, conf.getLog());
+            PackageManagerUtils.collectAndFilterEnvIfNeeded(conf, buildInfo);
             return buildInfo;
         }
 

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -3,13 +3,11 @@ package org.jfrog.build.extractor.maven;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.execution.AbstractExecutionListener;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.artifact.ProjectArtifactMetadata;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
@@ -677,6 +675,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
 
             BuildInfo buildInfo = buildInfoBuilder.durationMillis(time).build();
             PackageManagerUtils.collectEnvIfNeeded(conf, buildInfo);
+            PackageManagerUtils.filterBuildInfoProperties(conf, buildInfo);
             return buildInfo;
         }
 

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -675,7 +675,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
 
             BuildInfo buildInfo = buildInfoBuilder.durationMillis(time).build();
             PackageManagerUtils.collectEnvIfNeeded(conf, buildInfo);
-            PackageManagerUtils.filterBuildInfoProperties(conf, buildInfo);
+            PackageManagerUtils.filterBuildInfoProperties(conf, buildInfo, conf.getLog());
             return buildInfo;
         }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractor.java
@@ -12,7 +12,7 @@ public interface BuildInfoExtractor<C> {
 
     /**
      * <ol> <li>Collect the props (from -D props and the props supplied in the {@link
-     * org.jfrog.build.api.BuildInfoConfigProperties#PROP_PROPS_FILE} file.</li>
+     * org.jfrog.build.extractor.ci.BuildInfoConfigProperties#PROP_PROPS_FILE} file.</li>
      *
      * <li>Collect published artifacts and dependency artifacts produced/used by the underlying build technology, based
      * on the context.</li> </ol>

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -16,6 +16,8 @@ import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.BuildInfoConfigProperties;
 import org.jfrog.build.extractor.ci.BuildInfoProperties;
 import org.jfrog.build.extractor.clientConfiguration.ClientProperties;
+import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
+import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 
 import java.io.File;
 import java.io.IOException;
@@ -114,6 +116,9 @@ public abstract class BuildInfoExtractorUtils {
     }
 
     public static Properties getEnvProperties(Properties startProps, Log log) {
+        IncludeExcludePatterns patterns = new IncludeExcludePatterns(
+                startProps.getProperty(BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS),
+                startProps.getProperty(BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS));
         Properties props = new Properties();
         // Add all the startProps that starts with BuildInfoProperties.BUILD_INFO_ENVIRONMENT_PREFIX
         for (Map.Entry<Object, Object> startEntry : startProps.entrySet()) {
@@ -126,6 +131,9 @@ public abstract class BuildInfoExtractorUtils {
         Map<String, String> envMap = System.getenv();
         for (Map.Entry<String, String> entry : envMap.entrySet()) {
             String varKey = entry.getKey();
+            if (PatternMatcher.pathConflicts(varKey, patterns)) {
+                continue;
+            }
             props.put(BuildInfoProperties.BUILD_INFO_ENVIRONMENT_PREFIX + varKey, entry.getValue());
         }
 
@@ -134,6 +142,9 @@ public abstract class BuildInfoExtractorUtils {
         Map<String, String> filteredSysProps = CommonUtils.entriesOnlyOnLeftMap(sysProps, System.getenv());
         for (Map.Entry<String, String> entry : filteredSysProps.entrySet()) {
             String varKey = entry.getKey();
+            if (PatternMatcher.pathConflicts(varKey, patterns)) {
+                continue;
+            }
             props.put(varKey, entry.getValue());
         }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -157,14 +157,11 @@ public abstract class BuildInfoExtractorUtils {
         return props;
     }
 
-    private static boolean isBuildInfoProperty(String PropertyKey) {
-        if (StringUtils.startsWith(PropertyKey, BuildInfoProperties.BUILD_INFO_ENVIRONMENT_PREFIX)) {
-            return true;
-        }
-        if (StringUtils.startsWith(PropertyKey, BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS)) {
-            return true;
-        }
-        return StringUtils.startsWith(PropertyKey, BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS);
+    private static boolean isBuildInfoProperty(String propertyKey) {
+        return StringUtils.startsWithAny(propertyKey,
+                BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS,
+                BuildInfoProperties.BUILD_INFO_ENVIRONMENT_PREFIX,
+                BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS);
     }
 
     //TODO: [by YS] duplicates ArtifactoryBuildInfoClient. The client should depend on this module

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PatternMatcher.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PatternMatcher.java
@@ -23,17 +23,20 @@ public abstract class PatternMatcher {
      */
     public static boolean pathConflicts(String path, IncludeExcludePatterns patterns) {
         String[] includePatterns = patterns.getIncludePatterns();
-        String[] excludePatterns = patterns.getExcludePatterns();
 
         if ((includePatterns.length > 0) && !pathMatchesPattern(path, includePatterns)) {
             return true;
         }
 
-        if ((excludePatterns.length > 0) && pathMatchesPattern(path, excludePatterns)) {
+        if (isPathExcluded(path, patterns)) {
             return true;
         }
-
         return false;
+    }
+
+    public static boolean isPathExcluded(String path, IncludeExcludePatterns patterns) {
+        String[] excludePatterns = patterns.getExcludePatterns();
+        return  (excludePatterns.length > 0) && pathMatchesPattern(path, excludePatterns);
     }
 
     /**

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PatternMatcher.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/PatternMatcher.java
@@ -22,21 +22,26 @@ public abstract class PatternMatcher {
      * @return True if the path conflicts
      */
     public static boolean pathConflicts(String path, IncludeExcludePatterns patterns) {
+        if (!isPathIncluded(path, patterns)) {
+            return true;
+        }
+        return isPathExcluded(path, patterns);
+    }
+
+    public static boolean isPathIncluded(String path, IncludeExcludePatterns patterns) {
         String[] includePatterns = patterns.getIncludePatterns();
-
-        if ((includePatterns.length > 0) && !pathMatchesPattern(path, includePatterns)) {
+        if (includePatterns.length == 0) {
             return true;
         }
-
-        if (isPathExcluded(path, patterns)) {
-            return true;
-        }
-        return false;
+        return pathMatchesPattern(path, includePatterns);
     }
 
     public static boolean isPathExcluded(String path, IncludeExcludePatterns patterns) {
         String[] excludePatterns = patterns.getExcludePatterns();
-        return  (excludePatterns.length > 0) && pathMatchesPattern(path, excludePatterns);
+        if (excludePatterns.length == 0) {
+            return false;
+        }
+        return pathMatchesPattern(path, excludePatterns);
     }
 
     /**

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
@@ -34,8 +34,7 @@ public abstract class PackageManagerExtractor implements Serializable {
         if (buildInfo == null) {
             return;
         }
-        PackageManagerUtils.collectEnvIfNeeded(clientConfiguration, buildInfo);
-        PackageManagerUtils.filterBuildInfoProperties(clientConfiguration, buildInfo, clientConfiguration.getLog());
+        PackageManagerUtils.collectAndFilterEnvIfNeeded(clientConfiguration, buildInfo);
         saveBuildInfoToFile(clientConfiguration, buildInfo);
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
@@ -35,7 +35,7 @@ public abstract class PackageManagerExtractor implements Serializable {
             return;
         }
         PackageManagerUtils.collectEnvIfNeeded(clientConfiguration, buildInfo);
-        PackageManagerUtils.filterBuildInfoProperties(clientConfiguration, buildInfo);
+        PackageManagerUtils.filterBuildInfoProperties(clientConfiguration, buildInfo, clientConfiguration.getLog());
         saveBuildInfoToFile(clientConfiguration, buildInfo);
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerExtractor.java
@@ -35,6 +35,7 @@ public abstract class PackageManagerExtractor implements Serializable {
             return;
         }
         PackageManagerUtils.collectEnvIfNeeded(clientConfiguration, buildInfo);
+        PackageManagerUtils.filterBuildInfoProperties(clientConfiguration, buildInfo);
         saveBuildInfoToFile(clientConfiguration, buildInfo);
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -76,6 +76,7 @@ public class PackageManagerUtils {
             return;
         }
         buildInfo.setProperties(envProperties);
+        PackageManagerUtils.filterBuildInfoProperties(clientConfiguration, buildInfo, clientConfiguration.getLog());
     }
 
     public static void filterBuildInfoProperties(ArtifactoryClientConfiguration clientConfiguration, BuildInfo buildInfo, Log log) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -123,7 +123,7 @@ public class PackageManagerUtils {
         return PatternMatcher.pathConflicts(entry.getKey().toString(), patterns);
     }
 
-    private static boolean containsSuspectedSecrets(String value) {
+    public static boolean containsSuspectedSecrets(String value) {
         if (StringUtils.isBlank(value)) {
             return false;
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -3,11 +3,16 @@ package org.jfrog.build.extractor.packageManager;
 import org.apache.http.client.utils.URIBuilder;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.ci.BuildInfo;
+import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
+import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -55,7 +60,6 @@ public class PackageManagerUtils {
         Properties envProperties = new Properties();
         envProperties.putAll(clientConfiguration.getAllProperties());
 
-        // Filter env according to the include-exclude patterns
         envProperties = BuildInfoExtractorUtils.getEnvProperties(envProperties, clientConfiguration.getLog());
 
         // Add results to the buildInfo
@@ -64,5 +68,52 @@ public class PackageManagerUtils {
             return;
         }
         buildInfo.setProperties(envProperties);
+    }
+
+    public static void filterBuildInfoProperties(ArtifactoryClientConfiguration clientConfiguration, BuildInfo buildInfo) {
+        String include = clientConfiguration.getEnvVarsIncludePatterns();
+        String exclude = clientConfiguration.getEnvVarsExcludePatterns();
+        IncludeExcludePatterns includeExcludePatterns = new IncludeExcludePatterns(include, exclude);
+        filterExcludeIncludeProperties(includeExcludePatterns, buildInfo);
+    }
+
+    private static void filterExcludeIncludeProperties(IncludeExcludePatterns includePattern, BuildInfo buildInfo) {
+        // Filter envs/global properties
+        Properties props = buildInfo.getProperties();
+        if (props != null && props.size() > 0) {
+            Properties filteredProps = getExcludeIncludeProperties(includePattern, props);
+            buildInfo.setProperties(filteredProps);
+        }
+
+        // Filter modules properties
+        List<Module> modules = buildInfo.getModules();
+        if (modules != null && modules.size() > 0) {
+            return;
+        }
+        for (Module module : modules) {
+            Properties moduleProps = module.getProperties();
+            if (moduleProps != null && moduleProps.size() > 0) {
+                module.setProperties(getExcludeIncludeProperties(includePattern, moduleProps));
+            }
+        }
+    }
+
+
+    private static Properties getExcludeIncludeProperties(IncludeExcludePatterns patterns, Properties properties) {
+        Properties props = new Properties();
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            if (!isExcludedByKey(patterns, entry) && !isExcludedByValue(patterns, entry)) {
+                props.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return props;
+    }
+
+    private static boolean isExcludedByKey(IncludeExcludePatterns patterns, Map.Entry<Object, Object> entry) {
+        return PatternMatcher.pathConflicts(entry.getKey().toString(), patterns);
+    }
+
+    private static boolean isExcludedByValue(IncludeExcludePatterns patterns, Map.Entry<Object, Object> entry) {
+        return PatternMatcher.isPathExcluded(entry.getValue().toString(), patterns);
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -60,7 +60,7 @@ public class PackageManagerUtils {
      * @param clientConfiguration - Artifactory client configuration
      * @param buildInfo           - The target build-info
      */
-    public static void collectEnvIfNeeded(ArtifactoryClientConfiguration clientConfiguration, BuildInfo buildInfo) {
+    public static void collectAndFilterEnvIfNeeded(ArtifactoryClientConfiguration clientConfiguration, BuildInfo buildInfo) {
         if (!clientConfiguration.isIncludeEnvVars()) {
             return;
         }
@@ -76,7 +76,7 @@ public class PackageManagerUtils {
             return;
         }
         buildInfo.setProperties(envProperties);
-        PackageManagerUtils.filterBuildInfoProperties(clientConfiguration, buildInfo, clientConfiguration.getLog());
+        filterBuildInfoProperties(clientConfiguration, buildInfo, clientConfiguration.getLog());
     }
 
     public static void filterBuildInfoProperties(ArtifactoryClientConfiguration clientConfiguration, BuildInfo buildInfo, Log log) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.packageManager;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.jfrog.build.extractor.BuildInfoExtractorUtils;
 import org.jfrog.build.extractor.ci.BuildInfo;
@@ -19,6 +20,12 @@ import java.util.Properties;
  * Created by Bar Belity on 12/07/2020.
  */
 public class PackageManagerUtils {
+    private static final String apiKeySecretPrefix = "AKCp8";
+    private static final int apiKeySecretMinimalLength = 73;
+    private static final String referenceTokenSecretPrefix = "cmVmdGtuOjAxOj";
+    private static final int referenceTokenSecretMinimalLength = 64;
+    private static final String accessTokenSecretPrefix = "eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJ";
+    private static final int accessTokenSecretMinimalLength = 0;
 
     /**
      * Create a new client configuration from the 'buildInfoConfig.propertiesFile' and environment variables.
@@ -102,7 +109,7 @@ public class PackageManagerUtils {
     private static Properties getExcludeIncludeProperties(IncludeExcludePatterns patterns, Properties properties) {
         Properties props = new Properties();
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            if (!isExcludedByKey(patterns, entry) && !isExcludedByValue(patterns, entry)) {
+            if (!isExcludedByKey(patterns, entry) && !containsSuspectedSecrets(entry.getValue().toString())) {
                 props.put(entry.getKey(), entry.getValue());
             }
         }
@@ -113,7 +120,26 @@ public class PackageManagerUtils {
         return PatternMatcher.pathConflicts(entry.getKey().toString(), patterns);
     }
 
-    private static boolean isExcludedByValue(IncludeExcludePatterns patterns, Map.Entry<Object, Object> entry) {
-        return PatternMatcher.isPathExcluded(entry.getValue().toString(), patterns);
+    private static boolean containsSuspectedSecrets(String value) {
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        return containsSuspectedSecret(value, apiKeySecretPrefix, apiKeySecretMinimalLength) ||
+                containsSuspectedSecret(value, referenceTokenSecretPrefix, referenceTokenSecretMinimalLength) ||
+                containsSuspectedSecret(value, accessTokenSecretPrefix, accessTokenSecretMinimalLength);
+    }
+
+    /**
+     * Checks whether the value of a variable contains a suspected secret.
+     * Done by searching for a known constant prefix of the secret and verifying the length of the substring is sufficient to include the expected length of the secret.
+     *
+     * @param variableValue       - string to search in
+     * @param secretPrefix        - secret constant prefix
+     * @param secretMinimalLength - secret minimal expected length
+     * @return whether a secret is suspected
+     */
+    private static boolean containsSuspectedSecret(String variableValue, String secretPrefix, int secretMinimalLength) {
+        int secretIndex = variableValue.indexOf(secretPrefix);
+        return secretIndex > -1 && variableValue.substring(secretIndex).length() >= secretMinimalLength;
     }
 }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -150,6 +150,47 @@ public class BuildExtractorUtilsTest {
         System.clearProperty(gogoKey);
     }
 
+    public void testExcludePatterns() {
+        // Put system properties
+        String kokoKey = "koko";
+        String koko2Key = "akoko";
+        String gogoKey = "gogo";
+        System.setProperty(kokoKey, "parent");
+        System.setProperty(koko2Key, "parent2");
+        System.setProperty(gogoKey, "2");
+
+        Properties startProps = new Properties();
+        startProps.put(BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS, "*koko");
+        Properties buildInfoProperties = getEnvProperties(startProps, null);
+        assertNull(buildInfoProperties.getProperty("koko"), "Should not find koko property due to exclude patterns");
+        assertNull(buildInfoProperties.getProperty("akoko"), "Should not find akoko property due to exclude patterns");
+        assertEquals(buildInfoProperties.getProperty("gogo"), "2", "gogo parent number property does not match");
+
+        System.clearProperty(kokoKey);
+        System.clearProperty(gogoKey);
+    }
+
+    public void testIncludePatterns() {
+        // Put system properties
+        String gogoKey = "gogo1";
+        String gogo2Key = "gogo2a";
+        String kokoKey = "koko";
+        System.setProperty(kokoKey, "parent");
+        System.setProperty(gogoKey, "1");
+        System.setProperty(gogo2Key, "2");
+
+        Properties startProps = new Properties();
+        startProps.put(BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS, "gogo?*");
+        Properties buildInfoProperties = getEnvProperties(startProps, null);
+        assertEquals(buildInfoProperties.getProperty("gogo1"), "1", "gogo1 parent number property does not match");
+        assertEquals(buildInfoProperties.getProperty("gogo2a"), "2", "gogo2a parent number property does not match");
+        assertNull(buildInfoProperties.getProperty("koko"), "Should not find koko property due to include patterns");
+
+        System.clearProperty(gogoKey);
+        System.clearProperty(gogo2Key);
+        System.clearProperty(kokoKey);
+    }
+
     public void testBuildToJson() throws IOException {
         String[] requestedByA = new String[]{"parentA", "b", "moduleId"};
         String[] requestedByB = new String[]{"parentB", "d", "moduleId"};

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -150,47 +150,6 @@ public class BuildExtractorUtilsTest {
         System.clearProperty(gogoKey);
     }
 
-    public void testExcludePatterns() {
-        // Put system properties
-        String kokoKey = "koko";
-        String koko2Key = "akoko";
-        String gogoKey = "gogo";
-        System.setProperty(kokoKey, "parent");
-        System.setProperty(koko2Key, "parent2");
-        System.setProperty(gogoKey, "2");
-
-        Properties startProps = new Properties();
-        startProps.put(BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS, "*koko");
-        Properties buildInfoProperties = getEnvProperties(startProps, null);
-        assertNull(buildInfoProperties.getProperty("koko"), "Should not find koko property due to exclude patterns");
-        assertNull(buildInfoProperties.getProperty("akoko"), "Should not find akoko property due to exclude patterns");
-        assertEquals(buildInfoProperties.getProperty("gogo"), "2", "gogo parent number property does not match");
-
-        System.clearProperty(kokoKey);
-        System.clearProperty(gogoKey);
-    }
-
-    public void testIncludePatterns() {
-        // Put system properties
-        String gogoKey = "gogo1";
-        String gogo2Key = "gogo2a";
-        String kokoKey = "koko";
-        System.setProperty(kokoKey, "parent");
-        System.setProperty(gogoKey, "1");
-        System.setProperty(gogo2Key, "2");
-
-        Properties startProps = new Properties();
-        startProps.put(BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS, "gogo?*");
-        Properties buildInfoProperties = getEnvProperties(startProps, null);
-        assertEquals(buildInfoProperties.getProperty("gogo1"), "1", "gogo1 parent number property does not match");
-        assertEquals(buildInfoProperties.getProperty("gogo2a"), "2", "gogo2a parent number property does not match");
-        assertNull(buildInfoProperties.getProperty("koko"), "Should not find koko property due to include patterns");
-
-        System.clearProperty(gogoKey);
-        System.clearProperty(gogo2Key);
-        System.clearProperty(kokoKey);
-    }
-
     public void testBuildToJson() throws IOException {
         String[] requestedByA = new String[]{"parentA", "b", "moduleId"};
         String[] requestedByB = new String[]{"parentB", "d", "moduleId"};

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
@@ -132,7 +132,6 @@ public class PackageManagerUtilsTest {
         assertFalse(containsSuspectedSecrets("text with Capital"));
         assertFalse(containsSuspectedSecrets(" spacewith spacewith spacewith AKCp8with spacewith spacewith spacewith space"));
 
-
         assertTrue(containsSuspectedSecrets("AKCp8with spacewith spacewith spacewith spacewith spacewith spacewith space"));
         assertTrue(containsSuspectedSecrets("cmVmdGtuOjAxOjtext with pacewith spacewith spacewith spacewith spacewith space"));
         assertTrue(containsSuspectedSecrets("eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJtext with Capital"));

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
@@ -14,9 +14,12 @@ import java.util.Date;
 import java.util.Properties;
 
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getEnvProperties;
+import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.containsSuspectedSecrets;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.filterBuildInfoProperties;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class PackageManagerUtilsTest {
     static String key1 = "test-env-key1";
@@ -118,6 +121,21 @@ public class PackageManagerUtilsTest {
         assertEquals(buildInfo.getModule("foo").getProperties().getProperty("dummy-prefix" + key1), value1, key1 + " property does not match");
         assertNull(buildInfo.getModule("foo").getProperties().getProperty(key2), "Should not find " + key2 + " property due to include patterns");
         assertNull(buildInfo.getModule("foo").getProperties().getProperty(key3), "Should not find " + key3 + " property due to include patterns");
+    }
+
+    @Test
+    public void testContainsSuspectedSecrets() {
+        assertFalse(containsSuspectedSecrets(null));
+        assertFalse(containsSuspectedSecrets(""));
+        assertFalse(containsSuspectedSecrets("text"));
+        assertFalse(containsSuspectedSecrets("text with space"));
+        assertFalse(containsSuspectedSecrets("text with Capital"));
+        assertFalse(containsSuspectedSecrets(" spacewith spacewith spacewith AKCp8with spacewith spacewith spacewith space"));
+
+
+        assertTrue(containsSuspectedSecrets("AKCp8with spacewith spacewith spacewith spacewith spacewith spacewith space"));
+        assertTrue(containsSuspectedSecrets("cmVmdGtuOjAxOjtext with pacewith spacewith spacewith spacewith spacewith space"));
+        assertTrue(containsSuspectedSecrets("eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJtext with Capital"));
     }
 
     private BuildInfo createBuildInfo(Properties props) {

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
@@ -1,0 +1,145 @@
+package org.jfrog.build.extractor.packageManager;
+
+import org.jfrog.build.extractor.builder.BuildInfoBuilder;
+import org.jfrog.build.extractor.ci.BuildInfo;
+import org.jfrog.build.extractor.ci.BuildInfoConfigProperties;
+import org.jfrog.build.extractor.ci.Module;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+import java.util.Properties;
+
+import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getEnvProperties;
+import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.filterBuildInfoProperties;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class PackageManagerUtilsTest {
+    static String key1 = "test-env-key1";
+    static String value1 = "test-env-value1";
+    static String key2 = "test-env-key2";
+    static String value2 = "test-env-value2";
+    static String key3 = "test-env3";
+    static String value3 = "test-env-key1";
+
+    @BeforeClass
+    public static void setup() {
+        System.setProperty(key1, value1);
+        System.setProperty(key2, value2);
+        System.setProperty(key3, value3);
+    }
+
+    @AfterTest
+    public static void tearDown() {
+        System.clearProperty(key1);
+        System.clearProperty(key2);
+        System.clearProperty(key3);
+    }
+
+    @Test
+    public void testEmptyExcludePatterns() {
+        // build info with no properties
+        BuildInfo buildInfo = new BuildInfoBuilder("BUILD_NAME")
+                .number("BUILD_NUMBER")
+                .startedDate(new Date())
+                .properties(new Properties())
+                .build();
+        filter(buildInfo);
+
+        // build info with properties
+        Properties props = new Properties();
+        props.put(BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS, "*" + key1);
+        buildInfo = new BuildInfoBuilder("BUILD_NAME")
+                .number("BUILD_NUMBER")
+                .startedDate(new Date())
+                .properties(props)
+                .build();
+        filter(buildInfo);
+
+        // build info with properties in modules
+        Properties moduleProps = new Properties();
+        moduleProps.setProperty(key1, value1);
+        final Module module = new Module();
+        module.setId("foo");
+        module.setProperties(moduleProps);
+        buildInfo = new BuildInfoBuilder("BUILD_NAME")
+                .number("BUILD_NUMBER")
+                .startedDate(new Date())
+                .properties(new Properties())
+                .addModule(module).build();
+        filter(buildInfo);
+    }
+
+    @Test
+    public void testExcludePatterns() {
+        Properties props = new Properties();
+        props.put(BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS, "*" + key1);
+
+        BuildInfo buildInfo = createBuildInfoTest(props);
+        filter(buildInfo);
+
+        // Excluded build info property by key
+        assertNull(buildInfo.getProperties().getProperty(key1), "Should not find '" + key1 + "' property due to exclude patterns");
+        // Not Excluded build info property by key
+        assertEquals(buildInfo.getProperties().getProperty(key2), value2, key2 + " property does not match");
+        // Excluded build info property by value
+        assertNull(buildInfo.getProperties().getProperty(key3), "Should not find '" + key3 + "' property due to exclude patterns");
+
+        // Excluded module property by key
+        assertNull(buildInfo.getModule("foo").getProperties().getProperty(key1), "Should not find '" + key1 + "' property due to exclude patterns");
+        // Excluded module property by key
+        assertNull(buildInfo.getModule("foo").getProperties().getProperty("dummy-prefix" + key1), "Should not find 'dummy-prefix" + key1 + "' property due to exclude patterns");
+        // Not excluded module property by key
+        assertEquals(buildInfo.getModule("foo").getProperties().getProperty(key2), value2, key2 + " property does not match");
+        // Excluded module property by value
+        assertNull(buildInfo.getModule("foo").getProperties().getProperty(key3), "Should not find '" + key3 + "' property due to exclude patterns");
+
+    }
+
+    @Test
+    public void testIncludePatterns() {
+        Properties props = new Properties();
+        props.put(BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS, "*" + key1);
+
+        BuildInfo buildInfo = createBuildInfoTest(props);
+        filter(buildInfo);
+
+        // Included build info property by key
+        assertEquals(buildInfo.getProperties().getProperty(key1), value1, key1 + " property does not match");
+        assertNull(buildInfo.getProperties().getProperty(key2), "Should not find '" + key2 + "' property due to exclude patterns");
+        assertNull(buildInfo.getProperties().getProperty(key3), "Should not find '" + key3 + "' property due to exclude patterns");
+
+        // Included module property by key
+        assertEquals(buildInfo.getModule("foo").getProperties().getProperty(key1), value1, key1 + " property does not match");
+        assertEquals(buildInfo.getModule("foo").getProperties().getProperty("dummy-prefix" + key1), value1, key1 + " property does not match");
+        assertNull(buildInfo.getModule("foo").getProperties().getProperty(key2), "Should not find " + key2 + " property due to include patterns");
+        assertNull(buildInfo.getModule("foo").getProperties().getProperty(key3), "Should not find " + key3 + " property due to include patterns");
+    }
+
+    private BuildInfo createBuildInfoTest(Properties props) {
+        Properties buildInfoProperties = getEnvProperties(props, null);
+        Properties moduleProps = new Properties();
+        moduleProps.setProperty(key1, value1);
+        moduleProps.setProperty("dummy-prefix" + key1, value1);
+        moduleProps.setProperty(key2, value2);
+        moduleProps.setProperty(key3, value3);
+        final Module module = new Module();
+        module.setId("foo");
+        module.setProperties(moduleProps);
+        BuildInfo buildInfo = new BuildInfoBuilder("BUILD_NAME")
+                .number("BUILD_NUMBER")
+                .startedDate(new Date())
+                .properties(buildInfoProperties)
+                .addModule(module).build();
+        return buildInfo;
+    }
+
+    private void filter(BuildInfo buildInfo) {
+        ArtifactoryClientConfiguration config = new ArtifactoryClientConfiguration(null);
+        config.fillFromProperties(buildInfo.getProperties());
+        filterBuildInfoProperties(config, buildInfo);
+    }
+}

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.packageManager;
 
+import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.builder.BuildInfoBuilder;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.BuildInfoConfigProperties;
@@ -23,7 +24,7 @@ public class PackageManagerUtilsTest {
     static String key2 = "test-env-key2";
     static String value2 = "test-env-value2";
     static String key3 = "test-env3";
-    static String value3 = "test-env-key1";
+    static String value3 = "AKCp8-test-env-key333333333est-env-key333333333est-env-key333333333est-env-key333333333";
 
     @BeforeClass
     public static void setup() {
@@ -47,7 +48,7 @@ public class PackageManagerUtilsTest {
                 .startedDate(new Date())
                 .properties(new Properties())
                 .build();
-        filter(buildInfo);
+        filterBuildInfoPropertiesTestHelper(buildInfo);
 
         // build info with properties
         Properties props = new Properties();
@@ -57,7 +58,7 @@ public class PackageManagerUtilsTest {
                 .startedDate(new Date())
                 .properties(props)
                 .build();
-        filter(buildInfo);
+        filterBuildInfoPropertiesTestHelper(buildInfo);
 
         // build info with properties in modules
         Properties moduleProps = new Properties();
@@ -70,7 +71,7 @@ public class PackageManagerUtilsTest {
                 .startedDate(new Date())
                 .properties(new Properties())
                 .addModule(module).build();
-        filter(buildInfo);
+        filterBuildInfoPropertiesTestHelper(buildInfo);
     }
 
     @Test
@@ -78,8 +79,8 @@ public class PackageManagerUtilsTest {
         Properties props = new Properties();
         props.put(BuildInfoConfigProperties.PROP_ENV_VARS_EXCLUDE_PATTERNS, "*" + key1);
 
-        BuildInfo buildInfo = createBuildInfoTest(props);
-        filter(buildInfo);
+        BuildInfo buildInfo = createBuildInfo(props);
+        filterBuildInfoPropertiesTestHelper(buildInfo);
 
         // Excluded build info property by key
         assertNull(buildInfo.getProperties().getProperty(key1), "Should not find '" + key1 + "' property due to exclude patterns");
@@ -104,8 +105,8 @@ public class PackageManagerUtilsTest {
         Properties props = new Properties();
         props.put(BuildInfoConfigProperties.PROP_ENV_VARS_INCLUDE_PATTERNS, "*" + key1);
 
-        BuildInfo buildInfo = createBuildInfoTest(props);
-        filter(buildInfo);
+        BuildInfo buildInfo = createBuildInfo(props);
+        filterBuildInfoPropertiesTestHelper(buildInfo);
 
         // Included build info property by key
         assertEquals(buildInfo.getProperties().getProperty(key1), value1, key1 + " property does not match");
@@ -119,27 +120,26 @@ public class PackageManagerUtilsTest {
         assertNull(buildInfo.getModule("foo").getProperties().getProperty(key3), "Should not find " + key3 + " property due to include patterns");
     }
 
-    private BuildInfo createBuildInfoTest(Properties props) {
+    private BuildInfo createBuildInfo(Properties props) {
         Properties buildInfoProperties = getEnvProperties(props, null);
         Properties moduleProps = new Properties();
         moduleProps.setProperty(key1, value1);
         moduleProps.setProperty("dummy-prefix" + key1, value1);
         moduleProps.setProperty(key2, value2);
         moduleProps.setProperty(key3, value3);
-        final Module module = new Module();
+        Module module = new Module();
         module.setId("foo");
         module.setProperties(moduleProps);
-        BuildInfo buildInfo = new BuildInfoBuilder("BUILD_NAME")
+        return new BuildInfoBuilder("BUILD_NAME")
                 .number("BUILD_NUMBER")
                 .startedDate(new Date())
                 .properties(buildInfoProperties)
                 .addModule(module).build();
-        return buildInfo;
     }
 
-    private void filter(BuildInfo buildInfo) {
+    private void filterBuildInfoPropertiesTestHelper(BuildInfo buildInfo) {
         ArtifactoryClientConfiguration config = new ArtifactoryClientConfiguration(null);
         config.fillFromProperties(buildInfo.getProperties());
-        filterBuildInfoProperties(config, buildInfo);
+        filterBuildInfoProperties(config, buildInfo, new NullLog());
     }
 }


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Prior to this PR, build-info properties were filtered only for environment variables and system properties.
The PR moves all filter logic into one place and performs exclude/include logic for all properties, including:

1. Environment variables (including properties with `buildInfo.env` prefix)
2. System properties
3. Properties from file
4. Build-info modules properties
5. Exclude not just the key but also the value of properties