### PR TITLE
Fix Python tests

### DIFF
--- a/build-info-extractor-pip/src/test/resources/org/jfrog/build/extractor/requirementsProject/requirements.txt
+++ b/build-info-extractor-pip/src/test/resources/org/jfrog/build/extractor/requirementsProject/requirements.txt
@@ -1,3 +1,3 @@
-PyYAML==5.4
+PyYAML==6.0.1
 macholib==1.11
 nltk==3.4.5

--- a/build-info-extractor-pip/src/test/resources/org/jfrog/build/extractor/setuppyProject/setup.py
+++ b/build-info-extractor-pip/src/test/resources/org/jfrog/build/extractor/setuppyProject/setup.py
@@ -10,5 +10,5 @@ setup(
     author_email='jfrog@jfrog.com',
     url='https://github.com/jfrog/project-examples',
     packages=[],
-    install_requires=['PyYAML==5.4', 'nltk==3.4.5'],
+    install_requires=['PyYAML==6.0.1', 'nltk==3.4.5'],
 )


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

PyYaml < 6.0.1 is not compatible with Cython>=3.0, which released on [July 17, 2023](https://github.com/cython/cython/releases/tag/3.0.0).

This PR fixes the following stacktrace in the tests:

>
           Traceback (most recent call last):
            File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
              return hook(config_settings)
                     ^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
              return self._get_build_requires(config_settings, requirements=['wheel'])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
              self.run_setup()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
              exec(code, locals())
            File "<string>", line 271, in <module>
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
              return distutils.core.setup(**attrs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
              return run_commands(dist)
                     ^^^^^^^^^^^^^^^^^^
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
              dist.run_commands()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
              self.run_command(cmd)
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 1234, in run_command
              super().run_command(command)
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
              cmd_obj.run()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 314, in run
              self.find_sources()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
              mm.run()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 551, in run
              self.add_defaults()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
              sdist.add_defaults(self)
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
              super().add_defaults()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
              self._add_defaults_ext()
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
              self.filelist.extend(build_ext.get_source_files())
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "<string>", line 201, in get_source_files
            File "/tmp/pip-build-env-jxxrygqy/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
              raise AttributeError(attr)
          AttributeError: cython_sources
          [end of output]