### PR TITLE
Client configuration should prefer system properties

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -75,8 +75,8 @@ public abstract class BuildInfoExtractorUtils {
 
     public static Properties mergePropertiesWithSystemAndPropertyFile(Properties existingProps, Log log) {
         Properties mergedProps = new Properties();
-        mergedProps.putAll(addSystemProperties(existingProps));
         mergedProps.putAll(searchAdditionalPropertiesFile(mergedProps, log));
+        mergedProps.putAll(addSystemProperties(existingProps));
         return mergedProps;
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -75,7 +75,9 @@ public abstract class BuildInfoExtractorUtils {
 
     public static Properties mergePropertiesWithSystemAndPropertyFile(Properties existingProps, Log log) {
         Properties mergedProps = new Properties();
+        // Add properties from file.
         mergedProps.putAll(searchAdditionalPropertiesFile(mergedProps, log));
+        // Merge properties from system properties - should be second to override any properties defined in the file.
         mergedProps.putAll(addSystemProperties(existingProps));
         return mergedProps;
     }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Fix https://github.com/jfrog/jfrog-cli/issues/2373

The setup for the client should prioritize Java system properties over the [default properties](https://github.com/jfrog/jfrog-cli-core/blob/c6fd4b1140b46298b9f87f988e3836b7863adc46/artifactory/utils/buildinfoproperties.go#L81C1-L81C1) set by the JFrog CLI. Take this command, for instance, where the JFrog CLI specifies `artifactory.publish.artifacts=true`, but a conflicting false value is set by a system property:
```sh
jf mvn clean install -Dartifactory.publish.artifacts=false
```

In this case, the system property should take precedence over the default value from the JFrog CLI.
