### PR TITLE
Fix getLatestBuildNumber wrong condition

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -283,8 +283,9 @@ public class ArtifactoryManager extends ManagerBase {
     }
 
     public String getLatestBuildNumber(String buildName, String latestType, String project) throws IOException {
-        if (!LATEST.equals(latestType.trim()) && LAST_RELEASE.equals(latestType.trim())) {
-            log.warn("GetLatestBuildNumber accepts only two latest types: LATEST or LAST_RELEASE");
+        String trimmedLatestType = latestType.trim();
+        if (!LATEST.equals(trimmedLatestType) && !LAST_RELEASE.equals(trimmedLatestType)) {
+            log.warn("GetLatestBuildNumber accepts only two latest types: LATEST or LAST_RELEASE. Got: "+ trimmedLatestType);
             return null;
         }
         Version versionService = new Version(log);


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Wrong condition - missed the LATEST option