### PR TITLE
Fix tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,2 @@
-- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/build-info) passed. If this feature is not already covered by the tests, I added new tests.
+- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
 -----

--- a/.github/workflows/frogbot-scan-pr-gradle.yml
+++ b/.github/workflows/frogbot-scan-pr-gradle.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
       # Setup Gradle is needed only in case that Gradle wrapper isn't used.
       # - name: Setup Gradle
       #  uses: gradle/gradle-build-action@v2

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -76,7 +76,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+          cache: false
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -120,11 +126,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
-      - name: Install Go
-        uses: actions/setup-go@v3
+          distribution: "zulu"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
+          cache: false
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -150,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
     runs-on: ${{ matrix.os }}
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -164,11 +172,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
-      - name: Install Go
-        uses: actions/setup-go@v3
+          distribution: "zulu"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
+          cache: false
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -210,7 +220,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -244,7 +254,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -266,7 +276,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -284,11 +294,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
-      - name: Install Go
-        uses: actions/setup-go@v3
+          distribution: "zulu"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
+          cache: false
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -321,7 +333,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -330,9 +342,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install NuGet
-        uses: nuget/setup-nuget@v1
+        uses: nuget/setup-nuget@v2
         with:
-          nuget-version: 5.x
+          nuget-version: 6.x
       - name: Install dotnet
         uses: actions/setup-dotnet@v2
         with:
@@ -341,11 +353,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
-      - name: Install Go
-        uses: actions/setup-go@v3
+          distribution: "zulu"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.22.x
+          cache: false
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -387,13 +401,19 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
       - name: Setup Python3
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Setup Virtualenv
         run: python -m venv env
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+          cache: false
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -433,7 +453,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
 
       - name: Cache local Maven repository
         uses: actions/cache@v3


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
Changes:
1. Use zulu Java distribution (Java 8 temurin is no longer available).
2. Setup Go 1.22 before setting up local Artifactory.
3. Use `macos-13` instead of `macos-latest` on certain tests due to compatibility issues with `arm64` (`macos-latest-large` is also `amd64` but causes issues due to subscription limitations).
4. Use NuGet 6.

See tests are passing [here](https://github.com/RobiNino/build-info/actions/runs/9186571861).
