### PR TITLE
Escape backslashes so that they won't be removed when loading the properties

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/encryption/PropertyEncryptor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/encryption/PropertyEncryptor.java
@@ -49,6 +49,8 @@ public class PropertyEncryptor {
     private static Properties decryptProperties(byte[] encryptedData, EncryptionKeyPair keyPair) throws IOException, InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeyException {
         byte[] decryptedBytes = decrypt(encryptedData, keyPair);
         String decryptedString = new String(decryptedBytes, StandardCharsets.UTF_8);
+        // Escape backslashes so that they won't be removed when loading the properties.
+        decryptedString = decryptedString.replace("\\", "\\\\");
         return stringToProperties(decryptedString);
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfigurationTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfigurationTest.java
@@ -79,7 +79,7 @@ public class ArtifactoryClientConfigurationTest {
     public void testReadEncryptedWindowsPath() throws IOException, InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeyException {
         // Create property with windows path
         String key = "path";
-        String value = "C:\\use\\home";
+        String value = "C:\\user\\home";
         ArtifactoryClientConfiguration client = new ArtifactoryClientConfiguration(new NullLog());
         Properties clientProps = new Properties();
         clientProps.put(key, value);
@@ -95,7 +95,7 @@ public class ArtifactoryClientConfigurationTest {
             // Assert decrypted successfully.
             Properties props = decryptPropertiesFromFile(tempFile.toString(), keyPair);
             assertNotNull(props);
-            assertEquals(props.getProperty(key), client.getAllProperties().get(key));
+            assertEquals(props.getProperty(key), value);
         }
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfigurationTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfigurationTest.java
@@ -75,6 +75,30 @@ public class ArtifactoryClientConfigurationTest {
         }
     }
 
+    @Test(description = "Test read encrypted property file")
+    public void testReadEncryptedWindowsPath() throws IOException, InvalidAlgorithmParameterException, IllegalBlockSizeException, NoSuchPaddingException, BadPaddingException, NoSuchAlgorithmException, InvalidKeyException {
+        // Create property with windows path
+        String key = "path";
+        String value = "C:\\use\\home";
+        ArtifactoryClientConfiguration client = new ArtifactoryClientConfiguration(new NullLog());
+        Properties clientProps = new Properties();
+        clientProps.put(key, value);
+        client.fillFromProperties(clientProps);
+
+        // Save property into the file
+        tempFile = Files.createTempFile("BuildInfoExtractorUtilsTest", "").toAbsolutePath();
+        client.root.props.put(BuildInfoConfigProperties.PROP_PROPS_FILE, tempFile.toString());
+
+        try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile.toFile())) {
+            // Save encrypted file.
+            EncryptionKeyPair keyPair = client.persistToEncryptedPropertiesFile(fileOutputStream);
+            // Assert decrypted successfully.
+            Properties props = decryptPropertiesFromFile(tempFile.toString(), keyPair);
+            assertNotNull(props);
+            assertEquals(props.getProperty(key), client.getAllProperties().get(key));
+        }
+    }
+
     private ArtifactoryClientConfiguration createProxyClient() {
         ArtifactoryClientConfiguration client = new ArtifactoryClientConfiguration(new NullLog());
         Properties props = new Properties();


### PR DESCRIPTION

- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
