### PR TITLE
Support multiple no proxy hosts in Maven

### DIFF
--- a/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryResolutionTest.java
+++ b/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryResolutionTest.java
@@ -33,6 +33,7 @@ public class ArtifactoryResolutionTest {
     final int HTTP_PROXY_PORT = 8888;
     final int HTTPS_PROXY_PORT = 8889;
     final String NO_PROXY_PATTERN = "www.http-no-proxy-url.com";
+    final String MULTIPLE_NO_PROXY_PATTERNS = "www.no-proxy-1.com,www.http-no-proxy-url.com";
     ArtifactoryResolution artifactoryResolution;
     ArtifactoryResolution artifactoryResolutionOnlyRelease;
     RemoteRepository snapshotRepository;
@@ -177,6 +178,16 @@ public class ArtifactoryResolutionTest {
     @Test(description = "In the case of 'http.nonProxyHosts' matching the repository URL with 'https' prefix, null is returned from getProxy().")
     public void TestNullProxyHttps() {
         ArtifactoryResolution artifactoryResolutionWithNoHttp = new ArtifactoryResolution(HTTP_RELEASE_URL, "https://" + NO_PROXY_PATTERN, USERNAME, PASSWORD, proxySelector, new NullPlexusLog());
+        assertNull(artifactoryResolutionWithNoHttp.createSnapshotRepository().getProxy());
+    }
+
+    @Test(description = "In the case of 'http.nonProxyHosts' with multiple hosts that one of them is matching the repository URL, null is returned from getProxy().")
+    public void TestMultipleNoProxy() {
+        // Prepare
+        ProxySelector multipleNoHostsProxySelector = new ProxySelector(HTTP_PROXY_URL, HTTP_PROXY_PORT, HTTP_PROXY_USERNAME, HTTP_PROXY_PASSWORD, HTTPS_PROXY_URL, HTTPS_PROXY_PORT, HTTPS_PROXY_USERNAME, HTTPS_PROXY_PASSWORD, MULTIPLE_NO_PROXY_PATTERNS);
+        // Act
+        ArtifactoryResolution artifactoryResolutionWithNoHttp = new ArtifactoryResolution(HTTP_RELEASE_URL, "https://" + NO_PROXY_PATTERN, USERNAME, PASSWORD, multipleNoHostsProxySelector, new NullPlexusLog());
+        // Assert
         assertNull(artifactoryResolutionWithNoHttp.createSnapshotRepository().getProxy());
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ProxySelector.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ProxySelector.java
@@ -25,13 +25,15 @@ public class ProxySelector {
     private Proxy httpsProxy;
 
     public ProxySelector(String httpHost, int httpPort, String httpUsername, String httpPassword, String httpsHost, int httpsPort, String httpsUsername, String httpsPassword, String noProxy) {
-        this.noProxy = noProxy;
         if (StringUtils.isNotBlank(httpHost)) {
             this.httpProxy = new Proxy(httpHost, httpPort, httpUsername, httpPassword, false);
         }
         if (StringUtils.isNotBlank(httpsHost)) {
             this.httpsProxy = new Proxy(httpsHost, httpsPort, httpsUsername, httpsPassword, true);
         }
+        // The NO_PROXY environment variable standard uses commas to separate no-proxy hosts.
+        // The Java system property http.nonProxyHosts uses pipes.
+        this.noProxy = StringUtils.replace(noProxy, ",", "|");
     }
 
     public Proxy getProxy(String repositoryUrl) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

Fix https://github.com/jfrog/jfrog-cli/issues/2638

The `NO_PROXY` pattern for specifying multiple hosts is a comma-separated list:
`NO_PROXY=host1.jfrog.io,host2.jfrog.io`
https://www.gnu.org/software/emacs/manual/html_node/url/Proxies.html

In Java, the system property `http.nonProxyHosts` uses a pipe-separated list for multiple hosts:
`-Dhttp.nonProxyHosts=host1.jfrog.io|host2.jfrog.io`
https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html

This pull request adjusts the `http.nonProxyHosts` value by replacing commas with pipes.