### PR TITLE
Replace NettyDockerCmdExecFactory for OkHttpDockerCmdExecFactory

### DIFF
--- a/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerJavaWrapper.java
+++ b/build-info-extractor-docker/src/main/java/org/jfrog/build/extractor/docker/DockerJavaWrapper.java
@@ -10,7 +10,7 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.command.BuildImageResultCallback;
 import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.github.dockerjava.core.command.PushImageResultCallback;
-import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
+import com.github.dockerjava.okhttp.OkHttpDockerCmdExecFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jfrog.build.api.util.Log;
@@ -74,7 +74,7 @@ public class DockerJavaWrapper {
         }
 
         DockerClientConfig config = configBuilder.build();
-        return DockerClientBuilder.getInstance(config).withDockerCmdExecFactory(new NettyDockerCmdExecFactory()).build();
+        return DockerClientBuilder.getInstance(config).withDockerCmdExecFactory(new OkHttpDockerCmdExecFactory()).build();
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -472,6 +472,7 @@ project('build-info-extractor-docker') {
         implementation(group: 'com.github.docker-java', name: 'docker-java', version: dockerJavaVersion) {
             exclude group: 'org.glassfish.jersey.core', module: 'jersey-common'
         }
+        implementation(group: 'com.github.docker-java', name: 'docker-java-transport-okhttp', version: dockerJavaVersion)
         implementation group: 'org.glassfish.jersey.core', name: 'jersey-common', version: jerseyVersion
     }
 }


### PR DESCRIPTION
Add support to npipe protocol for windows docker by using okHttp.
Fixes #797 

- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
