### PR TITLE
Remove Guava

### DIFF
--- a/build-info-client/src/main/java/org/jfrog/build/client/DeployableArtifactDetail.java
+++ b/build-info-client/src/main/java/org/jfrog/build/client/DeployableArtifactDetail.java
@@ -1,7 +1,5 @@
 package org.jfrog.build.client;
 
-import com.google.common.collect.ArrayListMultimap;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/BuildDockerCreator.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/BuildDockerCreator.java
@@ -2,12 +2,13 @@ package org.jfrog.build.extractor.docker.extractor;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ArrayListMultimap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -34,7 +35,7 @@ import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class BuildDockerCreator extends PackageManagerExtractor {
-    private final ArrayListMultimap<String, String> artifactProperties;
+    private final MultiValuedMap<String, String> artifactProperties;
     private final ArtifactoryManagerBuilder artifactoryManagerBuilder;
     private final ImageFileType imageFileType;
     private final String sourceRepo;
@@ -55,7 +56,7 @@ public class BuildDockerCreator extends PackageManagerExtractor {
      * @param artifactProperties        - Properties to be attached to the docker layers deployed to Artifactory.
      */
     public BuildDockerCreator(ArtifactoryManagerBuilder artifactoryManagerBuilder, String imageFile, ImageFileType imageFileType,
-                              ArrayListMultimap<String, String> artifactProperties, String sourceRepo, Log logger) {
+                              MultiValuedMap<String, String> artifactProperties, String sourceRepo, Log logger) {
         this.artifactoryManagerBuilder = artifactoryManagerBuilder;
         this.artifactProperties = artifactProperties;
         this.sourceRepo = sourceRepo;
@@ -91,7 +92,7 @@ public class BuildDockerCreator extends PackageManagerExtractor {
             BuildDockerCreator dockerBuildCreate = new BuildDockerCreator(artifactoryManagerBuilder,
                     imageFile,
                     imageFileType,
-                    ArrayListMultimap.create(clientConfiguration.publisher.getMatrixParams().asMultimap()),
+                    new ArrayListValuedHashMap<>(clientConfiguration.publisher.getMatrixParams()),
                     clientConfiguration.publisher.getRepoKey(),
                     clientConfiguration.getLog());
 
@@ -136,7 +137,7 @@ public class BuildDockerCreator extends PackageManagerExtractor {
     /**
      * Update each layer's properties with artifactProperties.
      */
-    private void setImageLayersProps(DockerLayers layers, ArrayListMultimap<String, String> artifactProperties, ArtifactoryManagerBuilder artifactoryManagerBuilder) throws IOException {
+    private void setImageLayersProps(DockerLayers layers, MultiValuedMap<String, String> artifactProperties, ArtifactoryManagerBuilder artifactoryManagerBuilder) throws IOException {
         if (layers == null) {
             return;
         }

--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPush.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/extractor/DockerPush.java
@@ -1,11 +1,12 @@
 package org.jfrog.build.extractor.docker.extractor;
 
-import com.google.common.collect.ArrayListMultimap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.ci.BuildInfo;
 import org.jfrog.build.extractor.ci.Module;
-import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
@@ -21,7 +22,7 @@ import java.util.Map;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
 public class DockerPush extends DockerCommand {
-    private final ArrayListMultimap<String, String> artifactProperties;
+    private final MultiValuedMap<String, String> artifactProperties;
 
 
     /**
@@ -36,7 +37,7 @@ public class DockerPush extends DockerCommand {
      * @param env                       - Environment variables to use during docker push execution.
      */
     public DockerPush(ArtifactoryManagerBuilder artifactoryManagerBuilder,
-                      String imageTag, String host, ArrayListMultimap<String, String> artifactProperties, String targetRepository, String username,
+                      String imageTag, String host, MultiValuedMap<String, String> artifactProperties, String targetRepository, String username,
                       String password, Log logger, Map<String, String> env) {
         super(artifactoryManagerBuilder, imageTag, host, targetRepository, username, password, logger, env);
         this.artifactProperties = artifactProperties;
@@ -58,7 +59,7 @@ public class DockerPush extends DockerCommand {
             DockerPush dockerPush = new DockerPush(artifactoryManagerBuilder,
                     dockerHandler.getImageTag(),
                     dockerHandler.getHost(),
-                    ArrayListMultimap.create(clientConfiguration.publisher.getMatrixParams().asMultimap()),
+                    new ArrayListValuedHashMap<>(clientConfiguration.publisher.getMatrixParams()),
                     clientConfiguration.publisher.getRepoKey(),
                     clientConfiguration.publisher.getUsername(),
                     clientConfiguration.publisher.getPassword(),
@@ -85,7 +86,7 @@ public class DockerPush extends DockerCommand {
             String imageId = DockerJavaWrapper.getImageIdFromTag(imageTag, host, env, logger);
             DockerImage image = new DockerImage(imageId, imageTag, "", targetRepository, artifactoryManagerBuilder, "", "");
             Module module = image.generateBuildInfoModule(logger, DockerUtils.CommandType.Push);
-            if (module.getArtifacts() == null || module.getArtifacts().size() == 0) {
+            if (module.getArtifacts() == null || module.getArtifacts().isEmpty()) {
                 logger.warn("Could not find docker image: " + imageTag + " in Artifactory.");
             } else {
                 setImageLayersProps(image.getLayers(), artifactProperties, artifactoryManagerBuilder);
@@ -104,7 +105,7 @@ public class DockerPush extends DockerCommand {
     /**
      * Update each layer's properties with artifactProperties.
      */
-    private void setImageLayersProps(DockerLayers layers, ArrayListMultimap<String, String> artifactProperties, ArtifactoryManagerBuilder artifactoryManagerBuilder) throws IOException {
+    private void setImageLayersProps(DockerLayers layers, MultiValuedMap<String, String> artifactProperties, ArtifactoryManagerBuilder artifactoryManagerBuilder) throws IOException {
         if (layers == null) {
             return;
         }

--- a/build-info-extractor-docker/src/test/java/org/jfrog/build/extractor/docker/extractor/DockerExtractorTest.java
+++ b/build-info-extractor-docker/src/test/java/org/jfrog/build/extractor/docker/extractor/DockerExtractorTest.java
@@ -2,10 +2,9 @@ package org.jfrog.build.extractor.docker.extractor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
+import org.apache.commons.compress.utils.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -18,6 +17,7 @@ import org.jfrog.build.extractor.executor.CommandResults;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +43,7 @@ public class DockerExtractorTest extends IntegrationTestsBase {
     private static final String SHORT_IMAGE_TAG_VIRTUAL = "3";
     private static final String EXPECTED_REMOTE_PATH_KANIKO = "hello-world/latest";
     private static final String DOCKER_HOST = "BITESTS_ARTIFACTORY_DOCKER_HOST";
-    private final ArrayListMultimap<String, String> artifactProperties = ArrayListMultimap.create();
+    private final MultiValuedMap<String, String> artifactProperties;
     private String pullImageFromVirtual;
     private String virtualDomainName;
     private String host;
@@ -56,12 +56,12 @@ public class DockerExtractorTest extends IntegrationTestsBase {
         localRepo1 = getKeyWithTimestamp(DOCKER_LOCAL_REPO);
         remoteRepo = getKeyWithTimestamp(DOCKER_REMOTE_REPO);
         virtualRepo = getKeyWithTimestamp(DOCKER_VIRTUAL_REPO);
-        artifactProperties.putAll(ImmutableMultimap.<String, String>builder()
-                .put("build.name", "docker-push-test")
-                .put("build.number", "1")
-                .put("build.timestamp", "321")
-                .put("property-key", "property-value")
-                .build());
+        artifactProperties = new ArrayListValuedHashMap<String, String>() {{
+            put("build.name", "docker-push-test");
+            put("build.number", "1");
+            put("build.timestamp", "321");
+            put("property-key", "property-value");
+        }};
     }
 
     @BeforeClass

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoPublish.java
@@ -1,7 +1,8 @@
 package org.jfrog.build.extractor.go.extractor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ArrayListMultimap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -46,7 +47,7 @@ public class GoPublish extends GoCommand {
     private static final String PKG_MOD_FILE_EXTENSION = "mod";
     private static final String PKG_INFO_FILE_EXTENSION = "info";
 
-    private final ArrayListMultimap<String, String> properties;
+    private final MultiValuedMap<String, String> properties;
     private final List<Artifact> artifactList = new ArrayList<>();
     private final String deploymentRepo;
     private final String version;
@@ -61,7 +62,7 @@ public class GoPublish extends GoCommand {
      * @param version                   - The package's version.
      * @param logger                    - The logger.
      */
-    public GoPublish(ArtifactoryManagerBuilder artifactoryManagerBuilder, ArrayListMultimap<String, String> properties, String repo, Path path, String version, String module, Log logger) throws IOException {
+    public GoPublish(ArtifactoryManagerBuilder artifactoryManagerBuilder, MultiValuedMap<String, String> properties, String repo, Path path, String version, String module, Log logger) throws IOException {
         super(artifactoryManagerBuilder, path, module, logger);
         this.goDriver = new GoDriver(GO_CLIENT_CMD, null, path.toFile(), logger);
         this.moduleName = goDriver.getModuleName();
@@ -93,7 +94,7 @@ public class GoPublish extends GoCommand {
 
             GoPublish goPublish = new GoPublish(
                     artifactoryManagerBuilder,
-                    ArrayListMultimap.create(clientConfiguration.publisher.getMatrixParams().asMultimap()),
+                    new ArrayListValuedHashMap<>(clientConfiguration.publisher.getMatrixParams()),
                     clientConfiguration.publisher.getRepoKey(),
                     Paths.get(packageManagerHandler.getPath() != null ? packageManagerHandler.getPath() : ".").toAbsolutePath(),
                     clientConfiguration.goHandler.getGoPublishedVersion(),
@@ -153,7 +154,7 @@ public class GoPublish extends GoCommand {
     private File archiveProjectDir() throws IOException {
         File zipFile = File.createTempFile(LOCAL_TMP_PKG_PREFIX + LOCAL_PKG_FILENAME, PKG_ZIP_FILE_EXTENSION, path.toFile());
         try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipFile.toPath()));
-            Stream<Path> pathFileTree = Files.walk(path)) {
+             Stream<Path> pathFileTree = Files.walk(path)) {
             List<Path> pathsList = pathFileTree
                     // Remove .git dir content, directories and the temp zip file
                     .filter(p -> !path.relativize(p).startsWith(".git/") && !Files.isDirectory(p) && !p.toFile().getName().equals(zipFile.getName()))

--- a/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoZipBallStreamer.java
+++ b/build-info-extractor-go/src/main/java/org/jfrog/build/extractor/go/extractor/GoZipBallStreamer.java
@@ -34,7 +34,6 @@
 
 package org.jfrog.build.extractor.go.extractor;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
@@ -50,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 
@@ -75,7 +75,7 @@ public class GoZipBallStreamer implements Closeable {
         this.projectName = projectName;
         this.version = version;
         this.log = log;
-        excludedDirectories = Sets.newHashSet();
+        excludedDirectories = new HashSet<>();
     }
 
     public void writeDeployableZip(File deployableZip) throws IOException {
@@ -202,7 +202,7 @@ public class GoZipBallStreamer implements Closeable {
     private void scanEntries() {
         Enumeration<? extends ZipEntry> entries = zipFile.getEntries();
         ZipEntry zipEntry;
-        Set<String> allDirectories = Sets.newHashSet();
+        Set<String> allDirectories = new HashSet<>();
         while (entries.hasMoreElements()) {
             zipEntry = entries.nextElement();
             if (!zipEntry.isDirectory() && isSubModule(zipEntry.getName())) {

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/GoDriverTest.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.go;
 
-import com.google.common.collect.Sets;
+import org.apache.commons.compress.utils.Sets;
 import org.apache.commons.io.FileUtils;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.executor.CommandResults;

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoDependencyTreeTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoDependencyTreeTest.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.go.extractor;
 
-import com.google.common.collect.Sets;
+import org.apache.commons.compress.utils.Sets;
 import org.jfrog.build.api.util.NullLog;
 import org.jfrog.build.extractor.scan.DependencyTree;
 import org.testng.annotations.Test;

--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
@@ -1,12 +1,11 @@
 package org.jfrog.build.extractor.go.extractor;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Sets;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jfrog.build.IntegrationTestsBase;
-import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.ci.*;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
@@ -66,7 +65,7 @@ public class GoExtractorTest extends IntegrationTestsBase {
             this.targetDir = targetDir;
             this.name = name;
             this.version = version;
-            this.dependencies = Sets.newHashSet(dependencies);
+            this.dependencies = new HashSet<>(Arrays.asList(dependencies));
         }
 
         private String getDependencyId() {
@@ -176,7 +175,7 @@ public class GoExtractorTest extends IntegrationTestsBase {
     @Test
     public void goRunPublishTest() {
         Path projectDir = null;
-        ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
+        MultiValuedMap<String, String> properties = MultiMapUtils.newListValuedHashMap();
         try {
             // Run Go build on project1 locally
             Project project = Project.PROJECT_1;

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/ArtifactoryTask.java
@@ -1,8 +1,8 @@
 package org.jfrog.gradle.plugin.artifactory.task;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import groovy.lang.Closure;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -162,10 +162,10 @@ public class ArtifactoryTask extends DefaultTask {
 
     public final Set<GradleDeployDetails> deployDetails = new TreeSet<>();
 
-    private final Multimap<String, CharSequence> properties = ArrayListMultimap.create();
+    private final MultiValuedMap<String, CharSequence> properties = MultiMapUtils.newListValuedHashMap();
 
     @Input
-    public Multimap<String, CharSequence> getProperties() {
+    public MultiValuedMap<String, CharSequence> getProperties() {
         return properties;
     }
 

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelper.java
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/task/helper/TaskHelper.java
@@ -1,6 +1,6 @@
 package org.jfrog.gradle.plugin.artifactory.task.helper;
 
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -70,12 +70,12 @@ public abstract class TaskHelper {
                         .name(project.getName()).version(project.getVersion().toString())
                         .classifier(artifact.getClassifier())
                         .type(artifact.getType()).build();
-        Multimap<String, CharSequence> artifactSpecsProperties = artifactoryTask.artifactSpecs.getProperties(spec);
+        MultiValuedMap<String, CharSequence> artifactSpecsProperties = artifactoryTask.artifactSpecs.getProperties(spec);
         addProps(propsToAdd, artifactSpecsProperties);
         return propsToAdd;
     }
 
-    private void addProps(Map<String, String> target, Multimap<String, CharSequence> props) {
+    private void addProps(Map<String, String> target, MultiValuedMap<String, CharSequence> props) {
         for (Map.Entry<String, CharSequence> entry : props.entries()) {
             // Make sure all GString are now Java Strings
             String key = entry.getKey();

--- a/build-info-extractor-npm/src/test/java/org/jfrog/build/extractor/npm/extractor/NpmExtractorTest.java
+++ b/build-info-extractor-npm/src/test/java/org/jfrog/build/extractor/npm/extractor/NpmExtractorTest.java
@@ -1,7 +1,8 @@
 package org.jfrog.build.extractor.npm.extractor;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableMultimap;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -207,18 +208,26 @@ public class NpmExtractorTest extends IntegrationTestsBase {
     @DataProvider
     private Object[][] npmPublishProvider() {
         return new Object[][]{
-                {Project.A, ArrayListMultimap.create(), Project.A.getTargetPath(), ""},
-                {Project.A, ArrayListMultimap.create(ImmutableMultimap.of("a", "b")), Project.A.getTargetPath(), ""},
-                {Project.B, ArrayListMultimap.create(), Project.B.getTargetPath(), Project.B.getPackedFileName()},
-                {Project.B, ArrayListMultimap.create(ImmutableMultimap.of("a", "b", "c", "d")), Project.B.getTargetPath(), Project.B.getPackedFileName()},
-                {Project.C, ArrayListMultimap.create(), Project.C.getTargetPath(), ""},
-                {Project.C, ArrayListMultimap.create(ImmutableMultimap.of("a", "b", "a", "d")), Project.C.getTargetPath(), ""}
+                {Project.A, MultiMapUtils.emptyMultiValuedMap(), Project.A.getTargetPath(), ""},
+                {Project.A, new ArrayListValuedHashMap<String, String>() {{
+                    put("a", "b");
+                }}, Project.A.getTargetPath(), ""},
+                {Project.B, MultiMapUtils.emptyMultiValuedMap(), Project.B.getTargetPath(), Project.B.getPackedFileName()},
+                {Project.B, new ArrayListValuedHashMap<String, String>() {{
+                    put("a", "b");
+                    put("c", "d");
+                }}, Project.B.getTargetPath(), Project.B.getPackedFileName()},
+                {Project.C, MultiMapUtils.emptyMultiValuedMap(), Project.C.getTargetPath(), ""},
+                {Project.C, new ArrayListValuedHashMap<String, String>() {{
+                    put("a", "b");
+                    put("a", "d");
+                }}, Project.C.getTargetPath(), ""}
         };
     }
 
     @SuppressWarnings("unused")
     @Test(dataProvider = "npmPublishProvider")
-    public void npmPublishTest(Project project, ArrayListMultimap<String, String> props, String targetPath, String packageName) {
+    public void npmPublishTest(Project project, MultiValuedMap<String, String> props, String targetPath, String packageName) {
         Path projectDir = null;
         try {
             // Run npm publish

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ModuleExtractorUtils.java
@@ -1,18 +1,10 @@
 package org.jfrog.build.extractor;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.jfrog.build.extractor.ci.Module;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
 
 import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 
@@ -20,62 +12,22 @@ import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
  * Utilities for serializing/deserializing Module info as json
  */
 public class ModuleExtractorUtils {
-    private static JsonFactory createJsonFactory() {
-        JsonFactory jsonFactory = new JsonFactory();
-        ObjectMapper mapper = createMapper();
-        mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
-        jsonFactory.setCodec(mapper);
-        return jsonFactory;
-    }
-
-    /**
-     * Given a Module object, serialize it as a json string.
-     *
-     * @param module The module to serialize
-     * @return The json string representing the serialized module
-     * @throws IOException
-     */
-    public static String moduleToJsonString(Module module) throws IOException {
-        JsonFactory jsonFactory = createJsonFactory();
-
-        try (StringWriter writer = new StringWriter();
-             JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer)) {
-            jsonGenerator.useDefaultPrettyPrinter();
-            jsonGenerator.writeObject(module);
-
-            return writer.getBuffer().toString();
-        }
-    }
-
-    /**
-     * Given a serialized json module string, deserialize it into a Module object.
-     *
-     * @param json The serialized json module string
-     * @return A Module object deserialized from the provided string
-     * @throws IOException
-     */
-    public static Module jsonStringToModule(String json) throws IOException {
-        JsonFactory jsonFactory = createJsonFactory();
-        JsonParser parser = jsonFactory.createParser(new StringReader(json));
-        return jsonFactory.getCodec().readValue(parser, Module.class);
-    }
 
     /**
      * Given a Module object, serialize it to a json string and write it to the provided file.
      *
      * @param module The module object
      * @param toFile The file to write the serialized module to
-     * @throws IOException
+     * @throws IOException in case of any serialization error.
      */
     public static void saveModuleToFile(Module module, File toFile) throws IOException {
-        String moduleInfoJson = moduleToJsonString(module);
         if (!toFile.getParentFile().exists()) {
             toFile.getParentFile().mkdirs();
         }
         if (!toFile.exists()) {
             toFile.createNewFile();
         }
-        Files.asCharSink(toFile, Charsets.UTF_8).write(moduleInfoJson);
+        createMapper().writeValue(toFile, module);
     }
 
     /**
@@ -83,10 +35,10 @@ public class ModuleExtractorUtils {
      *
      * @param fromFile The file containing a serialized json string
      * @return The Module object deserialized from the content of the file
-     * @throws IOException
+     * @throws IOException in case of any deserialization error.
      */
     public static Module readModuleFromFile(File fromFile) throws IOException {
-        String moduleInfoJson = Files.asCharSource(fromFile, Charsets.UTF_8).read();
-        return jsonStringToModule(moduleInfoJson);
+        return createMapper().readValue(fromFile, new TypeReference<Module>() {
+        });
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactSpecs.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactSpecs.java
@@ -1,7 +1,7 @@
 package org.jfrog.build.extractor.clientConfiguration;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.LinkedList;
@@ -41,8 +41,8 @@ public class ArtifactSpecs extends LinkedList<ArtifactSpec> {
      * @param spec
      * @return
      */
-    public Multimap<String, CharSequence> getProperties(ArtifactSpec spec) {
-        Multimap<String, CharSequence> props = ArrayListMultimap.create();
+    public MultiValuedMap<String, CharSequence> getProperties(ArtifactSpec spec) {
+        MultiValuedMap<String, CharSequence> props = MultiMapUtils.newListValuedHashMap();
         for (ArtifactSpec matcherSpec : this) {
             if (matcherSpec.matches(spec)) {
                 Map<String, CharSequence> matcherSpecProperties = matcherSpec.getProperties();

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/ArtifactoryManager.java
@@ -1,7 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.client.artifactory;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.jfrog.build.api.dependency.BuildPatternArtifacts;
@@ -28,6 +27,7 @@ import org.jfrog.build.extractor.usageReport.UsageReporter;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -72,7 +72,7 @@ public class ArtifactoryManager extends ManagerBase {
         setPropertiesService.execute(jfrogHttpClient);
     }
 
-    public void setProperties(String relativePath, ArrayListMultimap<String, String> properties, boolean encodeProperties) throws IOException {
+    public void setProperties(String relativePath, MultiValuedMap<String, String> properties, boolean encodeProperties) throws IOException {
         SetProperties setPropertiesService = new SetProperties(relativePath, properties, encodeProperties, log);
         setPropertiesService.execute(jfrogHttpClient);
     }
@@ -309,7 +309,7 @@ public class ArtifactoryManager extends ManagerBase {
         if (versionService.execute(jfrogHttpClient).isOSS()) {
             throw new IllegalArgumentException(String.format("%s is not supported in Artifactory OSS.", latestType));
         }
-        List<BuildPatternArtifactsRequest> artifactsRequest = Lists.newArrayList();
+        List<BuildPatternArtifactsRequest> artifactsRequest = new ArrayList<>();
         artifactsRequest.add(new BuildPatternArtifactsRequest(buildName, latestType, project));
         List<BuildPatternArtifacts> artifactsResponses = retrievePatternArtifacts(artifactsRequest);
         // Artifactory returns null if no build was found

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SetProperties.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/artifactory/services/SetProperties.java
@@ -1,6 +1,7 @@
 package org.jfrog.build.extractor.clientConfiguration.client.artifactory.services;
 
-import com.google.common.collect.ArrayListMultimap;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpPut;
@@ -18,12 +19,12 @@ import static org.jfrog.build.extractor.UrlUtils.encodeUrl;
 
 public class SetProperties extends VoidJFrogService {
     public static final String SET_PROPERTIES_ENDPOINT = "api/storage/";
-    private final ArrayListMultimap<String, String> propertiesMap;
+    private final MultiValuedMap<String, String> propertiesMap;
     private final boolean encodeProperties;
     private final String relativePath;
     private final String propertiesString;
 
-    private SetProperties(String relativePath, String propertiesString, ArrayListMultimap<String, String> propertiesMap, boolean encodeProperties, Log log) {
+    private SetProperties(String relativePath, String propertiesString, MultiValuedMap<String, String> propertiesMap, boolean encodeProperties, Log log) {
         super(log);
         this.relativePath = relativePath;
         this.propertiesMap = propertiesMap;
@@ -35,7 +36,7 @@ public class SetProperties extends VoidJFrogService {
         this(relativePath, propertiesString, null, encodeProperties, log);
     }
 
-    public SetProperties(String relativePath, ArrayListMultimap<String, String> propertiesMap, boolean encodeProperties, Log log) {
+    public SetProperties(String relativePath, MultiValuedMap<String, String> propertiesMap, boolean encodeProperties, Log log) {
         this(relativePath, null, propertiesMap, encodeProperties, log);
     }
 
@@ -79,8 +80,8 @@ public class SetProperties extends VoidJFrogService {
         }
     }
 
-    private ArrayListMultimap<String, String> mapPropsString(String props) {
-        ArrayListMultimap<String, String> propsMap = ArrayListMultimap.create();
+    private MultiValuedMap<String, String> mapPropsString(String props) {
+        MultiValuedMap<String, String> propsMap = MultiMapUtils.newListValuedHashMap();
         String[] propsList = props.split(";");
         for (String prop : propsList) {
             if (isNotEmpty(prop)) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/deploy/DeployDetails.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/deploy/DeployDetails.java
@@ -1,9 +1,7 @@
 package org.jfrog.build.extractor.clientConfiguration.deploy;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.BuildFileBean;
 import org.jfrog.build.api.producerConsumer.ProducerConsumerItem;
@@ -47,7 +45,7 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
     /**
      * Properties to attach to the deployed file as matrix params.
      */
-    ArrayListMultimap<String, String> properties;
+    MultiValuedMap<String, String> properties;
     /**
      * Target deploy repository.
      */
@@ -60,6 +58,7 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
      * The package type generated this artifact's deploy details.
      */
     private PackageType packageType;
+
     /**
      * @return Return the target deployment repository.
      */
@@ -75,7 +74,7 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
         return file;
     }
 
-    public ArrayListMultimap<String, String> getProperties() {
+    public MultiValuedMap<String, String> getProperties() {
         return properties;
     }
 
@@ -88,11 +87,11 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
     }
 
     public void setSha256(String sha256) {
-        this.sha256=sha256;
+        this.sha256 = sha256;
     }
 
     public void setArtifactPath(String artifactPath) {
-        this.artifactPath=artifactPath;
+        this.artifactPath = artifactPath;
     }
 
     public Boolean getDeploySucceeded() {
@@ -165,10 +164,8 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
         public Builder bean(BuildFileBean bean) {
             Properties beanProperties = bean.getProperties();
             if (beanProperties != null) {
-                ArrayListMultimap<String, String> multimap = ArrayListMultimap.create();
-                for (Map.Entry<String, String> entry : Maps.fromProperties(beanProperties).entrySet()) {
-                    multimap.put(entry.getKey(), entry.getValue());
-                }
+                MultiValuedMap<String, String> multimap = MultiMapUtils.newListValuedHashMap();
+                beanProperties.forEach((key, value) -> multimap.put((String) key, (String) value));
                 deployDetails.properties = multimap;
             }
             deployDetails.sha1 = bean.getSha1();
@@ -218,7 +215,7 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
 
         public Builder addProperty(String key, String value) {
             if (deployDetails.properties == null) {
-                deployDetails.properties = ArrayListMultimap.create();
+                deployDetails.properties = MultiMapUtils.newListValuedHashMap();
             }
             deployDetails.properties.put(key, value);
             return this;
@@ -226,16 +223,16 @@ public class DeployDetails implements Comparable<DeployDetails>, Serializable, P
 
         public Builder addProperties(Map<String, String> propertiesToAdd) {
             if (deployDetails.properties == null) {
-                deployDetails.properties = ArrayListMultimap.create();
+                deployDetails.properties = MultiMapUtils.newListValuedHashMap();
             }
 
-            deployDetails.properties.putAll(Multimaps.forMap(propertiesToAdd));
+            deployDetails.properties.putAll(propertiesToAdd);
             return this;
         }
 
-        public Builder addProperties(Multimap<String, String> propertiesToAdd) {
+        public Builder addProperties(MultiValuedMap<String, String> propertiesToAdd) {
             if (deployDetails.properties == null) {
-                deployDetails.properties = ArrayListMultimap.create();
+                deployDetails.properties = MultiMapUtils.newListValuedHashMap();
             }
 
             deployDetails.properties.putAll(propertiesToAdd);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DependenciesDownloaderHelper.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.clientConfiguration.util;
 
-import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -22,6 +21,8 @@ import org.jfrog.filespecs.FileSpec;
 import org.jfrog.filespecs.entities.FilesGroup;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -245,15 +246,15 @@ public class DependenciesDownloaderHelper {
     protected Map<String, String> downloadFileConcurrently(final String uriWithParams, long fileSize, final String fileDestination, String filePath)
             throws Exception {
         String[] downloadedFilesPaths;
-        File tempDir = Files.createTempDir();
-        String tempPath = tempDir.getPath() + File.separatorChar + filePath;
+        Path tempDir = Files.createTempDirectory("downloadFileConcurrently");
+        Path tempPath = tempDir.resolve(filePath);
         try {
-            downloadedFilesPaths = doConcurrentDownload(fileSize, uriWithParams, tempPath);
+            downloadedFilesPaths = doConcurrentDownload(fileSize, uriWithParams, tempPath.toString());
             try (InputStream inputStream = concatenateFilesToSingleStream(downloadedFilesPaths)) {
                 return downloader.saveDownloadedFile(inputStream, fileDestination);
             }
         } finally {
-            FileUtils.deleteDirectory(tempDir);
+            FileUtils.deleteDirectory(tempDir.toFile());
         }
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DeploymentUrlUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/DeploymentUrlUtils.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.util;
 
-import com.google.common.collect.ArrayListMultimap;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.api.util.CommonUtils;
 import org.jfrog.build.extractor.UrlUtils;
@@ -66,7 +66,7 @@ public abstract class DeploymentUrlUtils {
     }
 
 
-    public static String buildMatrixParamsString(ArrayListMultimap<String, String> matrixParams, boolean encodeProperties)
+    public static String buildMatrixParamsString(MultiValuedMap<String, String> matrixParams, boolean encodeProperties)
             throws UnsupportedEncodingException {
         StringBuilder matrix = new StringBuilder();
         if (matrixParams != null && !matrixParams.isEmpty()) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/PublishedItemsHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/PublishedItemsHelper.java
@@ -16,8 +16,8 @@
 
 package org.jfrog.build.extractor.clientConfiguration.util;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.extractor.clientConfiguration.util.spec.UploadSpecHelper;
@@ -45,8 +45,8 @@ public class PublishedItemsHelper {
      *                                    then the value is treated as a source only (target will be "").
      * @return a Map containing the sources as keys and targets as values
      */
-    public static Multimap<String, String> getPublishedItemsPatternPairs(String publishedItemsPropertyValue) {
-        Multimap<String, String> patternPairMap = HashMultimap.create();
+    public static MultiValuedMap<String, String> getPublishedItemsPatternPairs(String publishedItemsPropertyValue) {
+        MultiValuedMap<String, String> patternPairMap = MultiMapUtils.newSetValuedHashMap();
         if (StringUtils.isNotBlank(publishedItemsPropertyValue)) {
 
             List<String> patternPairs = parsePatternsFromProperty(publishedItemsPropertyValue);
@@ -148,9 +148,9 @@ public class PublishedItemsHelper {
      * @throws IOException in case of any file system exception
      */
     @Deprecated
-    public static Multimap<String, File> buildPublishingData(File checkoutDir, String pattern, String targetPath)
+    public static MultiValuedMap<String, File> buildPublishingData(File checkoutDir, String pattern, String targetPath)
             throws IOException {
-        final Multimap<String, File> filePathsMap = HashMultimap.create();
+        final MultiValuedMap<String, File> filePathsMap = MultiMapUtils.newSetValuedHashMap();
         File patternAbsolutePath = getAbsolutePath(checkoutDir, pattern);
         if (patternAbsolutePath.isFile()) {
             // The given pattern is an absolute path of just one file, let's add it to our result map
@@ -211,7 +211,7 @@ public class PublishedItemsHelper {
      * @return a Multimap containing the targets as keys and the files as values
      */
     @Deprecated
-    public static Multimap<String, File> wildCardBuildPublishingData(
+    public static MultiValuedMap<String, File> wildCardBuildPublishingData(
             File checkoutDir, String pattern, String targetPath, boolean flat, boolean isRecursive, boolean regexp) {
         if (!regexp) {
             pattern = PathsUtils.pathToRegExp(pattern);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SingleSpecDeploymentProducer.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SingleSpecDeploymentProducer.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.util.spec;
 
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -20,14 +20,13 @@ import java.util.regex.Pattern;
 /**
  * Actual FileSpec performer, scans the file-system for matching files and creates the deployment data.
  * Handles a single Spec from the 'files' section of a FileSpec.
- *
  * Created by Bar Belity on 07/03/2018.
  */
 public class SingleSpecDeploymentProducer {
 
     private FilesGroup spec;
     private File workspace;
-    private Multimap<String, String> buildProperties;
+    private MultiValuedMap<String, String> buildProperties;
 
     private Pattern regexpPattern;
     private Pattern regexpExcludePattern;
@@ -43,7 +42,7 @@ public class SingleSpecDeploymentProducer {
     private int separatorsCount;
     private Set<String> symlinkSet = new HashSet<>();
 
-    SingleSpecDeploymentProducer(FilesGroup spec, File workspace, Multimap<String, String> buildProperties) {
+    SingleSpecDeploymentProducer(FilesGroup spec, File workspace, MultiValuedMap<String, String> buildProperties) {
         this.spec = spec;
         this.workspace = workspace;
         this.buildProperties = buildProperties;
@@ -52,6 +51,7 @@ public class SingleSpecDeploymentProducer {
     /**
      * Executes a single FileSpec.
      * Find all files matching the spec, create and publish its DeployDetails.
+     *
      * @param deploymentSet Set containing the DeployDetails to deploy
      */
     public void executeSpec(Set<DeployDetails> deploymentSet, ProducerConsumerExecutor executor)
@@ -136,8 +136,9 @@ public class SingleSpecDeploymentProducer {
 
     /**
      * Check all file candidates for upload in the provided directory, to specified depth.
-     * @param dir base directory to start search for files
-     * @param depth level of folders to search in
+     *
+     * @param dir           base directory to start search for files
+     * @param depth         level of folders to search in
      * @param deploymentSet Set containing the DeployDetails to deploy
      */
     private void collectFiles(String dir, int depth, Set<DeployDetails> deploymentSet, ProducerConsumerExecutor executor)
@@ -195,7 +196,8 @@ public class SingleSpecDeploymentProducer {
     /**
      * Receives a candidate file to upload, creates DeployDetails for the file in case should upload it.
      * Adds the DeployDetails to the BlockingQueue.
-     * @param file upload candidate
+     *
+     * @param file          upload candidate
      * @param deploymentSet Set containing the DeployDetails to deploy
      */
     private void processDeployCandidate(File file, Set<DeployDetails> deploymentSet, ProducerConsumerExecutor executor)
@@ -223,11 +225,12 @@ public class SingleSpecDeploymentProducer {
 
     /**
      * Checks if the provided file path matches spec's patterns
-     * @param filePath to candidate file
-     * @param regexpPattern regexp to matched files
+     *
+     * @param filePath             to candidate file
+     * @param regexpPattern        regexp to matched files
      * @param regexpExcludePattern regexp to excluded files
-     * @param workspaceDir File object that represents the workspace
-     * @param baseDirFile the directory to get files from
+     * @param workspaceDir         File object that represents the workspace
+     * @param baseDirFile          the directory to get files from
      * @return true if the file path matches all terms
      */
     private static boolean isFileMatchPattern(String filePath, Pattern regexpPattern, Pattern regexpExcludePattern,
@@ -250,6 +253,7 @@ public class SingleSpecDeploymentProducer {
 
     /**
      * Throws exception if more than 1M files to deploy found
+     *
      * @param numberOfFiles the number of artifacts to deploy
      */
     private static void validateUploadLimit(int numberOfFiles) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecDeploymentProducer.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecDeploymentProducer.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.clientConfiguration.util.spec;
 
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.producerConsumer.ProducerRunnableBase;
 import org.jfrog.filespecs.FileSpec;
@@ -12,7 +12,6 @@ import java.util.Set;
 
 /**
  * Producer object to use with the ProducerConsumerExecutor during artifact deployment by filespec operation.
- *
  * Created by Bar Belity on 27/03/2018.
  */
 public class SpecDeploymentProducer extends ProducerRunnableBase {
@@ -24,9 +23,9 @@ public class SpecDeploymentProducer extends ProducerRunnableBase {
 
     private FileSpec spec;
     private File workspace;
-    private Multimap<String, String> buildProperties;
+    private MultiValuedMap<String, String> buildProperties;
 
-    SpecDeploymentProducer(FileSpec spec, File workspace, Multimap<String, String> buildProperties) {
+    SpecDeploymentProducer(FileSpec spec, File workspace, MultiValuedMap<String, String> buildProperties) {
         this.spec = spec;
         this.workspace = workspace;
         this.buildProperties = buildProperties;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/SpecsHelper.java
@@ -1,13 +1,13 @@
 package org.jfrog.build.extractor.clientConfiguration.util.spec;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.builder.ArtifactBuilder;
 import org.jfrog.build.extractor.ci.Artifact;
 import org.jfrog.build.extractor.ci.Dependency;
-import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
@@ -21,11 +21,7 @@ import org.jfrog.filespecs.FileSpecsValidation;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.jfrog.build.api.util.CommonUtils.handleJavaTmpdirProperty;
 import static org.jfrog.build.client.PreemptiveHttpClientBuilder.CONNECTION_POOL_SIZE;
@@ -61,8 +57,8 @@ public class SpecsHelper {
         return uploadArtifactsBySpec(uploadSpec, DEFAULT_NUMBER_OF_THREADS, workspace, createMultiMap(buildProperties), artifactoryManagerBuilder);
     }
 
-    private static <K, V> Multimap<K, V> createMultiMap(Map<K, V> input) {
-        Multimap<K, V> multimap = ArrayListMultimap.create();
+    private static <K, V> MultiValuedMap<K, V> createMultiMap(Map<K, V> input) {
+        MultiValuedMap<K, V> multimap = MultiMapUtils.newListValuedHashMap();
         for (Map.Entry<K, V> entry : input.entrySet()) {
             multimap.put(entry.getKey(), entry.getValue());
         }
@@ -82,7 +78,7 @@ public class SpecsHelper {
      *                     checksums or in case of any file system exception
      */
     public List<Artifact> uploadArtifactsBySpec(String uploadSpec, int numberOfThreads, File workspace,
-                                                Multimap<String, String> buildProperties,
+                                                MultiValuedMap<String, String> buildProperties,
                                                 ArtifactoryManagerBuilder artifactoryManagerBuilder) throws Exception {
         FileSpec fileSpec = FileSpec.fromString(uploadSpec);
         FileSpecsValidation.validateUploadFileSpec(fileSpec, this.log);
@@ -157,13 +153,13 @@ public class SpecsHelper {
      * @param props Spec's properties
      * @return created properties map
      */
-    public static ArrayListMultimap<String, String> getPropertiesMap(String props) {
-        ArrayListMultimap<String, String> propertiesMap = ArrayListMultimap.create();
+    public static MultiValuedMap<String, String> getPropertiesMap(String props) {
+        MultiValuedMap<String, String> propertiesMap = MultiMapUtils.newListValuedHashMap();
         fillPropertiesMap(props, propertiesMap);
         return propertiesMap;
     }
 
-    public static void fillPropertiesMap(String props, ArrayListMultimap<String, String> propertiesMap) {
+    public static void fillPropertiesMap(String props, MultiValuedMap<String, String> propertiesMap) {
         if (StringUtils.isBlank(props)) {
             return;
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/util/spec/UploadSpecHelper.java
@@ -1,7 +1,7 @@
 package org.jfrog.build.extractor.clientConfiguration.util.spec;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -18,9 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.jfrog.build.api.util.FileChecksumCalculator.MD5_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA1_ALGORITHM;
-import static org.jfrog.build.api.util.FileChecksumCalculator.SHA256_ALGORITHM;
+import static org.jfrog.build.api.util.FileChecksumCalculator.*;
 import static org.jfrog.build.extractor.clientConfiguration.util.PathsUtils.removeUnescapedChar;
 
 /**
@@ -40,7 +38,7 @@ public class UploadSpecHelper {
      */
     public static DeployDetails buildDeployDetails(String targetPath, File artifactFile,
                                                    String uploadTarget, String explode, String props,
-                                                   Multimap<String, String> buildProperties)
+                                                   MultiValuedMap<String, String> buildProperties)
             throws IOException, NoSuchAlgorithmException {
         String path = UploadSpecHelper.wildcardCalculateTargetPath(targetPath, artifactFile);
         path = StringUtils.replace(path, "//", "/");
@@ -153,9 +151,9 @@ public class UploadSpecHelper {
         return PathsUtils.reformatRegexp(sourcePath, fileTargetPath.replace('\\', '/'), pathPattern);
     }
 
-    public static Multimap<String, File> getUploadPathsMap(List<File> files, File workspaceDir, String targetPath,
-                                                           boolean isFlat, Pattern regexPattern, boolean isAbsolutePath) {
-        Multimap<String, File> filePathsMap = HashMultimap.create();
+    public static MultiValuedMap<String, File> getUploadPathsMap(List<File> files, File workspaceDir, String targetPath,
+                                                                 boolean isFlat, Pattern regexPattern, boolean isAbsolutePath) {
+        MultiValuedMap<String, File> filePathsMap = new HashSetValuedHashMap<>();
         boolean isTargetDirectory = StringUtils.endsWith(targetPath, "/");
 
         for (File file : files) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/executor/CommandExecutor.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.executor;
 
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.SystemUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.UrlUtils;
@@ -182,7 +181,7 @@ public class CommandExecutor implements Serializable {
 
     private static Process runProcess(File execDir, String executablePath, List<String> args, List<String> credentials, Map<String, String> env, Log logger) throws IOException {
         // Make sure to copy the environment variables map to avoid changing the original map or in case it is immutable.
-        Map<String, String> newEnv = Maps.newHashMap(env);
+        Map<String, String> newEnv = new HashMap<>(env);
 
         args = formatCommand(args, credentials, executablePath, newEnv);
         logCommand(logger, args, credentials);

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Issue.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/scan/Issue.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 
@@ -96,7 +95,7 @@ public class Issue implements Comparable<Issue> {
     }
 
     @Override
-    public int compareTo(@Nonnull Issue otherIssue) {
+    public int compareTo(Issue otherIssue) {
         return Integer.compare(hashCode(), Objects.hashCode(otherIssue));
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/client/ArtifactSpecTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/client/ArtifactSpecTest.java
@@ -1,8 +1,9 @@
 package org.jfrog.build.extractor.client;
 
-import com.google.common.collect.ImmutableMap;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactSpec;
 import org.testng.annotations.Test;
+
+import java.util.HashMap;
 
 import static org.testng.Assert.*;
 
@@ -14,7 +15,7 @@ import static org.testng.Assert.*;
 public class ArtifactSpecTest {
 
     @Test
-    public void stringConstruction() throws Exception {
+    public void stringConstruction() {
         ArtifactSpec standard = ArtifactSpec.newSpec("conf grp:art:ver:cls@jar k1:v1, k2:v2 , k3:   v3");
         ArtifactSpec noPropSpaces = ArtifactSpec.newSpec("conf grp:art:ver:cls@jar k1:v1,k2:v2,k3:v3");
         ArtifactSpec noConf = ArtifactSpec.newSpec("grp:art:ver:cls@jar k1:v1, k2:v2 , k3:   v3");
@@ -26,41 +27,50 @@ public class ArtifactSpecTest {
         assertEquals(standard.getVersion(), "ver");
         assertEquals(standard.getClassifier(), "cls");
         assertEquals(standard.getType(), "jar");
-        assertEquals(standard.getProperties(), ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"));
-
+        assertEquals(standard.getProperties(), new HashMap<String, String>() {{
+            put("k1", "v1");
+            put("k2", "v2");
+            put("k3", "v3");
+        }});
         assertEquals(noPropSpaces.getConfiguration(), "conf");
         assertEquals(noPropSpaces.getGroup(), "grp");
         assertEquals(noPropSpaces.getName(), "art");
         assertEquals(noPropSpaces.getVersion(), "ver");
         assertEquals(noPropSpaces.getClassifier(), "cls");
         assertEquals(noPropSpaces.getType(), "jar");
-        assertEquals(noPropSpaces.getProperties(), ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"));
-
+        assertEquals(noPropSpaces.getProperties(), new HashMap<String, String>() {{
+            put("k1", "v1");
+            put("k2", "v2");
+            put("k3", "v3");
+        }});
         assertEquals(noConf.getConfiguration(), "*");
         assertEquals(noConf.getGroup(), "grp");
         assertEquals(noConf.getName(), "art");
         assertEquals(noConf.getVersion(), "ver");
         assertEquals(noConf.getClassifier(), "cls");
         assertEquals(noConf.getType(), "jar");
-        assertEquals(noConf.getProperties(), ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"));
+        assertEquals(noConf.getProperties(), new HashMap<String, String>() {{
+            put("k1", "v1");
+            put("k2", "v2");
+            put("k3", "v3");
+        }});
 
-        try {
-            ArtifactSpec noProps = ArtifactSpec.newSpec("all grp:art:ver:cls@jar");
-            fail("Artifact spec cannot be constructed from string without a properties notation.");
-        } catch (IllegalArgumentException e) {
-            //Expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> ArtifactSpec.newSpec("all grp:art:ver:cls@jar"));
         assertEquals(allConf.getConfiguration(), "*");
         assertEquals(allConf.getGroup(), "grp");
         assertEquals(allConf.getName(), "art");
         assertEquals(allConf.getVersion(), "ver");
         assertEquals(allConf.getClassifier(), "cls");
         assertEquals(allConf.getType(), "jar");
-        assertEquals(allConf.getProperties(), ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"));
+        assertEquals(allConf.getProperties(), new HashMap<String, String>() {{
+            put("k1", "v1");
+            put("k2", "v2");
+            put("k3", "v3");
+        }});
     }
 
     @Test
-    public void matches() throws Exception {
+    public void matches() {
         ArtifactSpec spec =
                 ArtifactSpec.builder().configuration("conf").group("grp").name("art").version("ver").classifier("cls")
                         .type("jar").build();
@@ -89,7 +99,7 @@ public class ArtifactSpecTest {
     }
 
     @Test
-    public void matchesWithNull1() throws Exception {
+    public void matchesWithNull1() {
         ArtifactSpec spec =
                 ArtifactSpec.builder().configuration(null).group("org.jfrog").name("shared")
                         .version("1.0")
@@ -99,9 +109,9 @@ public class ArtifactSpecTest {
     }
 
     @Test
-    public void matchesWithNull2() throws Exception {
+    public void matchesWithNull2() {
         ArtifactSpec spec = ArtifactSpec.builder().group("org.jfrog").name("shared")
-                        .version("1.0").build();
+                .version("1.0").build();
         someTests(spec);
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/client/DeploymentUrlUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/client/DeploymentUrlUtilsTest.java
@@ -1,6 +1,7 @@
 package org.jfrog.build.extractor.client;
 
-import com.google.common.collect.ArrayListMultimap;
+import org.apache.commons.collections4.MultiMapUtils;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.jfrog.build.extractor.clientConfiguration.ClientProperties;
 import org.jfrog.build.extractor.clientConfiguration.util.DeploymentUrlUtils;
 import org.testng.Assert;
@@ -35,7 +36,7 @@ public class DeploymentUrlUtilsTest {
 
 
     public void testKeyWithMultiValuesParam() throws UnsupportedEncodingException {
-        ArrayListMultimap<String, String> params = ArrayListMultimap.create();
+        MultiValuedMap<String, String> params = MultiMapUtils.newListValuedHashMap();
         params.put("key", "valueA");
         params.put("key", "valueB");
         params.put("keyA", "valueA");

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/executor/CommandExecutorTest.java
@@ -1,6 +1,5 @@
 package org.jfrog.build.extractor.executor;
 
-import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -17,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -98,7 +98,7 @@ public class CommandExecutorTest {
         }
         File projectDir = Files.createTempDirectory("").toFile();
         try {
-            Map<String, String> env = Maps.newHashMap(System.getenv());
+            Map<String, String> env = new HashMap<>(System.getenv());
             Path execPath = Paths.get("C:\\Program Files\\Go\\bin\\go");
             CommandExecutor.addToWindowsPath(env, execPath);
             assertTrue(env.get("Path").startsWith("C:\\Program Files\\Go\\bin"));

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/util/PublishedItemsHelperTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/util/PublishedItemsHelperTest.java
@@ -1,6 +1,6 @@
 package org.jfrog.build.extractor.util;
 
-import com.google.common.collect.Multimap;
+import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.io.FilenameUtils;
 import org.jfrog.build.extractor.clientConfiguration.util.PublishedItemsHelper;
 import org.testng.annotations.BeforeClass;
@@ -32,9 +32,9 @@ public class PublishedItemsHelperTest {
     }
 
     public void testDoubleDotWithStartWildcard() throws IOException {
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs("../../saas/**/*.xml=>target/xml");
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs("../../saas/**/*.xml=>target/xml");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 2, "Expected to find 2 files");
             for (Map.Entry<String, File> fileEntry : buildPublishingData.entries()) {
                 String targetPath = PublishedItemsHelper.calculateTargetPath(fileEntry.getKey(), fileEntry.getValue());
@@ -45,10 +45,10 @@ public class PublishedItemsHelperTest {
     }
 
     public void testAbsolutePath() throws IOException {
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs(
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs(
                 absoluteFile.getAbsolutePath() + "=>jaja/gululu");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 1, "Expected to find 1 files");
             assertTrue(buildPublishingData.containsValue(absoluteFile), "Expected to find the absolute file");
             for (Map.Entry<String, File> fileEntry : buildPublishingData.entries()) {
@@ -59,9 +59,9 @@ public class PublishedItemsHelperTest {
     }
 
     public void testAbsolutePathSameWorkspace() throws IOException {
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs(checkoutDir.getAbsolutePath() + "/inner/*.gradle" + "=>test/props");
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs(checkoutDir.getAbsolutePath() + "/inner/*.gradle" + "=>test/props");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 1, "Expected to find 1 file");
             for (Map.Entry<String, File> fileEntry : buildPublishingData.entries()) {
                 String targetPath = PublishedItemsHelper.calculateTargetPath(fileEntry.getKey(), fileEntry.getValue());
@@ -72,14 +72,14 @@ public class PublishedItemsHelperTest {
 
     public void testMultiPatterns() throws IOException {
         String pattern = "**/multi1/*=>test/multi1, **multi2/*=>test/multi2";
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs(pattern);
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs(pattern);
         assertEquals(pairs.keySet().size(), 2, "Expected to find 2 keys");
     }
 
     public void testAllWorkspace() throws IOException {
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs("**");
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs("**");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 6, "Expected to find 6 files");
         }
     }
@@ -87,17 +87,17 @@ public class PublishedItemsHelperTest {
     public void testAbsolutePathWithDoubleStar() throws IOException {
         File resourceAsFile = getResourceAsFile("/root/workspace");
         String fileAbsolutePath = FilenameUtils.separatorsToUnix(resourceAsFile.getAbsolutePath());
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs(fileAbsolutePath + "/ant/**");
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs(fileAbsolutePath + "/ant/**");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 7, "Expected to find 7 files");
         }
     }
 
     public void testAllSpecificFilesFromCheckoutDir() throws IOException {
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs("**/*.blabla=>blabla");
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs("**/*.blabla=>blabla");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 2, "Expected to find 2 files");
             for (Map.Entry<String, File> fileEntry : buildPublishingData.entries()) {
                 String targetPath = PublishedItemsHelper.calculateTargetPath(fileEntry.getKey(), fileEntry.getValue());
@@ -107,9 +107,9 @@ public class PublishedItemsHelperTest {
     }
 
     public void testEmptyTargetPath() throws IOException {
-        Multimap<String, String> pairs = getPublishedItemsPatternPairs("../../**/**/*.xml");
+        MultiValuedMap<String, String> pairs = getPublishedItemsPatternPairs("../../**/**/*.xml");
         for (final Map.Entry<String, String> entry : pairs.entries()) {
-            Multimap<String, File> buildPublishingData = getBuildPublishingData(entry);
+            MultiValuedMap<String, File> buildPublishingData = getBuildPublishingData(entry);
             assertEquals(buildPublishingData.size(), 2, "Expected to find 2 files");
             for (Map.Entry<String, File> fileEntry : buildPublishingData.entries()) {
                 String targetPath = PublishedItemsHelper.calculateTargetPath(fileEntry.getKey(), fileEntry.getValue());
@@ -118,11 +118,11 @@ public class PublishedItemsHelperTest {
         }
     }
 
-    private Multimap<String, String> getPublishedItemsPatternPairs(String pattern) {
+    private MultiValuedMap<String, String> getPublishedItemsPatternPairs(String pattern) {
         return PublishedItemsHelper.getPublishedItemsPatternPairs(pattern);
     }
 
-    private Multimap<String, File> getBuildPublishingData(Map.Entry<String, String> entry) throws IOException {
+    private MultiValuedMap<String, File> getBuildPublishingData(Map.Entry<String, String> entry) throws IOException {
         return PublishedItemsHelper.buildPublishingData(checkoutDir, entry.getKey(), entry.getValue());
     }
 

--- a/build-info-parent/pom.xml
+++ b/build-info-parent/pom.xml
@@ -47,12 +47,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>r08</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.12.0</version>

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         commonsIoVersion = '2.11.0'
         commonsLang3Version = '3.12.0'
         commonsLoggingVersion = '1.2'
+        commonsCollections4Version = '4.4'
         dockerJavaVersion = '3.3.3'
         easymockclassextensionVersion = '3.2'
         eclipseAetherVersion = '1.1.0'
@@ -18,7 +19,6 @@ buildscript {
         gradleVersionsPluginVersion = '0.42.0'
 
         groovyAllVersion = '3.0.13'
-        guavaVersion = '32.1.3-jre'
         httpClientVersion = '4.5.14'
         httpCoreVersion = '4.4.16'
         ivyVersion = '2.5.2'
@@ -134,6 +134,7 @@ subprojects {
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
         implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
+        implementation group: 'org.apache.commons', name: 'commons-collections4', version: commonsCollections4Version
         implementation group: 'org.apache.commons', name: 'commons-compress', version: commonsCompressVersion
 
         implementation("org.apache.httpcomponents:httpclient:$httpClientVersion") {
@@ -142,7 +143,6 @@ subprojects {
 
         implementation "org.apache.httpcomponents:httpcore:$httpCoreVersion"
         implementation "commons-codec:commons-codec:$commonsCodecVersion"
-        implementation group: 'com.google.guava', name: 'guava', 'version': guavaVersion
         implementation group: 'org.jfrog.filespecs', name: 'file-specs-java', version: fileSpecsJavaVersion
 
         testImplementation group: 'org.testng', name: 'testng', version: testNgVersion


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

Fix https://github.com/jfrog/build-info/issues/792.

Remove Guava entirely from build-info.
Replace Guava's ArrayListMultimap with Apache Commons collection's ArrayListValuedHashMap.
Replace Guava's HashMultimap with Apache Commons collection's HashSetValuedHashMap.