### PR TITLE
Fix go version extractor to accept valid semver with 2 dashes

### DIFF
--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoVersionUtilsTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoVersionUtilsTest.java
@@ -33,6 +33,7 @@ public class GoVersionUtilsTest {
         assertEquals(GoVersionUtils.getMajorVersion("v1.2.3----RC-SNAPSHOT.12.9.1--.12+788", log), 1);
         assertEquals(GoVersionUtils.getMajorVersion("v1.2.3----R-S.12.9.1--.12+meta", log), 1);
         assertEquals(GoVersionUtils.getMajorVersion("v2.2.0-beta.1", log), 2);
+        assertEquals(GoVersionUtils.getMajorVersion("v2.0.0-beta-1", log), 2);
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -478,6 +478,10 @@ project('build-info-extractor-docker') {
 
 project('build-info-extractor-go') {
     description = 'JFrog Build-Info Go Extractor'
+
+    dependencies {
+        implementation group: 'com.github.zafarkhaja', name: 'java-semver', version: '0.10.2'
+    }
 }
 
 project('build-info-extractor-pip') {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
