### PR TITLE
Fix get build number of AQL

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -33,11 +33,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.jfrog.build.extractor.clientConfiguration.client.artifactory.services.ScanBuild.XRAY_SCAN_CONNECTION_TIMEOUT_SECS;
+import static org.jfrog.build.extractor.clientConfiguration.util.AqlHelper.isBuildLatestType;
 
 public class ArtifactoryManager extends ManagerBase {
-    public static final String LATEST = "LATEST";
-    public static final String LAST_RELEASE = "LAST_RELEASE";
-
     public ArtifactoryManager(String artifactoryUrl, String username, String password, String accessToken, Log log) {
         super(artifactoryUrl, username, password, accessToken, log);
     }
@@ -181,7 +179,7 @@ public class ArtifactoryManager extends ManagerBase {
     }
 
     public BuildInfo getBuildInfo(String buildName, String buildNumber, String project) throws IOException {
-        if (LATEST.equals(buildNumber.trim()) || LAST_RELEASE.equals(buildNumber.trim())) {
+        if (isBuildLatestType(buildNumber)) {
             buildNumber = getLatestBuildNumber(buildName, buildNumber, project);
             if (buildNumber == null) {
                 return null;
@@ -303,8 +301,8 @@ public class ArtifactoryManager extends ManagerBase {
 
     public String getLatestBuildNumber(String buildName, String latestType, String project) throws IOException {
         String trimmedLatestType = latestType.trim();
-        if (!LATEST.equals(trimmedLatestType) && !LAST_RELEASE.equals(trimmedLatestType)) {
-            log.warn("GetLatestBuildNumber accepts only two latest types: LATEST or LAST_RELEASE. Got: "+ trimmedLatestType);
+        if (!isBuildLatestType(latestType)) {
+            log.warn("GetLatestBuildNumber accepts only two latest types: LATEST or LAST_RELEASE. Got: " + trimmedLatestType);
             return null;
         }
         Version versionService = new Version(log);

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/AqlHelperTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/util/AqlHelperTest.java
@@ -1,0 +1,45 @@
+package org.jfrog.build.extractor.clientConfiguration.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
+import org.jfrog.filespecs.entities.FilesGroup;
+import org.mockserver.integration.ClientAndServer;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.jfrog.build.extractor.clientConfiguration.util.AqlHelper.LAST_RELEASE;
+import static org.jfrog.build.extractor.clientConfiguration.util.AqlHelper.LATEST;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.testng.Assert.assertEquals;
+
+public class AqlHelperTest {
+    @DataProvider
+    private Object[][] latestBuildNumberProvider() {
+        return new Object[][]{
+                {"123", "123", "123"},
+                {"", "123", "123"},
+                {LATEST, "123", "123"},
+                {LAST_RELEASE, "123", "123"},
+                {"", "", ""}
+        };
+    }
+
+    @Test(dataProvider = "latestBuildNumberProvider")
+    public void latestBuildNumberTest(String inputBuildNumber, String outputBuildNumber, String expectedBuildNumber) throws IOException {
+        try (ClientAndServer mockServer = ClientAndServer.startClientAndServer(8888);
+             ArtifactoryManager mockArtifactoryManager = new ArtifactoryManager("http://127.0.0.1:8888/artifactory", "", new NullLog())) {
+            mockServer.when(request().withPath("/artifactory/api/system/version")).respond(response().withStatusCode(HttpStatus.SC_OK).withBody("{\"version\":\"1.2.3\",\"addons\":[\"aaa\"]}"));
+            mockServer.when(request().withPath("/artifactory/api/build/patternArtifacts")).respond(response().withStatusCode(HttpStatus.SC_OK).withBody(String.format("[{\"buildName\":\"indiana\",\"buildNumber\":\"%s\"}]", outputBuildNumber)));
+
+            FilesGroup filesGroup = new FilesGroup();
+            filesGroup.setBuild("indiana" + (StringUtils.isNotBlank(inputBuildNumber) ? "/" + inputBuildNumber : ""));
+            AqlHelper aqlHelper = new AqlHelper(mockArtifactoryManager, new NullLog(), filesGroup);
+            assertEquals(aqlHelper.buildNumber, expectedBuildNumber);
+        }
+    }
+}


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix an issue caused by https://github.com/jfrog/build-info/pull/740.
In AQL queries for builds, we always try to get the latest build number, regardless of its value.
We should try to get the latest build number only in one of the following conditions:
1. buildNumber is "LATEST"
2. buildNumber is "LAST_RELEASE"
3. buildNumber is empty