### PR TITLE
NuGet - add `allowInsecureConnections` attribute to config

### DIFF
--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
@@ -163,8 +163,7 @@ public class NugetRun extends PackageManagerExtractor {
                     handler.getModule(),
                     clientConfiguration.resolver.getUsername(),
                     clientConfiguration.resolver.getPassword(),
-                    clientConfiguration.dotnetHandler.apiProtocol(),
-                    clientConfiguration.nuGetAllowInsecureConnections);
+                    clientConfiguration.dotnetHandler.apiProtocol(), false);
             nugetRun.executeAndSaveBuildInfo(clientConfiguration);
         } catch (RuntimeException e) {
             ExceptionUtils.printRootCauseStackTrace(e, System.out);

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.jfrog.build.api.util.FileChecksumCalculator.*;
+import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.DEFAULT_NUGET_ALLOW_INSECURE_CONNECTIONS;
 import static org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration.DEFAULT_NUGET_PROTOCOL;
 import static org.jfrog.build.extractor.packageManager.PackageManagerUtils.createArtifactoryClientConfiguration;
 
@@ -96,7 +97,7 @@ public class NugetRun extends PackageManagerExtractor {
      * @param apiProtocol               - A string indicates which NuGet protocol should be used (V2/V3).
      */
 
-    public NugetRun(ArtifactoryManagerBuilder artifactoryManagerBuilder, String resolutionRepo, boolean useDotnetCli, String nugetCmdArgs, Log logger, Path path, Map<String, String> env, String module, String username, String password, String apiProtocol, boolean allowInsecureConnections) {
+    public NugetRun(ArtifactoryManagerBuilder artifactoryManagerBuilder, String resolutionRepo, boolean useDotnetCli, String nugetCmdArgs, Log logger, Path path, Map<String, String> env, String module, String username, String password, String apiProtocol, Boolean allowInsecureConnections) {
         this.artifactoryManagerBuilder = artifactoryManagerBuilder;
         this.toolchainDriver = useDotnetCli ? new DotnetDriver(env, path, logger) : new NugetDriver(env, path, logger);
         this.workingDir = Files.isDirectory(path) ? path : path.toAbsolutePath().getParent();
@@ -108,7 +109,7 @@ public class NugetRun extends PackageManagerExtractor {
         this.password = password;
         this.apiProtocol = StringUtils.isBlank(apiProtocol) ? DEFAULT_NUGET_PROTOCOL : apiProtocol;
         this.module = module;
-        this.allowInsecureConnections = allowInsecureConnections;
+        this.allowInsecureConnections = allowInsecureConnections == null ? DEFAULT_NUGET_ALLOW_INSECURE_CONNECTIONS : allowInsecureConnections;
     }
 
     private static String removeQuotes(String str) {
@@ -163,7 +164,8 @@ public class NugetRun extends PackageManagerExtractor {
                     handler.getModule(),
                     clientConfiguration.resolver.getUsername(),
                     clientConfiguration.resolver.getPassword(),
-                    clientConfiguration.dotnetHandler.apiProtocol(), false);
+                    clientConfiguration.dotnetHandler.apiProtocol(),
+                    clientConfiguration.getNuGetAllowInsecureConnections());
             nugetRun.executeAndSaveBuildInfo(clientConfiguration);
         } catch (RuntimeException e) {
             ExceptionUtils.printRootCauseStackTrace(e, System.out);

--- a/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
+++ b/build-info-extractor-nuget/src/main/java/org/jfrog/build/extractor/nuget/extractor/NugetRun.java
@@ -47,7 +47,7 @@ public class NugetRun extends PackageManagerExtractor {
     private static final String CONFIG_FILE_FORMAT = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
             "<configuration>\n" +
             "\t<packageSources>\n" +
-            "\t\t<add key=\"JFrogJenkins\" value=\"%s\" protocolVersion=\"%s\" allowInsecureConnections=\"%b\" />\n" +
+            "\t\t<add key=\"JFrogJenkins\" value=\"%s\" protocolVersion=\"%s\" allowInsecureConnections=\"%s\"/>\n" +
             "\t</packageSources>\n" +
             "\t<packageSourceCredentials>\n" +
             "\t\t<JFrogJenkins>\n" +
@@ -223,7 +223,7 @@ public class NugetRun extends PackageManagerExtractor {
     private void addSourceToConfigFile(String configPath, ArtifactoryManager client, String repo, String username, String password, String apiProtocol, boolean allowInsecureConnections) throws Exception {
         String sourceUrl = toolchainDriver.buildNugetSourceUrl(client, repo, apiProtocol);
         String protocolVersion = apiProtocol.substring(apiProtocol.length() - 1);
-        String configFileText = String.format(CONFIG_FILE_FORMAT, sourceUrl, protocolVersion, username, password, Boolean.toString(allowInsecureConnections));
+        String configFileText = String.format(CONFIG_FILE_FORMAT, sourceUrl, protocolVersion, Boolean.toString(allowInsecureConnections), username, password);
         try (PrintWriter out = new PrintWriter(configPath)) {
             out.println(configFileText);
         }

--- a/build-info-extractor-nuget/src/test/java/org/jfrog/build/extractor/nuget/extractor/NugetExtractorTest.java
+++ b/build-info-extractor-nuget/src/test/java/org/jfrog/build/extractor/nuget/extractor/NugetExtractorTest.java
@@ -118,7 +118,7 @@ public class NugetExtractorTest extends IntegrationTestsBase {
         try {
             // Run nuget restore install
             projectDir = createProjectDir(project);
-            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, true, args, log, projectDir, env, moduleName, getUsername(), getAdminToken(), "v2",false);
+            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, true, args, log, projectDir, env, moduleName, getUsername(), getAdminToken(), "v2",ALLOW_INSECURE_CONNECTIONS_TEST);
             executeAndAssertBuildInfo(nugetRun, expectedModules, expectedDependencies);
         } catch (Exception e) {
             fail(ExceptionUtils.getStackTrace(e));

--- a/build-info-extractor-nuget/src/test/java/org/jfrog/build/extractor/nuget/extractor/NugetExtractorTest.java
+++ b/build-info-extractor-nuget/src/test/java/org/jfrog/build/extractor/nuget/extractor/NugetExtractorTest.java
@@ -31,6 +31,7 @@ public class NugetExtractorTest extends IntegrationTestsBase {
 
     private static final String NUGET_REMOTE_REPO = "build-info-tests-nuget-remote";
     private static final String CUSTOM_MODULE = "custom-module-name";
+    private static final boolean ALLOW_INSECURE_CONNECTIONS_TEST = true;
 
     private static final Path PROJECTS_ROOT = Paths.get(".").toAbsolutePath().normalize().resolve(Paths.get("src", "test", "resources", "org", "jfrog", "build", "extractor"));
 
@@ -95,7 +96,7 @@ public class NugetExtractorTest extends IntegrationTestsBase {
         try {
             // Run nuget restore install
             projectDir = createProjectDir(project);
-            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, false, args, log, projectDir, env, moduleName, getUsername(), getAdminToken(), "v2");
+            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, false, args, log, projectDir, env, moduleName, getUsername(), getAdminToken(), "v2",ALLOW_INSECURE_CONNECTIONS_TEST);
             executeAndAssertBuildInfo(nugetRun, expectedModules, expectedDependencies);
         } catch (Exception e) {
             fail(ExceptionUtils.getStackTrace(e));
@@ -117,7 +118,7 @@ public class NugetExtractorTest extends IntegrationTestsBase {
         try {
             // Run nuget restore install
             projectDir = createProjectDir(project);
-            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, true, args, log, projectDir, env, moduleName, getUsername(), getAdminToken(), "v2");
+            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, true, args, log, projectDir, env, moduleName, getUsername(), getAdminToken(), "v2",false);
             executeAndAssertBuildInfo(nugetRun, expectedModules, expectedDependencies);
         } catch (Exception e) {
             fail(ExceptionUtils.getStackTrace(e));
@@ -167,7 +168,7 @@ public class NugetExtractorTest extends IntegrationTestsBase {
     private void getProjectRootTest(String args, String expectedProjectRootFileName) {
         try {
             File rootDir = PROJECTS_ROOT.resolve("projectRootTestDir").toFile();
-            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, false, args, log, rootDir.toPath(), env, null, getUsername(), getAdminToken(), "v2");
+            NugetRun nugetRun = new NugetRun(artifactoryManagerBuilder, remoteRepo, false, args, log, rootDir.toPath(), env, null, getUsername(), getAdminToken(), "v2",ALLOW_INSECURE_CONNECTIONS_TEST);
             File projectRoot = nugetRun.getProjectRootPath();
             assertTrue(projectRoot.getPath().endsWith(expectedProjectRootFileName));
         } catch (Exception e) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -5,7 +5,6 @@ import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.build.api.util.CommonUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.ci.BuildInfo;
-import org.jfrog.build.extractor.ci.BuildInfoFields;
 import org.jfrog.build.extractor.ci.Issue;
 import org.jfrog.build.extractor.clientConfiguration.util.IssuesTrackerUtils;
 import org.jfrog.build.extractor.clientConfiguration.util.encryption.EncryptionKeyPair;
@@ -54,6 +53,8 @@ public class ArtifactoryClientConfiguration {
     public final DockerHandler dockerHandler;
     public final GoHandler goHandler;
     public final PrefixPropertyHandler root;
+    public final boolean nuGetAllowInsecureConnections;
+
     /**
      * To configure the props builder itself, so all method of this classes delegated from here
      */
@@ -73,6 +74,7 @@ public class ArtifactoryClientConfiguration {
         this.dotnetHandler = new DotnetHandler();
         this.dockerHandler = new DockerHandler();
         this.goHandler = new GoHandler();
+        this.nuGetAllowInsecureConnections = false;
     }
 
     public void fillFromProperties(Map<String, String> props, IncludeExcludePatterns patterns) {
@@ -1289,7 +1291,7 @@ public class ArtifactoryClientConfiguration {
             buildName = defaultProjectName;
             config.info.setBuildName(buildName);
         }
-        config.publisher.setMatrixParam(BuildInfoFields.BUILD_NAME, buildName);
+        config.publisher.setMatrixParam(BUILD_NAME, buildName);
 
         // Build number
         String buildNumber = config.info.getBuildNumber();
@@ -1297,7 +1299,7 @@ public class ArtifactoryClientConfiguration {
             buildNumber = new Date().getTime() + "";
             config.info.setBuildNumber(buildNumber);
         }
-        config.publisher.setMatrixParam(BuildInfoFields.BUILD_NUMBER, buildNumber);
+        config.publisher.setMatrixParam(BUILD_NUMBER, buildNumber);
 
         // Build start (was set by the plugin - no need to make up a fallback val)
         String buildTimestamp = config.info.getBuildTimestamp();
@@ -1312,7 +1314,7 @@ public class ArtifactoryClientConfiguration {
             buildTimestamp = String.valueOf(buildStartDate.getTime());
             config.info.setBuildTimestamp(buildTimestamp);
         }
-        config.publisher.setMatrixParam(BuildInfoFields.BUILD_TIMESTAMP, buildTimestamp);
+        config.publisher.setMatrixParam(BUILD_TIMESTAMP, buildTimestamp);
 
         // Build agent
         String buildAgentName = config.info.getBuildAgentName();

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -5,6 +5,7 @@ import org.jfrog.build.api.multiMap.Multimap;
 import org.jfrog.build.api.util.CommonUtils;
 import org.jfrog.build.api.util.Log;
 import org.jfrog.build.extractor.ci.BuildInfo;
+import org.jfrog.build.extractor.ci.BuildInfoFields;
 import org.jfrog.build.extractor.ci.Issue;
 import org.jfrog.build.extractor.clientConfiguration.util.IssuesTrackerUtils;
 import org.jfrog.build.extractor.clientConfiguration.util.encryption.EncryptionKeyPair;
@@ -1291,7 +1292,7 @@ public class ArtifactoryClientConfiguration {
             buildName = defaultProjectName;
             config.info.setBuildName(buildName);
         }
-        config.publisher.setMatrixParam(BUILD_NAME, buildName);
+        config.publisher.setMatrixParam(BuildInfoFields.BUILD_NAME, buildName);
 
         // Build number
         String buildNumber = config.info.getBuildNumber();
@@ -1299,7 +1300,7 @@ public class ArtifactoryClientConfiguration {
             buildNumber = new Date().getTime() + "";
             config.info.setBuildNumber(buildNumber);
         }
-        config.publisher.setMatrixParam(BUILD_NUMBER, buildNumber);
+        config.publisher.setMatrixParam(BuildInfoFields.BUILD_NUMBER, buildNumber);
 
         // Build start (was set by the plugin - no need to make up a fallback val)
         String buildTimestamp = config.info.getBuildTimestamp();
@@ -1314,7 +1315,7 @@ public class ArtifactoryClientConfiguration {
             buildTimestamp = String.valueOf(buildStartDate.getTime());
             config.info.setBuildTimestamp(buildTimestamp);
         }
-        config.publisher.setMatrixParam(BUILD_TIMESTAMP, buildTimestamp);
+        config.publisher.setMatrixParam(BuildInfoFields.BUILD_TIMESTAMP, buildTimestamp);
 
         // Build agent
         String buildAgentName = config.info.getBuildAgentName();

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -41,7 +41,6 @@ public class ArtifactoryClientConfiguration {
     // Try checksum deploy of files greater than 10KB
     public static final transient int DEFAULT_MIN_CHECKSUM_DEPLOY_SIZE_KB = 10;
     public static final String DEFAULT_NUGET_PROTOCOL = "v2";
-    // TODO add comment here
     public static final boolean DEFAULT_NUGET_ALLOW_INSECURE_CONNECTIONS = false;
 
     public final ResolverHandler resolver;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -41,6 +41,8 @@ public class ArtifactoryClientConfiguration {
     // Try checksum deploy of files greater than 10KB
     public static final transient int DEFAULT_MIN_CHECKSUM_DEPLOY_SIZE_KB = 10;
     public static final String DEFAULT_NUGET_PROTOCOL = "v2";
+    // TODO add comment here
+    public static final boolean DEFAULT_NUGET_ALLOW_INSECURE_CONNECTIONS = false;
 
     public final ResolverHandler resolver;
     public final PublisherHandler publisher;
@@ -54,7 +56,7 @@ public class ArtifactoryClientConfiguration {
     public final DockerHandler dockerHandler;
     public final GoHandler goHandler;
     public final PrefixPropertyHandler root;
-    public final boolean nuGetAllowInsecureConnections;
+
 
     /**
      * To configure the props builder itself, so all method of this classes delegated from here
@@ -75,7 +77,6 @@ public class ArtifactoryClientConfiguration {
         this.dotnetHandler = new DotnetHandler();
         this.dockerHandler = new DockerHandler();
         this.goHandler = new GoHandler();
-        this.nuGetAllowInsecureConnections = false;
     }
 
     public void fillFromProperties(Map<String, String> props, IncludeExcludePatterns patterns) {
@@ -209,6 +210,10 @@ public class ArtifactoryClientConfiguration {
 
     public boolean getInsecureTls() {
         return root.getBooleanValue(PROP_INSECURE_TLS, false);
+    }
+
+    public boolean getNuGetAllowInsecureConnections() {
+        return root.getBooleanValue(PROP_NUGET_ALLOW_INSECURE_CONNECTIONS, false);
     }
 
     public void setInsecureTls(boolean enabled) {

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientProperties.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientProperties.java
@@ -70,4 +70,10 @@ public interface ClientProperties {
      * Property for whether to use relaxed ssl check and ignore issues with server certificate
      */
     String PROP_INSECURE_TLS = "insecureTls";
+
+    /**
+     * Property to allow NuGet package sources to use insecure connections (HTTP).
+     * This setting is enforced by the NuGet client and is not recommended for production use.
+     */
+    String PROP_NUGET_ALLOW_INSECURE_CONNECTIONS = "nuget.AllowInsecureConnections";
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

## Allows the user to set `allowInsecureConnections` in NuGet config file.

```
  <packageSources>
    <add key="JFrogCli" value="%s" protocolVersion="%s" **allowInsecureConnections**="%v"/>
  </packageSources>
```

The [latest .NET 6 release](https://versionsof.net/core/6.0/6.0.36/) introduces changes to NuGet that now restrict the use of insecure connections for package sources unless a specific flag is enabled.

This update resolves the failing tests by adding the required flag for cases where it is necessary. This flag is primarily intended for testing purposes to allow use with local sources and should not be enabled in production environments.


For the tests this flag is set to true.
If you user would like to overwrite this flag, it can be done via the `nuget.AllowInsecureConnections` prop.
