### PR TITLE
Support browser login requests

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/JFrogHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/JFrogHttpClient.java
@@ -108,6 +108,10 @@ public class JFrogHttpClient implements AutoCloseable {
         return clientBuilder.getProxyConfiguration();
     }
 
+    public void setNoAnonymousUser() {
+        clientBuilder.setNoAnonymousUser(true);
+    }
+
     /**
      * Release all connection and cleanup resources.
      */

--- a/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClient.java
@@ -119,11 +119,10 @@ public class PreemptiveHttpClient implements AutoCloseable {
                     HttpHost targetHost = finalContext.getTargetHost();
                     Credentials creds = credsProvider.getCredentials(
                             new AuthScope(targetHost.getHostName(), targetHost.getPort()));
-                    if (creds == null) {
-                        throw new HttpException("No credentials for preemptive authentication");
+                    if (creds != null) {
+                        BasicScheme authScheme = new BasicScheme();
+                        authState.update(authScheme, creds);
                     }
-                    BasicScheme authScheme = new BasicScheme();
-                    authState.update(authScheme, creds);
                 }
             }
         }

--- a/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClientBuilder.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/PreemptiveHttpClientBuilder.java
@@ -55,6 +55,8 @@ public class PreemptiveHttpClientBuilder {
     private String userAgent = StringUtils.EMPTY;
     private String userName = StringUtils.EMPTY;
     private String password = StringUtils.EMPTY;
+    // Set to false to use the "anonymous" user if no credentials provided.
+    private boolean noAnonymousUser;
     private SSLContext sslContext;
     private boolean insecureTls;
     private HttpHost proxy;
@@ -91,6 +93,11 @@ public class PreemptiveHttpClientBuilder {
         return this;
     }
 
+    public PreemptiveHttpClientBuilder setNoAnonymousUser(boolean noAnonymousUser) {
+        this.noAnonymousUser = noAnonymousUser;
+        return this;
+    }
+
     public PreemptiveHttpClientBuilder setTimeout(int timeout) {
         this.timeout = timeout;
         return this;
@@ -104,7 +111,7 @@ public class PreemptiveHttpClientBuilder {
         return this;
     }
 
-    public ProxyConfiguration getProxyConfiguration(){
+    public ProxyConfiguration getProxyConfiguration() {
         return proxyConfiguration;
     }
 
@@ -150,6 +157,9 @@ public class PreemptiveHttpClientBuilder {
 
         if (StringUtils.isEmpty(accessToken)) {
             if (StringUtils.isEmpty(userName)) {
+                if (noAnonymousUser) {
+                    return;
+                }
                 userName = "anonymous";
                 password = "";
             }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/AccessManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/AccessManager.java
@@ -3,10 +3,8 @@ package org.jfrog.build.extractor.clientConfiguration.client.access;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.client.ManagerBase;
-import org.jfrog.build.extractor.clientConfiguration.client.access.services.CreateProject;
-import org.jfrog.build.extractor.clientConfiguration.client.access.services.DeleteProject;
-import org.jfrog.build.extractor.clientConfiguration.client.access.services.GetProject;
-import org.jfrog.build.extractor.clientConfiguration.client.access.services.UpdateProject;
+import org.jfrog.build.extractor.clientConfiguration.client.access.services.*;
+import org.jfrog.build.extractor.clientConfiguration.client.response.CreateAccessTokenResponse;
 
 import java.io.IOException;
 
@@ -14,6 +12,8 @@ public class AccessManager extends ManagerBase {
 
     public AccessManager(String AccessUrl, String accessToken, Log log) {
         super(AccessUrl, StringUtils.EMPTY, StringUtils.EMPTY, accessToken, log);
+        // The Access service should not accept the "anonymous" user
+        jfrogHttpClient.setNoAnonymousUser();
     }
 
     // Access has no version API.
@@ -36,6 +36,14 @@ public class AccessManager extends ManagerBase {
 
     public String getProject(String projectKey) throws IOException {
         return new GetProject(projectKey, log).execute(jfrogHttpClient);
+    }
+
+    public void sendBrowserLoginRequest(String uuid) throws IOException {
+        new SendBrowserLoginRequest(uuid, log).execute(jfrogHttpClient);
+    }
+
+    public CreateAccessTokenResponse getBrowserLoginRequestToken(String uuid) throws IOException {
+        return new GetBrowserLoginRequestToken(uuid, log).execute(jfrogHttpClient);
     }
 
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/GetBrowserLoginRequestToken.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/GetBrowserLoginRequestToken.java
@@ -1,0 +1,41 @@
+package org.jfrog.build.extractor.clientConfiguration.client.access.services;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.clientConfiguration.client.JFrogService;
+import org.jfrog.build.extractor.clientConfiguration.client.response.CreateAccessTokenResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.jfrog.build.extractor.clientConfiguration.client.access.services.Utils.BROWSER_LOGIN_ENDPOINT;
+
+public class GetBrowserLoginRequestToken extends JFrogService<CreateAccessTokenResponse> {
+    private final String uuid;
+
+    public GetBrowserLoginRequestToken(String uuid, Log logger) {
+        super(logger);
+        this.uuid = uuid;
+    }
+
+    @Override
+    public HttpRequestBase createRequest() throws IOException {
+        return new HttpGet(String.format("%s/token/%s", BROWSER_LOGIN_ENDPOINT, uuid));
+    }
+
+    @Override
+    protected void setResponse(InputStream stream) throws IOException {
+        result = getMapper().readValue(stream, CreateAccessTokenResponse.class);
+    }
+
+    @Override
+    protected void handleUnsuccessfulResponse(HttpEntity entity) throws IOException {
+        if (getStatusCode() == HttpStatus.SC_BAD_REQUEST) {
+            return;
+        }
+        super.handleUnsuccessfulResponse(entity);
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/GetBrowserLoginRequestToken.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/GetBrowserLoginRequestToken.java
@@ -33,6 +33,7 @@ public class GetBrowserLoginRequestToken extends JFrogService<CreateAccessTokenR
 
     @Override
     protected void handleUnsuccessfulResponse(HttpEntity entity) throws IOException {
+        // Until the user successfully completes the login process, Access will return status code 400.
         if (getStatusCode() == HttpStatus.SC_BAD_REQUEST) {
             return;
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/SendBrowserLoginRequest.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/SendBrowserLoginRequest.java
@@ -1,0 +1,44 @@
+package org.jfrog.build.extractor.clientConfiguration.client.access.services;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.jfrog.build.api.util.Log;
+import org.jfrog.build.extractor.clientConfiguration.client.VoidJFrogService;
+
+import java.io.IOException;
+
+import static org.jfrog.build.extractor.clientConfiguration.client.access.services.Utils.BROWSER_LOGIN_ENDPOINT;
+import static org.jfrog.build.extractor.clientConfiguration.util.JsonUtils.toJsonString;
+
+public class SendBrowserLoginRequest extends VoidJFrogService {
+    private final String uuid;
+
+    public SendBrowserLoginRequest(String uuid, Log logger) {
+        super(logger);
+        this.uuid = uuid;
+    }
+
+    @Override
+    public HttpRequestBase createRequest() throws IOException {
+        HttpPost request = new HttpPost(BROWSER_LOGIN_ENDPOINT + "/request");
+        BrowserLoginRequest browserLoginRequest = new BrowserLoginRequest(uuid);
+        StringEntity stringEntity = new StringEntity(toJsonString(browserLoginRequest), ContentType.APPLICATION_JSON);
+        request.setEntity(stringEntity);
+        return request;
+    }
+
+    private static class BrowserLoginRequest {
+        private final String session;
+
+        public BrowserLoginRequest(String session) {
+            this.session = session;
+        }
+
+        @SuppressWarnings("unused")
+        public String getSession() {
+            return session;
+        }
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/Utils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/access/services/Utils.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.client.access.services;
 
 public class Utils {
+    public static final String BROWSER_LOGIN_ENDPOINT = "api/v2/authentication/jfrog_client_login";
     public static final String PROJECTS_ENDPOINT = "api/v1/projects";
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/CreateAccessTokenResponse.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/response/CreateAccessTokenResponse.java
@@ -1,0 +1,70 @@
+package org.jfrog.build.extractor.clientConfiguration.client.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author yahavi
+ **/
+@SuppressWarnings("unused")
+public class CreateAccessTokenResponse {
+    @JsonProperty("token_id")
+    private String tokenId;
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("expires_in")
+    private int expiresIn;
+    @JsonProperty("scope")
+    private String scope;
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    public String getTokenId() {
+        return tokenId;
+    }
+
+    public void setTokenId(String tokenId) {
+        this.tokenId = tokenId;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(int expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -350,6 +350,14 @@ project('build-info-extractor') {
         testFixturesApi group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
         testFixturesApi group: 'org.testng', name: 'testng', version: testNgVersion
         testFixturesApi group: 'org.jfrog.filespecs', name: 'file-specs-java', version: fileSpecsJavaVersion
+        testFixturesApi('org.mock-server:mockserver-netty:5.15.0') {
+            exclude module: 'snakeyaml'
+            exclude module: 'json-smart'
+            exclude module: 'rhino'
+        }
+        testFixturesApi group: 'org.yaml', name: 'snakeyaml', version: '2.0'
+        testFixturesApi group: 'net.minidev', name: 'json-smart', version: '2.4.9'
+        testFixturesApi group: 'org.mozilla', name: 'rhino', version: '1.7.12'
     }
 }
 


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Required for:
* https://github.com/jfrog/jfrog-idea-plugin/pull/359

Add 2 new APIs required for SSO login:
1. SendBrowserLoginRequest
2. GetBrowserLoginRequestToken

Allow anonymous access in JFrog Access REST APIs.