### PR TITLE
Allow excluding dependencies by scope from build info

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/BuildInfoFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/BuildInfoFields.java
@@ -35,6 +35,7 @@ public interface BuildInfoFields {
     String BUILD_ROOT = "build.root";
     String RUN_PARAMETERS = "runParameters.";
     String INCREMENTAL = "incremental";
+    String DEPENDENCY_SCOPE_EXCLUDES = "dependencyScopeExcludes";
     String GENERATED_BUILD_INFO = "generated.build.info";
     String VCS = "vcs";
     String DEPLOYABLE_ARTIFACTS = "deployable.artifacts.map";

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -18,11 +18,13 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Predicate;
 
@@ -55,6 +57,7 @@ import static org.jfrog.build.extractor.ci.BuildInfoFields.BUILD_STARTED;
 import static org.jfrog.build.extractor.ci.BuildInfoFields.BUILD_TIMESTAMP;
 import static org.jfrog.build.extractor.ci.BuildInfoFields.BUILD_URL;
 import static org.jfrog.build.extractor.ci.BuildInfoFields.DELETE_BUILD_ARTIFACTS;
+import static org.jfrog.build.extractor.ci.BuildInfoFields.DEPENDENCY_SCOPE_EXCLUDES;
 import static org.jfrog.build.extractor.ci.BuildInfoFields.DEPLOYABLE_ARTIFACTS;
 import static org.jfrog.build.extractor.ci.BuildInfoFields.ENVIRONMENT_PREFIX;
 import static org.jfrog.build.extractor.ci.BuildInfoFields.GENERATED_BUILD_INFO;
@@ -1353,6 +1356,10 @@ public class ArtifactoryClientConfiguration {
 
         public void setIncremental(Boolean incremental) {
             setBooleanValue(INCREMENTAL, incremental);
+        }
+
+        public Set<String> getDependencyScopeExclusions() {
+            return new HashSet<>(Arrays.asList(getStringValue(DEPENDENCY_SCOPE_EXCLUDES, "").split(",")));
         }
     }
 


### PR DESCRIPTION
This PR adds the `dependencyScopeExcludes` option that allows to exclude dependencies from the generated buildInfo json file if configured.

The main reasoning behind this change is dat in some cases you have no control over the dependencies that are provided where ever your software is deployed in, but still want to use the goodness of the JFrog Platform without to much work then excluding the dependencies saves time, especially in Xray since it doesn't have an option to exclude dependencies by scope.