### PR TITLE
Added conditional statement to skip audit while releasing

### DIFF
--- a/release/pipelines.release.yml
+++ b/release/pipelines.release.yml
@@ -14,6 +14,7 @@ pipelines:
           NEXT_DEVELOPMENT_VERSION: 2.0.x-SNAPSHOT
           NEXT_GRADLE_VERSION: 4.0.0
           NEXT_GRADLE_DEVELOPMENT_VERSION: 4.0.x-SNAPSHOT
+          SKIP_AUDIT_CHECK: "false"
 
     steps:
       - name: Release
@@ -54,7 +55,14 @@ pipelines:
             - jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-release-local
 
             # Run audit
-            - jf audit --fail=false
+            - |
+              if [[ $SKIP_AUDIT_CHECK == "true" ]]; then
+                echo "Skipping audit check"
+              else
+                echo "Running audit check"
+                jf audit --fail=false
+              fi
+
 
             # Update version
             - sed -i -e "/build-info-version=/ s/=.*/=$NEXT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_VERSION/" gradle.properties


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

The `jf audit --fail=false` command is not working as expected and fails the release
Until it will be fixed, we added env var to allow skipping audit
default value is false