### PR TITLE
Add Client ID to the usage report

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ReportUsage.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ReportUsage.java
@@ -21,6 +21,9 @@ public class ReportUsage extends VoidJFrogService {
     public ReportUsage(UsageReporter usageReporter, Log log) {
         super(log);
         this.usageReporter = usageReporter;
+        if (usageReporter.getUniqueClientId() == null) {
+            log.debug("Wasn't able to generate unique client ID");
+        }
     }
 
     @Override

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ReportUsage.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/ReportUsage.java
@@ -21,9 +21,6 @@ public class ReportUsage extends VoidJFrogService {
     public ReportUsage(UsageReporter usageReporter, Log log) {
         super(log);
         this.usageReporter = usageReporter;
-        if (usageReporter.getUniqueClientId() == null) {
-            log.debug("Wasn't able to generate unique client ID");
-        }
     }
 
     @Override

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/usageReport/ClientIdUsageReporter.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/usageReport/ClientIdUsageReporter.java
@@ -1,0 +1,58 @@
+package org.jfrog.build.extractor.usageReport;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jfrog.build.api.util.Log;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+/**
+ * Created by tala on 02/04/2023.
+ */
+@SuppressWarnings("unused")
+public class ClientIdUsageReporter extends UsageReporter {
+    private final Log logger;
+    private final String uniqueClientId;
+
+    @SuppressWarnings("unused")
+    public String getUniqueClientId() {
+        return uniqueClientId;
+    }
+
+    @SuppressWarnings("unused")
+    public ClientIdUsageReporter(String productId, String[] featureIds, Log logger) {
+        super(productId, featureIds);
+        this.logger = logger;
+        uniqueClientId = generateUniqueClientId();
+    }
+
+    /**
+     * Generates unique client ID based on MAC address.
+     * The MAC address can't be retrieved from the generated ID, as SHA1 hashing is used.
+     *
+     * @return unique client ID
+     */
+    private String generateUniqueClientId() {
+        byte[] macAddress = null;
+        try {
+            macAddress = getMacAddress();
+        } catch (SocketException e) {
+            logger.warn("Wasn't able to generate unique client ID: " + ExceptionUtils.getRootCauseMessage(e));
+        }
+        return macAddress != null ? DigestUtils.sha1Hex(macAddress) : null;
+    }
+
+    private static byte[] getMacAddress() throws SocketException {
+        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        while (networkInterfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = networkInterfaces.nextElement();
+            byte[] macAddressed = networkInterface.getHardwareAddress();
+            if (macAddressed != null) {
+                return macAddressed;
+            }
+        }
+        return null;
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/usageReport/UsageReporter.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/usageReport/UsageReporter.java
@@ -1,15 +1,10 @@
 package org.jfrog.build.extractor.usageReport;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 
 import java.io.IOException;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
 
 /**
  * Created by Bar Belity on 20/11/2019.
@@ -17,7 +12,6 @@ import java.util.Enumeration;
 public class UsageReporter {
     private final String productId;
     private FeatureId[] features;
-    private String uniqueClientId;
 
     public UsageReporter(String productId, String[] featureIds) {
         this.productId = productId;
@@ -29,11 +23,6 @@ public class UsageReporter {
         try (ArtifactoryManager artifactoryManager = new ArtifactoryManager(artifactoryUrl, username, password, accessToken, log)) {
             if (proxyConfiguration != null) {
                 artifactoryManager.setProxyConfiguration(proxyConfiguration);
-            }
-            try {
-                uniqueClientId = uniqueClientId == null ? generateUniqueClientId() : uniqueClientId;
-            } catch (SocketException e) {
-                log.warn("Wasn't able to generate unique client ID: " + ExceptionUtils.getRootCauseMessage(e));
             }
             artifactoryManager.reportUsage(this);
         }
@@ -49,11 +38,6 @@ public class UsageReporter {
         return features;
     }
 
-    @SuppressWarnings("unused")
-    public String getUniqueClientId() {
-        return uniqueClientId;
-    }
-
     private void setFeatures(String[] featureIds) {
         features = new FeatureId[featureIds.length];
         int featureIndex = 0;
@@ -61,30 +45,6 @@ public class UsageReporter {
             features[featureIndex] = new FeatureId(featureId);
             featureIndex++;
         }
-    }
-
-    /**
-     * Generates unique client ID based on MAC address.
-     * The MAC address can't be retrieved from the generated ID, as SHA1 hashing is used.
-     *
-     * @return unique client ID
-     * @throws SocketException if an I/O error occurs while trying to found the MAC address
-     */
-    private String generateUniqueClientId() throws SocketException {
-        byte[] macAddress = getMacAddress();
-        return macAddress != null ? DigestUtils.sha1Hex(macAddress) : null;
-    }
-
-    private static byte[] getMacAddress() throws SocketException {
-        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        while (networkInterfaces.hasMoreElements()) {
-            NetworkInterface networkInterface = networkInterfaces.nextElement();
-            byte[] macAddressed = networkInterface.getHardwareAddress();
-            if (macAddressed != null) {
-                return macAddressed;
-            }
-        }
-        return null;
     }
 
     public static class FeatureId {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/usageReport/UsageReporter.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/usageReport/UsageReporter.java
@@ -1,23 +1,38 @@
 package org.jfrog.build.extractor.usageReport;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 
 import java.io.IOException;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
 
 /**
  * Created by Bar Belity on 20/11/2019.
  */
 public class UsageReporter {
-    private String productId;
+    private final String productId;
     private FeatureId[] features;
+    private final String uniqueClientId;
 
     public UsageReporter(String productId, String[] featureIds) {
         this.productId = productId;
         setFeatures(featureIds);
+        this.uniqueClientId = generateUniqueClientId();
     }
 
+    private String generateUniqueClientId() {
+        byte[] macAddress = getMacAddress();
+        if (macAddress != null) {
+            return new String(DigestUtils.sha1(macAddress));
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unused")
     public void reportUsage(String artifactoryUrl, String username, String password, String accessToken, ProxyConfiguration proxyConfiguration, Log log) throws IOException {
         try (ArtifactoryManager artifactoryManager = new ArtifactoryManager(artifactoryUrl, username, password, accessToken, log)) {
             if (proxyConfiguration != null) {
@@ -27,12 +42,19 @@ public class UsageReporter {
         }
     }
 
+    @SuppressWarnings("unused")
     public String getProductId() {
         return productId;
     }
 
+    @SuppressWarnings("unused")
     public FeatureId[] getFeatures() {
         return features;
+    }
+
+    @SuppressWarnings("unused")
+    public String getUniqueClientId() {
+        return uniqueClientId;
     }
 
     private void setFeatures(String[] featureIds) {
@@ -44,6 +66,24 @@ public class UsageReporter {
         }
     }
 
+    private static byte[] getMacAddress() {
+        try {
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            if (!networkInterfaces.hasMoreElements()) {
+                return null;
+            }
+            for (NetworkInterface networkInterface = networkInterfaces.nextElement(); networkInterfaces.hasMoreElements(); networkInterface = networkInterfaces.nextElement()) {
+                byte[] macAddressed = networkInterface.getHardwareAddress();
+                if (macAddressed != null) {
+                    return macAddressed;
+                }
+            }
+        } catch (SocketException e) {
+            return null;
+        }
+        return null;
+    }
+
     public static class FeatureId {
         private final String featureId;
 
@@ -51,6 +91,7 @@ public class UsageReporter {
             this.featureId = featureId;
         }
 
+        @SuppressWarnings("unused")
         public String getFeatureId() {
             return featureId;
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Add client ID to the usage report - we use the first network interface MAC address we found as the client ID.