### PR TITLE
Revert "Gradle legacy Archives are not published (#748)"

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -148,8 +148,8 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
                 String publicationsNames = clientConfig.publisher.getPublications()
                 if (publishingExtension != null && StringUtils.isNotBlank(publicationsNames)) {
                     addPublications(artifactoryTask, publishingExtension, publicationsNames)
-                } else {
-                    addDefaultPublicationsOrConfigurations(artifactoryTask, publishingExtension)
+                } else if (projectHasOneOfComponents(artifactoryTask.project, "java", "javaPlatform")) {
+                    addDefaultPublicationsOrConfigurations(artifactoryTask, publishingExtension);
                 }
             }
             artifactoryTask.projectEvaluated()
@@ -210,9 +210,6 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
      */
     private void addDefaultPublicationsOrConfigurations(ArtifactoryTask artifactoryTask, @Nullable PublishingExtension publishingExtension) {
         if (publishingExtension != null) {
-            if (!projectHasOneOfComponents(artifactoryTask.project, "java", "javaPlatform")) {
-                return
-            }
             Project project = artifactoryTask.project;
             // Add mavenWeb publication if war task exists and enabled
             Task warTask = project.tasks.findByName("war");
@@ -234,9 +231,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
 
             // Add publications to Artifactory task
             artifactoryTask.addDefaultPublications()
-        } else if (artifactoryTask.project.plugins.hasPlugin("maven")) {
-            // Only if the legacy Maven plugin is applied, add the default legacy Archive Configurations.
-            // The purpose of this filter is to prevent the addition of legacy Archive Configurations when using new Gradle versions.
+        } else {
             artifactoryTask.addDefaultArchiveConfiguration()
         }
     }


### PR DESCRIPTION
This reverts commit 9c66c86e37d103f314008c5a3d36137bc81b2a13.

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

The decision to revert the change in issue #748 was made after realizing that enforcing the "java" plugin was preventing projects in every Gradle version from publishing their JARs.