### PR TITLE
Resolved Issue with Running 'go' Command on Windows in Paths with Spaces

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -31,6 +31,7 @@ public class GoDriver implements Serializable {
     private final CommandExecutor commandExecutor;
     private final File workingDirectory;
     private final Log logger;
+    private static final String defaultExecutablePath = "go";
 
     public GoDriver(String executablePath, Map<String, String> env, File workingDirectory, Log logger) {
         this.commandExecutor = generateCommandExecutor(executablePath, env);
@@ -48,7 +49,7 @@ public class GoDriver implements Serializable {
     static Map<String, String> generateWindowsEnv(String executablePath, Map<String, String> env) {
         // If executablePath ends with "go" or "go.exe" - remove it from the directory path
         executablePath = StringUtils.removeEnd(executablePath, ".exe");
-        executablePath = StringUtils.removeEnd(executablePath, "go");
+        executablePath = StringUtils.removeEnd(executablePath, defaultExecutablePath);
 
         // Insert the Go executable directory path to the beginning of the Path environment variable
         // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable
@@ -61,6 +62,7 @@ public class GoDriver implements Serializable {
         }
         return newEnv;
     }
+
     /**
      * Create a CommandExecutor with the given executable path and environment variables.
      *
@@ -69,7 +71,6 @@ public class GoDriver implements Serializable {
      * @return CommandExecutor
      */
     private static CommandExecutor generateCommandExecutor(String executablePath, Map<String, String> env) {
-        String defaultExecutablePath = "go";
         if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals(executablePath, defaultExecutablePath) || env == null) {
             return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, defaultExecutablePath), env);
         }

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -71,7 +71,6 @@ public class GoDriver implements Serializable {
     }
 
     public CommandResults runCmd(String args, boolean verbose) throws IOException {
-        this.logger.info("Running go command: " + args);
         List<String> argsList = new ArrayList<>(Arrays.asList(args.split(" ")));
         return runCmd(argsList, verbose);
     }

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -46,8 +46,9 @@ public class GoDriver implements Serializable {
      * @return CommandExecutor
      */
     private static CommandExecutor generateCommandExecutor(String executablePath, Map<String, String> env) {
-        if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals("go", executablePath) || env == null) {
-            return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, "go"), env);
+        String defaultExecutablePath = "go";
+        if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals(executablePath, defaultExecutablePath) || env == null) {
+            return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, defaultExecutablePath), env);
         }
         // Handling Windows case:
         // A bug was identified for the Go executable in Windows where the executable path may be incorrectly parsed
@@ -55,17 +56,18 @@ public class GoDriver implements Serializable {
 
         // If executablePath ends with "go" or "go.exe" - remove it from the directory path
         executablePath = StringUtils.removeEnd(executablePath, ".exe");
-        executablePath = StringUtils.removeEnd(executablePath, "go");
+        executablePath = StringUtils.removeEnd(executablePath, defaultExecutablePath);
 
         // Insert the Go executable directory path to the beginning of the Path environment variable
         // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable
         env = Maps.newHashMap(env);
-        if (env.containsKey("Path")) {
-            env.put("Path", executablePath + File.pathSeparator + env.get("Path"));
+        String windowsPathEnvKey = "Path";
+        if (env.containsKey(windowsPathEnvKey)) {
+            env.put(windowsPathEnvKey, executablePath + File.pathSeparator + env.get(windowsPathEnvKey));
         } else {
-            env.put("Path", executablePath);
+            env.put(windowsPathEnvKey, executablePath);
         }
-        return new CommandExecutor("go", env);
+        return new CommandExecutor(defaultExecutablePath, env);
     }
 
     public CommandResults runCmd(String args, boolean verbose) throws IOException {

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -39,8 +39,6 @@ public class GoDriver implements Serializable {
 
     /**
      * Create a CommandExecutor with the given executable path and environment variables.
-     * Handle a bug in windows, where the go executable path was mistakenly considered as two command arguments
-     * in cases where the executable path contains spaces (for example: "C:\Program Files\Go\bin\go.exe").
      *
      * @param executablePath Go executable path
      * @param env            Environment variables map
@@ -50,12 +48,18 @@ public class GoDriver implements Serializable {
         if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals("go", executablePath) || env == null) {
             return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, "go"), env);
         }
-        // Handling windows case
-        // If executablePath ends with "/go" - remove it
+        // Handling Windows case:
+        // A bug was identified for the Go executable in Windows where the executable path may be incorrectly parsed
+        // as two command arguments when the path contains spaces (e.g., "C:\Program Files\Go\bin\go.exe").
+
+        // If executablePath ends with "/go" - remove it from the directory path
+        // TODO: handle \\go or go.exe?
         if (StringUtils.endsWith(executablePath, "go")) {
             executablePath = StringUtils.substring(executablePath, 0, executablePath.length() - 3);
         }
 
+        // Insert the Go executable directory path to the beginning of the Path environment variable
+        // todo: test for windows where we check that the right path entered the environment variable
         if (env.containsKey("Path")) {
             env.put("Path", executablePath + File.pathSeparator + env.get("Path"));
         } else {

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -31,9 +31,30 @@ public class GoDriver implements Serializable {
     private final Log logger;
 
     public GoDriver(String executablePath, Map<String, String> env, File workingDirectory, Log logger) {
-        this.commandExecutor = new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, "go"), env);
+        putGoExecutablePathInEnv(executablePath, env);
+        this.commandExecutor = new CommandExecutor("go", env);
         this.workingDirectory = workingDirectory;
         this.logger = logger;
+    }
+
+    /**
+     * Add go executable path to PATH env variable, so that go can be executed from any directory.
+     * A bug was found while running go commands in windows,
+     * where the go executable path was mistakenly considered as two command arguments
+     * because of space in the go executable path (for example: "C:\Program Files\Go\bin\go.exe").
+     *
+     * @param executablePath Go executable path
+     * @param env            Environment variables map
+     */
+    private static void putGoExecutablePathInEnv(String executablePath, Map<String, String> env) {
+        if (StringUtils.isBlank(executablePath) || env == null) {
+            return;
+        }
+        if (env.containsKey("PATH")) {
+            env.put("PATH", executablePath + File.pathSeparator + env.get("PATH"));
+        } else {
+            env.put("PATH", executablePath);
+        }
     }
 
     public CommandResults runCmd(String args, boolean verbose) throws IOException {

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.go;
 
+import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.Log;
@@ -57,6 +58,8 @@ public class GoDriver implements Serializable {
         executablePath = StringUtils.removeEnd(executablePath, "go");
 
         // Insert the Go executable directory path to the beginning of the Path environment variable
+        // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable
+        env = Maps.newHashMap(env);
         if (env.containsKey("Path")) {
             env.put("Path", executablePath + File.pathSeparator + env.get("Path"));
         } else {

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -33,9 +33,9 @@ public class GoDriver implements Serializable {
 
     public GoDriver(String executablePath, Map<String, String> env, File workingDirectory, Log logger) {
         logger.info("Using go executable path: " + executablePath);
-        logger.info("PATH environment variable before: " + env.get("PATH"));
+        logger.info("PATH environment variable before: " + env.get("Path"));
         putGoExecutablePathInEnv(executablePath, env);
-        logger.info("PATH environment variable after: " + env.get("PATH"));
+        logger.info("PATH environment variable after: " + env.get("Path"));
         this.commandExecutor = new CommandExecutor("go", env);
         this.workingDirectory = workingDirectory;
         this.logger = logger;

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -48,7 +48,7 @@ public class GoDriver implements Serializable {
      */
     private static CommandExecutor generateCommandExecutor(String executablePath, Map<String, String> env) {
         if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals("go", executablePath) || env == null) {
-            return new CommandExecutor(executablePath, env);
+            return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, "go"), env);
         }
         // Handling windows case
         // If executablePath ends with "/go" - remove it

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -26,12 +26,12 @@ public class GoDriver implements Serializable {
     private static final String GO_GET_CMD = "get";
     private static final String GO_LIST_MODULE_CMD = "list -m";
     private static final String GO_VERSION_CMD = "version";
+    private static final String DEFAULT_EXECUTABLE_NAME = "go";
 
     private static final long serialVersionUID = 1L;
     private final CommandExecutor commandExecutor;
     private final File workingDirectory;
     private final Log logger;
-    private static final String defaultExecutablePath = "go";
 
     public GoDriver(String executablePath, Map<String, String> env, File workingDirectory, Log logger) {
         this.commandExecutor = generateCommandExecutor(executablePath, env);
@@ -49,7 +49,7 @@ public class GoDriver implements Serializable {
     static Map<String, String> generateWindowsEnv(String executablePath, Map<String, String> env) {
         // If executablePath ends with "go" or "go.exe" - remove it from the directory path
         executablePath = StringUtils.removeEnd(executablePath, ".exe");
-        executablePath = StringUtils.removeEnd(executablePath, defaultExecutablePath);
+        executablePath = StringUtils.removeEnd(executablePath, DEFAULT_EXECUTABLE_NAME);
 
         // Insert the Go executable directory path to the beginning of the Path environment variable
         // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable
@@ -71,13 +71,13 @@ public class GoDriver implements Serializable {
      * @return CommandExecutor
      */
     private static CommandExecutor generateCommandExecutor(String executablePath, Map<String, String> env) {
-        if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals(executablePath, defaultExecutablePath) || env == null) {
-            return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, defaultExecutablePath), env);
+        if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals(executablePath, DEFAULT_EXECUTABLE_NAME) || env == null) {
+            return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, DEFAULT_EXECUTABLE_NAME), env);
         }
-        // Handling Windows case:
+        // Handling Windows case with a given executable path:
         // A bug was identified for the Go executable in Windows where the executable path may be incorrectly parsed
         // as two command arguments when the path contains spaces (e.g., "C:\Program Files\Go\bin\go.exe").
-        return new CommandExecutor(defaultExecutablePath, generateWindowsEnv(executablePath, env));
+        return new CommandExecutor(DEFAULT_EXECUTABLE_NAME, generateWindowsEnv(executablePath, env));
     }
 
     public CommandResults runCmd(String args, boolean verbose) throws IOException {

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -52,14 +52,11 @@ public class GoDriver implements Serializable {
         // A bug was identified for the Go executable in Windows where the executable path may be incorrectly parsed
         // as two command arguments when the path contains spaces (e.g., "C:\Program Files\Go\bin\go.exe").
 
-        // If executablePath ends with "/go" - remove it from the directory path
-        // TODO: handle \\go or go.exe?
-        if (StringUtils.endsWith(executablePath, "go")) {
-            executablePath = StringUtils.substring(executablePath, 0, executablePath.length() - 3);
-        }
+        // If executablePath ends with "go" or "go.exe" - remove it from the directory path
+        executablePath = StringUtils.removeEnd(executablePath, ".exe");
+        executablePath = StringUtils.removeEnd(executablePath, "go");
 
         // Insert the Go executable directory path to the beginning of the Path environment variable
-        // todo: test for windows where we check that the right path entered the environment variable
         if (env.containsKey("Path")) {
             env.put("Path", executablePath + File.pathSeparator + env.get("Path"));
         } else {

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.go;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -126,7 +127,7 @@ public class GoDriverTest {
         File projectDir = Files.createTempDirectory("").toFile();
         try {
             if (SystemUtils.IS_OS_WINDOWS) {
-                Map<String, String> env = System.getenv();
+                Map<String, String> env = Maps.newHashMap(System.getenv());
                 new GoDriver("C:\\Program Files\\Go\\bin\\go", env, projectDir, new NullLog());
                 assertTrue(getPathEnv(env).contains("C:\\Program Files\\Go\\bin"));
             }

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.go;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -118,18 +117,16 @@ public class GoDriverTest {
         }
     }
 
-    private static String getPathEnv(Map<String, String> env) {
-        return env.get(SystemUtils.IS_OS_WINDOWS ? "Path" : "PATH");
-    }
-
     @Test
-    public void testGoDriverInit() throws IOException {
+    public void testGoDriverWindowsInit() throws IOException {
         File projectDir = Files.createTempDirectory("").toFile();
         try {
             if (SystemUtils.IS_OS_WINDOWS) {
-                Map<String, String> env = Maps.newHashMap(System.getenv());
-                new GoDriver("C:\\Program Files\\Go\\bin\\go", env, projectDir, new NullLog());
-                assertTrue(getPathEnv(env).contains("C:\\Program Files\\Go\\bin"));
+                Map<String, String> systemEnv = System.getenv();
+                String executablePath = "C:\\Program Files\\Go\\bin\\go";
+                Map<String, String> executorEnv = GoDriver.generateWindowsEnv(executablePath, systemEnv);
+                assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
+                new GoDriver(executablePath, systemEnv, projectDir, new NullLog());
             }
         } finally {
             FileUtils.deleteDirectory(projectDir);

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.executor.CommandResults;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -119,15 +120,16 @@ public class GoDriverTest {
 
     @Test
     public void testGoDriverWindowsInit() throws IOException {
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Skipping Windows test");
+        }
         File projectDir = Files.createTempDirectory("").toFile();
         try {
-            if (SystemUtils.IS_OS_WINDOWS) {
-                Map<String, String> systemEnv = System.getenv();
-                String executablePath = "C:\\Program Files\\Go\\bin\\go";
-                Map<String, String> executorEnv = GoDriver.generateWindowsEnv(executablePath, systemEnv);
-                assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
-                new GoDriver(executablePath, systemEnv, projectDir, new NullLog());
-            }
+            Map<String, String> systemEnv = System.getenv();
+            String executablePath = "C:\\Program Files\\Go\\bin\\go";
+            Map<String, String> executorEnv = GoDriver.generateWindowsEnv(executablePath, systemEnv);
+            assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
+            new GoDriver(executablePath, systemEnv, projectDir, new NullLog());
         } finally {
             FileUtils.deleteDirectory(projectDir);
         }

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -2,6 +2,7 @@ package org.jfrog.build.extractor.go;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.executor.CommandResults;
 import org.testng.Assert;
@@ -13,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -110,6 +112,24 @@ public class GoDriverTest {
             CommandResults results = driver.getUsedModules(false, false, false);
             Set<String> actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n")).map(String::trim).collect(Collectors.toSet());
             assertTrue(actualUsedModules.contains("rsc.io/sampler v1.3.1"));
+        } finally {
+            FileUtils.deleteDirectory(projectDir);
+        }
+    }
+
+    private static String getPathEnv(Map<String, String> env) {
+        return env.get(SystemUtils.IS_OS_WINDOWS ? "Path" : "PATH");
+    }
+
+    @Test
+    public void testGoDriverInit() throws IOException {
+        File projectDir = Files.createTempDirectory("").toFile();
+        try {
+            if (SystemUtils.IS_OS_WINDOWS) {
+                Map<String, String> env = System.getenv();
+                new GoDriver("C:\\Program Files\\Go\\bin\\go", env, projectDir, new NullLog());
+                assertTrue(getPathEnv(env).contains("C:\\Program Files\\Go\\bin"));
+            }
         } finally {
             FileUtils.deleteDirectory(projectDir);
         }

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -121,7 +121,7 @@ public class GoDriverTest {
     @Test
     public void testGoDriverWindowsInit() throws IOException {
         if (!SystemUtils.IS_OS_WINDOWS) {
-            throw new SkipException("Skipping Windows test");
+            throw new SkipException("Skipping non-windows test");
         }
         File projectDir = Files.createTempDirectory("").toFile();
         try {
@@ -129,7 +129,6 @@ public class GoDriverTest {
             String executablePath = "C:\\Program Files\\Go\\bin\\go";
             Map<String, String> executorEnv = GoDriver.generateWindowsEnv(executablePath, systemEnv);
             assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
-            new GoDriver(executablePath, systemEnv, projectDir, new NullLog());
         } finally {
             FileUtils.deleteDirectory(projectDir);
         }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
