### PR TITLE
Fix getMajorProjectVersion Regex pattern in Go

### DIFF
--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoVersionUtils.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoVersionUtils.java
@@ -50,7 +50,7 @@ public class GoVersionUtils {
     public static int getMajorProjectVersion(String project, Log log) {
         if (!StringUtils.isEmpty(project)) {
             project = project.toLowerCase();
-            if (project.matches("^.*/v\\d")) {
+            if (project.matches("^.*/v\\d+")) {
                 String major = project.substring(project.lastIndexOf("/v") + 2);
                 try {
                     return Integer.parseInt(major);


### PR DESCRIPTION
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
-----
