### PR TITLE
Updated sonatype with nexus URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,7 +237,11 @@ subprojects {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
## Problem Description
unable to release since the response from sona type is 401 and probably it is nothing to do with credentials

## Solution
sonatype { nexusUrl ... snapshotRepositoryUrl ... } block is required to explicitly set the Nexus and snapshot repository URLs for the new OSSRH publishing API. The older sonatype() shortcut uses default URLs, which may not work with the updated Sonatype Central