### PR TITLE
Fix missing Maven 3.9.0 requirement field

### DIFF
--- a/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
+++ b/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
@@ -178,12 +178,12 @@
                     <role-hint>default</role-hint>
                     <field-name>loggerFactory</field-name>
                 </requirement>
+                <requirement>
+                    <role>org.eclipse.aether.impl.RemoteRepositoryFilterManager</role>
+                    <role-hint>default</role-hint>
+                    <field-name>remoteRepositoryFilterManager</field-name>
+                </requirement>
             </requirements>
-            <requirement>
-                <role>org.eclipse.aether.impl.RemoteRepositoryFilterManager</role>
-                <role-hint>default</role-hint>
-                <field-name>remoteRepositoryFilterManager</field-name>
-            </requirement>
         </component>
         <!-- A class responssible for enforcing metadata resolution from Artifactory, for Maven 3 versions prior to 3.2.1 -->
         <component>


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Should fix https://github.com/jfrog/jfrog-cli/issues/1863
```
[main] ERROR org.apache.maven.cli.MavenCli - NullPointerException
java.lang.NullPointerException
    at org.eclipse.aether.internal.impl.DefaultMetadataResolver.resolve (DefaultMetadataResolver.java:213)
    at org.eclipse.aether.internal.impl.DefaultMetadataResolver.resolveMetadata (DefaultMetadataResolver.java:198)
```