### PR TITLE
Add original deployment repository field

### DIFF
--- a/build-info-api/src/main/java/org/jfrog/build/api/Artifact.java
+++ b/build-info-api/src/main/java/org/jfrog/build/api/Artifact.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 public class Artifact extends BaseBuildFileBean {
 
     private String name;
+    private String originalDeploymentRepo;
 
     /**
      * Returns the name of the artifact
@@ -27,6 +28,24 @@ public class Artifact extends BaseBuildFileBean {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * Returns the original deployment repository of the artifact
+     *
+     * @return repository name
+     */
+    public String getOriginalDeploymentRepo() {
+        return originalDeploymentRepo;
+    }
+
+    /**
+     * Sets the original deployment repository of the artifact
+     *
+     * @param originalDeploymentRepo repository name
+     */
+    public void setOriginalDeploymentRepo(String originalDeploymentRepo) {
+        this.originalDeploymentRepo = originalDeploymentRepo;
     }
 
     @Override

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/ArtifactBuilder.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/builder/ArtifactBuilder.java
@@ -20,6 +20,7 @@ public class ArtifactBuilder {
     private String md5;
     private String remotePath;
     private Properties properties;
+    private String originalDeploymentRepo;
 
     public ArtifactBuilder(String name) {
         this.name = name;
@@ -43,6 +44,7 @@ public class ArtifactBuilder {
         artifact.setRemotePath(remotePath);
         artifact.setLocalPath(localPath);
         artifact.setProperties(properties);
+        artifact.setOriginalDeploymentRepo(originalDeploymentRepo);
         return artifact;
     }
 
@@ -131,6 +133,17 @@ public class ArtifactBuilder {
      */
     public ArtifactBuilder properties(Properties properties) {
         this.properties = properties;
+        return this;
+    }
+
+    /**
+     * Sets the originalDeploymentRepo of the artifact
+     *
+     * @param originalDeploymentRepo Artifact original deployment repository
+     * @return Builder instance
+     */
+    public ArtifactBuilder originalDeploymentRepo(String originalDeploymentRepo) {
+        this.originalDeploymentRepo = originalDeploymentRepo;
         return this;
     }
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/Artifact.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/Artifact.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 public class Artifact extends BaseBuildFileBean {
 
     private String name;
+    private String originalDeploymentRepo;
 
     /**
      * Returns the name of the artifact
@@ -25,6 +26,24 @@ public class Artifact extends BaseBuildFileBean {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * Returns the original deployment repository of the artifact
+     *
+     * @return repository name
+     */
+    public String getOriginalDeploymentRepo() {
+        return originalDeploymentRepo;
+    }
+
+    /**
+     * Sets the original deployment repository of the artifact
+     *
+     * @param originalDeploymentRepo repository name
+     */
+    public void setOriginalDeploymentRepo(String originalDeploymentRepo) {
+        this.originalDeploymentRepo = originalDeploymentRepo;
     }
 
     @Override
@@ -59,6 +78,7 @@ public class Artifact extends BaseBuildFileBean {
         result.setSha1(sha1);
         result.setRemotePath(remotePath);
         result.setProperties(getProperties());
+        result.setOriginalDeploymentRepo(getOriginalDeploymentRepo());
         return result;
     }
 
@@ -71,6 +91,7 @@ public class Artifact extends BaseBuildFileBean {
         result.setSha1(artifact.getSha1());
         result.setRemotePath(artifact.getRemotePath());
         result.setProperties(artifact.getProperties());
+        result.setOriginalDeploymentRepo(artifact.getOriginalDeploymentRepo());
         return result;
     }
 }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/Artifact.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/ci/Artifact.java
@@ -78,7 +78,7 @@ public class Artifact extends BaseBuildFileBean {
         result.setSha1(sha1);
         result.setRemotePath(remotePath);
         result.setProperties(getProperties());
-        result.setOriginalDeploymentRepo(getOriginalDeploymentRepo());
+        result.setOriginalDeploymentRepo(originalDeploymentRepo);
         return result;
     }
 

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertNull;
  * @author Tomer Cohen
  */
 @Test
-public class BuildExtractorUtilsTest {
+public class  BuildExtractorUtilsTest {
     private static final String POPO_KEY = BuildInfoProperties.BUILD_INFO_PROP_PREFIX + "popo";
     private static final String MOMO_KEY = BuildInfoProperties.BUILD_INFO_PROP_PREFIX + "momo";
     private static final String KOKO_KEY = BuildInfoProperties.BUILD_INFO_PROP_PREFIX + "koko";

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/BuildExtractorUtilsTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertNull;
  * @author Tomer Cohen
  */
 @Test
-public class  BuildExtractorUtilsTest {
+public class BuildExtractorUtilsTest {
     private static final String POPO_KEY = BuildInfoProperties.BUILD_INFO_PROP_PREFIX + "popo";
     private static final String MOMO_KEY = BuildInfoProperties.BUILD_INFO_PROP_PREFIX + "momo";
     private static final String KOKO_KEY = BuildInfoProperties.BUILD_INFO_PROP_PREFIX + "koko";

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/ci/ArtifactTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/ci/ArtifactTest.java
@@ -30,6 +30,7 @@ public class ArtifactTest {
         assertNull(artifact.getSha1(), "Artifact SHA1 checksum should have not been initialized.");
         assertNull(artifact.getSha256(), "Artifact SHA256 checksum should have not been initialized.");
         assertNull(artifact.getMd5(), "Artifact MD5 checksum should have not been initialized.");
+        assertNull(artifact.getOriginalDeploymentRepo(), "Artifact original deployment repository should have not been initialized.");
     }
 
     /**
@@ -43,6 +44,7 @@ public class ArtifactTest {
         String md5 = "gog";
         String localPath = "blip";
         String remotePath = "blop";
+        String originalDeploymentRepository = "repo";
         Properties properties = new Properties();
 
         Artifact artifact = new Artifact();
@@ -54,6 +56,7 @@ public class ArtifactTest {
         artifact.setLocalPath(localPath);
         artifact.setRemotePath(remotePath);
         artifact.setProperties(properties);
+        artifact.setOriginalDeploymentRepo(originalDeploymentRepository);
 
         Assert.assertEquals(artifact.getName(), name, "Unexpected artifact name.");
         Assert.assertEquals(artifact.getType(), type, "Unexpected artifact type.");
@@ -63,6 +66,7 @@ public class ArtifactTest {
         Assert.assertEquals(artifact.getLocalPath(), localPath, "Unexpected artifact local path.");
         Assert.assertEquals(artifact.getRemotePath(), remotePath, "Unexpected artifact remote path.");
         Assert.assertEquals(artifact.getProperties(), properties, "Unexpected artifact properties.");
+        Assert.assertEquals(artifact.getOriginalDeploymentRepo(),originalDeploymentRepository, "Unexpected artifact original deployment repository.");
     }
 
     public void testEqualsAndHash() {
@@ -75,6 +79,7 @@ public class ArtifactTest {
         artifact1.setSha1("111");
         artifact1.setSha256("11111");
         artifact1.setMd5("1111");
+        artifact1.setOriginalDeploymentRepo("repo");
         artifact1.setProperties(properties);
 
         Artifact artifact2 = new Artifact();
@@ -83,6 +88,7 @@ public class ArtifactTest {
         artifact2.setSha1("111");
         artifact2.setSha256("11111");
         artifact2.setMd5("1111");
+        artifact2.setOriginalDeploymentRepo("repo");
         artifact2.setProperties(properties);
 
         Artifact artifact3 = new Artifact();
@@ -91,6 +97,7 @@ public class ArtifactTest {
         artifact3.setSha1("1113");
         artifact3.setSha256("11133");
         artifact3.setMd5("11113");
+        artifact3.setOriginalDeploymentRepo("diff-repo");
         artifact3.setProperties(properties);
 
         Assert.assertEquals(artifact1, artifact2, "Expected equals == true for equivalent artifacts");

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/ci/BuildInfoMavenBuilderTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/ci/BuildInfoMavenBuilderTest.java
@@ -34,6 +34,7 @@ public class BuildInfoMavenBuilderTest {
     public static final String SHA1 = "e4e264c711ae7ab54f26542f0dd09a43b93fa12c";
     public static final String SHA2 = "yyyy23029162f3b2dc51f512cb64bce8cb6913ed6e540f23ec567d898f60yyyy";
     public static final String MD5 = "d9303a42c66c2824fd6ba0f75e335294";
+    public static final String DEPLOY_REPO = "repo";
 
     /**
      * Validates the build values when using the defaults
@@ -163,12 +164,12 @@ public class BuildInfoMavenBuilderTest {
      */
     public void testDuplicateModuleArtifacts() {
         ModuleBuilder module1 = new ModuleBuilder().type(ModuleType.MAVEN).id("id");
-        module1.addArtifact(new ArtifactBuilder("artifact1").md5(MD5).sha1(SHA1).sha256(SHA2).build());
-        module1.addArtifact(new ArtifactBuilder("artifact2").md5(MD5).sha1(SHA1).sha256(SHA2).build());
+        module1.addArtifact(new ArtifactBuilder("artifact1").md5(MD5).sha1(SHA1).sha256(SHA2).originalDeploymentRepo(DEPLOY_REPO).build());
+        module1.addArtifact(new ArtifactBuilder("artifact2").md5(MD5).sha1(SHA1).sha256(SHA2).originalDeploymentRepo(DEPLOY_REPO).build());
 
         ModuleBuilder module2 = new ModuleBuilder().type(ModuleType.MAVEN).id("id");
-        module2.addArtifact(new ArtifactBuilder("artifact1").md5(MD5).sha1(SHA1).sha256(SHA2).build());
-        module2.addArtifact(new ArtifactBuilder("artifact2").md5(MD5).sha1(SHA1).sha256(SHA2).build());
+        module2.addArtifact(new ArtifactBuilder("artifact1").md5(MD5).sha1(SHA1).sha256(SHA2).originalDeploymentRepo(DEPLOY_REPO).build());
+        module2.addArtifact(new ArtifactBuilder("artifact2").md5(MD5).sha1(SHA1).sha256(SHA2).originalDeploymentRepo(DEPLOY_REPO).build());
 
         BuildInfoMavenBuilder builder = new BuildInfoMavenBuilder("test").number("4").started("test");
         builder.addModule(module1.build());

--- a/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/AccessManagerTest.java
+++ b/build-info-extractor/src/test/java/org/jfrog/build/extractor/clientConfiguration/client/AccessManagerTest.java
@@ -45,7 +45,7 @@ public class AccessManagerTest extends IntegrationTestsBase {
     @BeforeClass
     @Override
     public void init() throws IOException {
-        super.init();
+        super.init(true);
         String accessUrl = getPlatformUrl() + "access";
         accessManager = new AccessManager(accessUrl, getAdminToken(), getLog());
     }

--- a/build-info-extractor/src/testFixtures/java/org/jfrog/build/IntegrationTestsBase.java
+++ b/build-info-extractor/src/testFixtures/java/org/jfrog/build/IntegrationTestsBase.java
@@ -70,7 +70,7 @@ public abstract class IntegrationTestsBase {
             inputStream.close();
         }
 
-        platformUrl = readParam(props, "url", "http://127.0.0.1:8081");
+        platformUrl = readParam(props, "url", "http://127.0.0.1:8082");
         if (!platformUrl.endsWith("/")) {
             platformUrl += "/";
         }

--- a/build-info-extractor/src/testFixtures/java/org/jfrog/build/IntegrationTestsBase.java
+++ b/build-info-extractor/src/testFixtures/java/org/jfrog/build/IntegrationTestsBase.java
@@ -59,8 +59,7 @@ public abstract class IntegrationTestsBase {
         return log;
     }
 
-    @BeforeClass
-    public void init() throws IOException {
+    public void init(boolean isAccessTest) throws IOException {
         Properties props = new Properties();
         // This file is not in GitHub. Create your own in src/test/resources or use environment variables.
         InputStream inputStream = this.getClass().getResourceAsStream("/artifactory-bi.properties");
@@ -69,8 +68,13 @@ public abstract class IntegrationTestsBase {
             props.load(inputStream);
             inputStream.close();
         }
+        String testPort = "8081";
+        // Change the port variable only if isAccessTest is true
+        if (isAccessTest) {
+            testPort = "8082";
+        }
 
-        platformUrl = readParam(props, "url", "http://127.0.0.1:8082");
+        platformUrl = readParam(props, "url", "http://127.0.0.1:" + testPort);
         if (!platformUrl.endsWith("/")) {
             platformUrl += "/";
         }
@@ -90,6 +94,16 @@ public abstract class IntegrationTestsBase {
         if (StringUtils.isNotEmpty(virtualRepo)) {
             createTestRepo(virtualRepo);
         }
+    }
+
+    @BeforeClass
+    public void init() throws IOException {
+        init(false);
+    }
+
+    @BeforeClass
+    public void accessInit() throws IOException {
+        init(true);
     }
 
     @AfterClass


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

Added an existing build-info field from build-info-go to enable its use in Artifactory as well.