### PR TITLE
Encryption keys aren't passed in Linux Jenkins agents

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoConfigProperties.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/BuildInfoConfigProperties.java
@@ -33,6 +33,12 @@ public interface BuildInfoConfigProperties {
     String ENV_BUILDINFO_PROPFILE = "BUILDINFO_PROPFILE";
 
     /**
+     * Environment variables holding the properties file encryption key
+     */
+    String ENV_PROPERTIES_FILE_KEY = "PROPERTIES_FILE_KEY";
+    String ENV_PROPERTIES_FILE_KEY_IV = "PROPERTIES_FILE_KEY_IV";
+
+    /**
      * Maven property which indicates whether to resolve dependencies from Artifactory.
      */
     String ARTIFACTORY_RESOLUTION_ENABLED = "artifactoryResolutionEnabled";

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -22,12 +22,7 @@ import org.jfrog.build.extractor.clientConfiguration.util.encryption.EncryptionK
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.InvalidAlgorithmParameterException;
@@ -38,15 +33,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.Predicate;
 
-import static org.apache.commons.lang3.StringUtils.endsWith;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.apache.commons.lang3.StringUtils.*;
+import static org.jfrog.build.api.BuildInfoConfigProperties.ENV_PROPERTIES_FILE_KEY;
+import static org.jfrog.build.api.BuildInfoConfigProperties.ENV_PROPERTIES_FILE_KEY_IV;
 import static org.jfrog.build.extractor.UrlUtils.encodeUrl;
 import static org.jfrog.build.extractor.UrlUtils.encodeUrlPathPart;
-import static org.jfrog.build.extractor.ci.BuildInfoConfigProperties.PROP_PROPS_FILE_KEY;
-import static org.jfrog.build.extractor.ci.BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV;
 import static org.jfrog.build.extractor.clientConfiguration.util.encryption.PropertyEncryptor.decryptPropertiesFromFile;
 
 /**
@@ -260,14 +251,14 @@ public abstract class BuildInfoExtractorUtils {
      * @return The encryption key obtained from system properties or additional properties.
      */
     private static String getPropertiesFileEncryptionKey() {
-        return StringUtils.isNotBlank(System.getenv(PROP_PROPS_FILE_KEY)) ? System.getenv(PROP_PROPS_FILE_KEY) : System.getProperty(PROP_PROPS_FILE_KEY);
+        return StringUtils.isNotBlank(System.getenv(ENV_PROPERTIES_FILE_KEY)) ? System.getenv(ENV_PROPERTIES_FILE_KEY) : System.getProperty(ENV_PROPERTIES_FILE_KEY);
     }
 
     /**
      * @return The encryption IV obtained from system properties or additional properties.
      */
     private static String getPropertiesFileEncryptionKeyIv() {
-        return StringUtils.isNotBlank(System.getenv(PROP_PROPS_FILE_KEY_IV)) ? System.getenv(PROP_PROPS_FILE_KEY_IV) : System.getProperty(PROP_PROPS_FILE_KEY_IV);
+        return StringUtils.isNotBlank(System.getenv(ENV_PROPERTIES_FILE_KEY_IV)) ? System.getenv(ENV_PROPERTIES_FILE_KEY_IV) : System.getProperty(ENV_PROPERTIES_FILE_KEY_IV);
     }
 
     private static String getAdditionalPropertiesFile(Properties additionalProps, Log log) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/BuildInfoConfigProperties.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/BuildInfoConfigProperties.java
@@ -10,12 +10,8 @@ public interface BuildInfoConfigProperties {
      */
     String BUILD_INFO_CONFIG_PREFIX = "buildInfoConfig.";
     String PROPERTIES_FILE = "propertiesFile";
-    String PROPERTIES_FILE_KEY = "propertiesFileKey";
-    String PROPERTIES_FILE_KEY_IV = "propertiesFileKeyIv";
 
     String PROP_PROPS_FILE = BUILD_INFO_CONFIG_PREFIX + PROPERTIES_FILE;
-    String PROP_PROPS_FILE_KEY = BUILD_INFO_CONFIG_PREFIX + PROPERTIES_FILE_KEY;
-    String PROP_PROPS_FILE_KEY_IV = BUILD_INFO_CONFIG_PREFIX + PROPERTIES_FILE_KEY_IV;
 
     String EXPORT_FILE = "exportFile";
     String PROP_EXPORT_FILE_PATH = BUILD_INFO_CONFIG_PREFIX + EXPORT_FILE;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/packageManager/PackageManagerUtils.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.jfrog.build.api.BuildInfoConfigProperties.ENV_PROPERTIES_FILE_KEY;
+import static org.jfrog.build.api.BuildInfoConfigProperties.ENV_PROPERTIES_FILE_KEY_IV;
+
 /**
  * Created by Bar Belity on 12/07/2020.
  */
@@ -58,6 +61,7 @@ public class PackageManagerUtils {
     /**
      * Collect and filter environment variables if needed.
      * Filter buildInfo properties according to the env include-exclude patterns.
+     *
      * @param clientConfiguration - Artifactory client configuration
      * @param buildInfo           - The target build-info
      */
@@ -140,8 +144,8 @@ public class PackageManagerUtils {
 
     public static boolean isJfrogInternalKey(String key) {
         return StringUtils.contains(key, BuildInfoConfigProperties.PROP_PROPS_FILE) ||
-                StringUtils.contains(key, BuildInfoConfigProperties.PROP_PROPS_FILE_KEY) ||
-                StringUtils.contains(key, BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV);
+                StringUtils.contains(key, ENV_PROPERTIES_FILE_KEY) ||
+                StringUtils.contains(key, ENV_PROPERTIES_FILE_KEY_IV);
     }
 
     /**

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.jfrog.build.IntegrationTestsBase.getLog;
+import static org.jfrog.build.api.BuildInfoConfigProperties.ENV_PROPERTIES_FILE_KEY;
+import static org.jfrog.build.api.BuildInfoConfigProperties.ENV_PROPERTIES_FILE_KEY_IV;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.BUILD_INFO_PROP_PREDICATE;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.buildInfoToJsonString;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createBuildInfoUrl;
@@ -114,8 +116,8 @@ public class BuildExtractorUtilsTest {
 
         Arrays.asList(POPO_KEY, MOMO_KEY, KOKO_KEY, GOGO_KEY).forEach(System::clearProperty);
         unsetEnv(BuildInfoConfigProperties.PROP_PROPS_FILE);
-        unsetEnv(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY);
-        unsetEnv(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV);
+        unsetEnv(ENV_PROPERTIES_FILE_KEY);
+        unsetEnv(ENV_PROPERTIES_FILE_KEY_IV);
     }
 
     public void getBuildInfoProperties() throws IOException {
@@ -309,7 +311,7 @@ public class BuildExtractorUtilsTest {
         // Create encrypted file with properties
         setupEncryptedFileTest(createProperties());
         // Remove key
-        unsetEnv(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY);
+        unsetEnv(ENV_PROPERTIES_FILE_KEY);
         // Read properties from the encrypted file
         Properties fileProps = filterDynamicProperties(
                 mergePropertiesWithSystemAndPropertyFile(new Properties(), getLog()),
@@ -326,8 +328,8 @@ public class BuildExtractorUtilsTest {
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile.toFile())) {
             EncryptionKeyPair keyPair = client.persistToEncryptedPropertiesFile(fileOutputStream);
-            setEnv(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY, Base64.getEncoder().encodeToString(keyPair.getSecretKey()));
-            setEnv(BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV, Base64.getEncoder().encodeToString(keyPair.getIv()));
+            setEnv(ENV_PROPERTIES_FILE_KEY, Base64.getEncoder().encodeToString(keyPair.getSecretKey()));
+            setEnv(ENV_PROPERTIES_FILE_KEY_IV, Base64.getEncoder().encodeToString(keyPair.getIv()));
         }
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/packageManager/PackageManagerUtilsTest.java
@@ -13,16 +13,11 @@ import org.testng.annotations.Test;
 import java.util.Date;
 import java.util.Properties;
 
+import static org.jfrog.build.api.BuildInfoConfigProperties.*;
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.getEnvProperties;
-import static org.jfrog.build.extractor.ci.BuildInfoConfigProperties.PROP_PROPS_FILE;
-import static org.jfrog.build.extractor.ci.BuildInfoConfigProperties.PROP_PROPS_FILE_KEY;
-import static org.jfrog.build.extractor.ci.BuildInfoConfigProperties.PROP_PROPS_FILE_KEY_IV;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.containsSuspectedSecrets;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.filterBuildInfoProperties;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class PackageManagerUtilsTest {
     static String key1 = "test-env-key1";
@@ -112,8 +107,8 @@ public class PackageManagerUtilsTest {
         Properties buildInfoProperties = getEnvProperties(props, new NullLog());
         Properties moduleProps = new Properties();
         moduleProps.setProperty(key1, value1);
-        moduleProps.setProperty(PROP_PROPS_FILE_KEY, value1);
-        moduleProps.setProperty(PROP_PROPS_FILE_KEY_IV, value1);
+        moduleProps.setProperty(ENV_PROPERTIES_FILE_KEY, value1);
+        moduleProps.setProperty(ENV_PROPERTIES_FILE_KEY_IV, value1);
         moduleProps.setProperty(PROP_PROPS_FILE, value1);
         Module module = new Module();
         module.setId("foo");
@@ -129,8 +124,8 @@ public class PackageManagerUtilsTest {
 
         // Excluded build info JFrog internal keys
         assertFalse(buildInfo.getProperties().containsKey(PROP_PROPS_FILE), "Should not find '" + PROP_PROPS_FILE + "' property due to exclude JFrog internal key");
-        assertFalse(buildInfo.getProperties().containsKey(PROP_PROPS_FILE_KEY_IV), "Should not find '" + PROP_PROPS_FILE_KEY_IV + "' property due to exclude JFrog internal key");
-        assertFalse(buildInfo.getProperties().containsKey(PROP_PROPS_FILE_KEY), "Should not find '" + PROP_PROPS_FILE_KEY + "' property due to exclude JFrog internal key");
+        assertFalse(buildInfo.getProperties().containsKey(ENV_PROPERTIES_FILE_KEY_IV), "Should not find '" + ENV_PROPERTIES_FILE_KEY_IV + "' property due to exclude JFrog internal key");
+        assertFalse(buildInfo.getProperties().containsKey(ENV_PROPERTIES_FILE_KEY), "Should not find '" + ENV_PROPERTIES_FILE_KEY + "' property due to exclude JFrog internal key");
 
         // Keep build info property
         assertEquals(buildInfo.getModule("foo").getProperties().getProperty(key1), value1, key1 + " property does not match");


### PR DESCRIPTION
- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----

Instead of setting the `buildInfoConfig.propertiesFileKey` and `buildInfoConfig.propertiesFileKeyIvy` environment variables, set the following environment variables:
`PROPERTIES_FILE_KEY` and `PROPERTIES_FILE_KEY_IV`.