### PR TITLE
Gradle legacy Archives are not published

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -148,8 +148,8 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
                 String publicationsNames = clientConfig.publisher.getPublications()
                 if (publishingExtension != null && StringUtils.isNotBlank(publicationsNames)) {
                     addPublications(artifactoryTask, publishingExtension, publicationsNames)
-                } else if (projectHasOneOfComponents(artifactoryTask.project, "java", "javaPlatform")) {
-                    addDefaultPublicationsOrConfigurations(artifactoryTask, publishingExtension);
+                } else {
+                    addDefaultPublicationsOrConfigurations(artifactoryTask, publishingExtension)
                 }
             }
             artifactoryTask.projectEvaluated()
@@ -210,6 +210,9 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
      */
     private void addDefaultPublicationsOrConfigurations(ArtifactoryTask artifactoryTask, @Nullable PublishingExtension publishingExtension) {
         if (publishingExtension != null) {
+            if (!projectHasOneOfComponents(artifactoryTask.project, "java", "javaPlatform")) {
+                return
+            }
             Project project = artifactoryTask.project;
             // Add mavenWeb publication if war task exists and enabled
             Task warTask = project.tasks.findByName("war");
@@ -231,7 +234,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
 
             // Add publications to Artifactory task
             artifactoryTask.addDefaultPublications()
-        } else {
+        } else if (artifactoryTask.project.plugins.hasPlugin("maven")) {
             artifactoryTask.addDefaultArchiveConfiguration()
         }
     }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -235,6 +235,8 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
             // Add publications to Artifactory task
             artifactoryTask.addDefaultPublications()
         } else if (artifactoryTask.project.plugins.hasPlugin("maven")) {
+            // Only if the legacy Maven plugin is applied, add the default legacy Archive Configurations.
+            // The purpose of this filter is to prevent the addition of legacy Archive Configurations when using new Gradle versions.
             artifactoryTask.addDefaultArchiveConfiguration()
         }
     }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

When the Gradle Java plugin is not applied, Legacy Gradle Archive configurations are not automatically collected and published in CI mode.