### PR TITLE
Add persistToPropertiesFile overload

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -239,12 +239,15 @@ public class ArtifactoryClientConfiguration {
             return;
         }
         try (FileOutputStream fos = new FileOutputStream(new File(getPropertiesFile()).getCanonicalFile())) {
-            preparePropertiesToPersist().store(fos, "BuildInfo configuration property file");
+            persistToPropertiesFile(fos);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
+    public void persistToPropertiesFile(OutputStream os) throws IOException {
+        preparePropertiesToPersist().store(os, "BuildInfo configuration property file");
+    }
 
     public EncryptionKeyPair persistToEncryptedPropertiesFile(OutputStream os) throws IOException, InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
         if (StringUtils.isEmpty(getPropertiesFile())) {


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Add persistToPropertiesFile overload to enable external stream. 
Relate to:
* https://github.com/jfrog/jenkins-artifactory-plugin/pull/923