### PR TITLE
Correct .npmrc for newer versions of NPM

### DIFF
--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/NpmDriver.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/NpmDriver.java
@@ -97,6 +97,32 @@ public class NpmDriver implements Serializable {
         }
     }
 
+    public int compareVersionTo(File workingDirectory, String compareVersion){
+        String currentVersion = this.version(workingDirectory);
+
+        List<Integer> currentComponents = Arrays.stream(currentVersion.split("\\."))
+                                                .map(Integer::parseInt)
+                                                .collect(Collectors.toList());
+        List<Integer> compareComponents = Arrays.stream(compareVersion.split("\\."))
+                                                .map(Integer::parseInt)
+                                                .collect(Collectors.toList());
+
+        int currentSize = currentComponents.size();
+        int compareSize = compareComponents.size();
+        int maxLength = Math.max(currentSize, compareSize);
+        
+        for (int i = 0; i < maxLength; i++){
+            int currentComp = i < currentSize ? currentComponents.get(i) : 0;
+            int compareComp = i < compareSize ? compareComponents.get(i) : 0;
+
+            int comp = compareComp - currentComp;
+            if(comp != 0){
+                return comp;
+            }
+        }
+        return 0;
+    }
+
     public String version(File workingDirectory) throws IOException, InterruptedException {
         return runCommand(workingDirectory, new String[]{"--version"}, Collections.emptyList()).getRes();
     }

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/NpmDriver.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/NpmDriver.java
@@ -97,8 +97,8 @@ public class NpmDriver implements Serializable {
         }
     }
 
-    public int compareVersionTo(File workingDirectory, String compareVersion){
-        String currentVersion = this.version(workingDirectory);
+    public int compareVersionTo(File workingDirectory, String compareVersion) throws IOException, InterruptedException {
+        String currentVersion = version(workingDirectory);
 
         List<Integer> currentComponents = Arrays.stream(currentVersion.split("\\."))
                                                 .map(Integer::parseInt)

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmBuildInfoExtractor.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmBuildInfoExtractor.java
@@ -189,9 +189,22 @@ public class NpmBuildInfoExtractor implements BuildInfoExtractor<NpmProject> {
             npmrcBuilder.append("proxy = ").append(this.npmProxy).append("\n");
         }
 
+        //Update Auth property for newer npm versions
+        if(this.npmDrive.compareVersionTo(workingDir, "8.19") >= 0)
+            String authProp = npmAuth.getProperty("_auth");
+        
+            String newAuthKey = artifactoryManage.getUrl();
+            if (!StringUtils.endsWith(newAuthKey, "/")) {
+                newAuthKey += "/";
+            }
+            newAuthKey += "api/npm/:_auth";
+            newAuthKey = newAuthKey.replaceAll("^http(s)?:","") + ":_auth";
+            npmAuth.setProperty(newAuthKey, authProp);
+            npmAuth.remove("_auth");
+        }
+
         // Save npm auth
         npmAuth.forEach((key, value) -> npmrcBuilder.append(key).append("=").append(value).append("\n"));
-
         // Write npmrc file
         try (FileWriter fileWriter = new FileWriter(npmrcPath.toFile());
              BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {

--- a/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmBuildInfoExtractor.java
+++ b/build-info-extractor-npm/src/main/java/org/jfrog/build/extractor/npm/extractor/NpmBuildInfoExtractor.java
@@ -190,17 +190,19 @@ public class NpmBuildInfoExtractor implements BuildInfoExtractor<NpmProject> {
         }
 
         //Update Auth property for newer npm versions
-        if(this.npmDrive.compareVersionTo(workingDir, "8.19") >= 0)
-            String authProp = npmAuth.getProperty("_auth");
-        
-            String newAuthKey = artifactoryManage.getUrl();
-            if (!StringUtils.endsWith(newAuthKey, "/")) {
-                newAuthKey += "/";
+        if( this.npmDriver.compareVersionTo(workingDir.toFile(), "8.19") >= 0){
+            try (ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.build()) {
+                String authProp = npmAuth.getProperty("_auth");
+
+                String newAuthKey = artifactoryManager.getUrl();
+                if (!StringUtils.endsWith(newAuthKey, "/")) {
+                    newAuthKey += "/";
+                }
+                newAuthKey += "api/npm/:_auth";
+                newAuthKey = newAuthKey.replaceAll("^http(s)?:","") + ":_auth";
+                npmAuth.setProperty(newAuthKey, authProp);
+                npmAuth.remove("_auth");
             }
-            newAuthKey += "api/npm/:_auth";
-            newAuthKey = newAuthKey.replaceAll("^http(s)?:","") + ":_auth";
-            npmAuth.setProperty(newAuthKey, authProp);
-            npmAuth.remove("_auth");
         }
 
         // Save npm auth


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
Replaces old _auth from the temp npmrc file conditionally if we are past or equal the version 8.19 which introduced the new format.