### PR TITLE
Fix for Jenkins Malformed encoding

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -111,6 +111,13 @@ public abstract class BuildInfoExtractorUtils {
             } else {
                 try (InputStream inputStream = Files.newInputStream(propertiesFile.toPath())) {
                     props.load(inputStream);
+                } catch (IllegalArgumentException e) {
+                    log.warn("[buildinfo] Properties file contains malformed Unicode encoding. Attempting to load with UTF-8 encoding: " + e.getMessage());
+                    try (BufferedReader reader = Files.newBufferedReader(propertiesFile.toPath(), StandardCharsets.UTF_8)) {
+                        props.load(reader);
+                    } catch (Exception fallbackException) {
+                        log.error("[buildinfo] Failed to load properties file even with UTF-8 fallback: " + fallbackException.getMessage());
+                    }
                 }
             }
         } catch (IOException | InvalidAlgorithmParameterException | IllegalBlockSizeException | NoSuchPaddingException |


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

The issue was that when loading properties files with malformed Unicode escape sequences (like `\uxxxx`), the original code would fail with `IllegalArgumentException: Malformed \uxxxx encoding`.
The fix implements a fallback strategy:
- First, try the normal properties loading
- If that fails with `IllegalArgumentException`, try loading with explicit UTF-8 encoding
- If that also fails, continue with empty properties rather than failing the entire build