### PR TITLE
Fix running executables with spaces in their paths in Windows

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/GoDriver.java
@@ -1,8 +1,6 @@
 package org.jfrog.build.extractor.go;
 
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.executor.CommandExecutor;
 import org.jfrog.build.extractor.executor.CommandResults;
@@ -26,7 +24,6 @@ public class GoDriver implements Serializable {
     private static final String GO_GET_CMD = "get";
     private static final String GO_LIST_MODULE_CMD = "list -m";
     private static final String GO_VERSION_CMD = "version";
-    private static final String DEFAULT_EXECUTABLE_NAME = "go";
 
     private static final long serialVersionUID = 1L;
     private final CommandExecutor commandExecutor;
@@ -34,50 +31,9 @@ public class GoDriver implements Serializable {
     private final Log logger;
 
     public GoDriver(String executablePath, Map<String, String> env, File workingDirectory, Log logger) {
-        this.commandExecutor = generateCommandExecutor(executablePath, env);
+        this.commandExecutor = new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, "go"), env);
         this.workingDirectory = workingDirectory;
         this.logger = logger;
-    }
-
-    /**
-     * Generate a new mutable copy of environment variables map with the Go executable directory path inserted to the beginning of the Path.
-     *
-     * @param executablePath Go executable path
-     * @param env            Environment variables map
-     * @return a new Environment variables map
-     */
-    static Map<String, String> generateWindowsEnv(String executablePath, Map<String, String> env) {
-        // If executablePath ends with "go" or "go.exe" - remove it from the directory path
-        executablePath = StringUtils.removeEnd(executablePath, ".exe");
-        executablePath = StringUtils.removeEnd(executablePath, DEFAULT_EXECUTABLE_NAME);
-
-        // Insert the Go executable directory path to the beginning of the Path environment variable
-        // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable
-        Map<String, String> newEnv = Maps.newHashMap(env);
-        String windowsPathEnvKey = "Path";
-        if (newEnv.containsKey(windowsPathEnvKey)) {
-            newEnv.put(windowsPathEnvKey, executablePath + File.pathSeparator + newEnv.get(windowsPathEnvKey));
-        } else {
-            newEnv.put(windowsPathEnvKey, executablePath);
-        }
-        return newEnv;
-    }
-
-    /**
-     * Create a CommandExecutor with the given executable path and environment variables.
-     *
-     * @param executablePath Go executable path
-     * @param env            Environment variables map
-     * @return CommandExecutor
-     */
-    private static CommandExecutor generateCommandExecutor(String executablePath, Map<String, String> env) {
-        if (!SystemUtils.IS_OS_WINDOWS || StringUtils.isBlank(executablePath) || StringUtils.equals(executablePath, DEFAULT_EXECUTABLE_NAME) || env == null) {
-            return new CommandExecutor(StringUtils.defaultIfEmpty(executablePath, DEFAULT_EXECUTABLE_NAME), env);
-        }
-        // Handling Windows case with a given executable path:
-        // A bug was identified for the Go executable in Windows where the executable path may be incorrectly parsed
-        // as two command arguments when the path contains spaces (e.g., "C:\Program Files\Go\bin\go.exe").
-        return new CommandExecutor(DEFAULT_EXECUTABLE_NAME, generateWindowsEnv(executablePath, env));
     }
 
     public CommandResults runCmd(String args, boolean verbose) throws IOException {

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -2,11 +2,9 @@ package org.jfrog.build.extractor.go;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.executor.CommandResults;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -15,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -113,22 +110,6 @@ public class GoDriverTest {
             CommandResults results = driver.getUsedModules(false, false, false);
             Set<String> actualUsedModules = Arrays.stream(results.getRes().split("\\r?\\n")).map(String::trim).collect(Collectors.toSet());
             assertTrue(actualUsedModules.contains("rsc.io/sampler v1.3.1"));
-        } finally {
-            FileUtils.deleteDirectory(projectDir);
-        }
-    }
-
-    @Test
-    public void testGoDriverWindowsInit() throws IOException {
-        if (!SystemUtils.IS_OS_WINDOWS) {
-            throw new SkipException("Skipping non-windows test");
-        }
-        File projectDir = Files.createTempDirectory("").toFile();
-        try {
-            Map<String, String> systemEnv = System.getenv();
-            String executablePath = "C:\\Program Files\\Go\\bin\\go";
-            Map<String, String> executorEnv = GoDriver.generateWindowsEnv(executablePath, systemEnv);
-            assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
         } finally {
             FileUtils.deleteDirectory(projectDir);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -36,7 +36,7 @@ public class CommandExecutor implements Serializable {
      * @param env            - Environment variables to use during execution.
      */
     public CommandExecutor(String executablePath, Map<String, String> env) {
-        this.executablePath = escapeSpacesInPath(executablePath);
+        this.executablePath = executablePath.trim();
         Map<String, String> finalEnvMap = new HashMap<>(System.getenv());
         if (env != null) {
             Map<String, String> fixedEnvMap = new HashMap<>(env);
@@ -190,11 +190,11 @@ public class CommandExecutor implements Serializable {
                 env = generateWindowsEnv(execPath, env);
                 args.add(0, execPath.getFileName().toString());
             } else {
-                args.add(0, executablePath);
+                args.add(0, executablePath.replaceAll(" ", "^ "));
             }
             args.addAll(0, Arrays.asList("cmd", "/c"));
         } else {
-            args.add(0, executablePath);
+            args.add(0, executablePath.replaceAll(" ", "\\\\ "));
             String strArgs = join(" ", args);
             args = new ArrayList<String>() {{
                 add("/bin/sh");
@@ -233,19 +233,6 @@ public class CommandExecutor implements Serializable {
             newEnv.put(windowsPathEnvKey, execDirPath);
         }
         return newEnv;
-    }
-
-    /**
-     * Escape spaces in the input executable path and trim leading and trailing whitespaces.
-     *
-     * @param executablePath - the executable path to process
-     * @return escaped and trimmed executable path.
-     */
-    private static String escapeSpacesInPath(String executablePath) {
-        if (executablePath == null) {
-            return null;
-        }
-        return executablePath.trim().replaceAll(" ", SystemUtils.IS_OS_WINDOWS ? "^ " : "\\\\ ");
     }
 
     private static void logCommand(Log logger, List<String> args, List<String> credentials) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -184,7 +184,7 @@ public class CommandExecutor implements Serializable {
         // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable.
         Map<String, String> newEnv = Maps.newHashMap(env);
 
-        args = formatCommand(args, credentials, executablePath, env);
+        args = formatCommand(args, credentials, executablePath, newEnv);
         logCommand(logger, args, credentials);
         ProcessBuilder processBuilder = new ProcessBuilder(args)
                 .directory(execDir);

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.executor;
 
+import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -97,10 +98,10 @@ public class CommandExecutorTest {
         }
         File projectDir = Files.createTempDirectory("").toFile();
         try {
-            Map<String, String> systemEnv = System.getenv();
+            Map<String, String> env = Maps.newHashMap(System.getenv());
             Path execPath = Paths.get("C:\\Program Files\\Go\\bin\\go");
-            Map<String, String> executorEnv = CommandExecutor.generateWindowsEnv(execPath, systemEnv);
-            assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
+            CommandExecutor.addToWindowsPath(env, execPath);
+            assertTrue(env.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
         } finally {
             FileUtils.deleteDirectory(projectDir);
         }

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -1,8 +1,10 @@
 package org.jfrog.build.extractor.executor;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.api.util.NullLog;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -12,8 +14,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -83,6 +87,22 @@ public class CommandExecutorTest {
             assertTrue(results.getRes().contains("I have spoken"));
         } finally {
             FileUtils.forceDelete(tmpDir.toFile());
+        }
+    }
+
+    @Test
+    public void testGenerateWindowsEnv() throws IOException {
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            throw new SkipException("Skipping test on non-Windows OS");
+        }
+        File projectDir = Files.createTempDirectory("").toFile();
+        try {
+            Map<String, String> systemEnv = System.getenv();
+            Path execPath = Paths.get("C:\\Program Files\\Go\\bin\\go");
+            Map<String, String> executorEnv = CommandExecutor.generateWindowsEnv(execPath, systemEnv);
+            assertTrue(executorEnv.get("Path").startsWith("C:\\Program Files\\Go\\bin"));
+        } finally {
+            FileUtils.deleteDirectory(projectDir);
         }
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
When executing a command on Windows, add its directory path to the Path environment variable and execute it using its name. We do that to avoid passing an executable path that contains spaces, which causes parsing issues in Windows CMD.
