### PR TITLE
Skip collecting pom if not exists

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -513,17 +513,19 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
                 }
             }
         }
-        /*
-         * In case of non packaging Pom project module, we need to create the pom file from the project's Artifact
-         */
+
+        // In case of non-pom packaging, add the pom file from the project's artifacts, if exist
         if (!pomFileAdded) {
-            addPomArtifact(project, module, patterns, excludeArtifactsFromBuild);
+            addPomArtifactIfExist(project, module, patterns, excludeArtifactsFromBuild);
         }
     }
 
-    private void addPomArtifact(MavenProject project, ModuleBuilder module,
-                                IncludeExcludePatterns patterns, boolean excludeArtifactsFromBuild) {
+    private void addPomArtifactIfExist(MavenProject project, ModuleBuilder module,
+                                       IncludeExcludePatterns patterns, boolean excludeArtifactsFromBuild) {
         File pomFile = project.getFile();
+        if (pomFile == null || !pomFile.exists()) {
+            return;
+        }
         Artifact projectArtifact = project.getArtifact();
         String artifactName = getArtifactName(projectArtifact.getArtifactId(), projectArtifact.getBaseVersion(), projectArtifact.getClassifier(), "pom");
         org.jfrog.build.extractor.ci.Artifact pomArtifact = new ArtifactBuilder(artifactName)


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

In Maven builds, the absence of a pom.xml file in the working directory might result in the following error:
```
java.lang.IllegalArgumentException: File not found: null
    at org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails$Builder.build (DeployDetails.java:154)
    at org.jfrog.build.extractor.maven.BuildInfoRecorder.addDeployableArtifact (BuildInfoRecorder.java:577)
    at org.jfrog.build.extractor.maven.BuildInfoRecorder.addPomArtifact (BuildInfoRecorder.java:540)
```

To replicate this problem, use the Maven deploy plugin to deploy a file from a directory lacking pom.xml. For instance:
```sh
jf mvn org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file -Dfile=README -Durl=https://acme.jfrog.io/artifactory/default-maven-local/ -DgroupId=groupId -DartifactId=artifactId -Dversion=1.0.0 -Dpackaging=jar -DrepositoryId=artifactory -s settings.xml
```