### PR TITLE
Include dependency metadata in build-info for Android

### DIFF
--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/ArtifactoryPluginBase.groovy
@@ -25,7 +25,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
 
     void apply(Project project) {
         if ("buildSrc".equals(project.name)) {
-            log.info("Artifactory Plugin disabled for ${project.path}")
+            log.debug("Artifactory Plugin disabled for ${project.path}")
             return
         }
         // Add an Artifactory plugin convention to all the project modules
@@ -49,7 +49,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         if (!conv.clientConfig.info.buildStarted) {
             conv.clientConfig.info.setBuildStarted(System.currentTimeMillis())
         }
-        log.info("Using Artifactory Plugin for ${project.path}")
+        log.debug("Using Artifactory Plugin for ${project.path}")
 
         project.gradle.addProjectEvaluationListener(new ProjectsEvaluatedBuildListener())
     }
@@ -87,8 +87,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
     private ArtifactoryTask addArtifactoryPublishTask(Project project) {
         ArtifactoryTask artifactoryTask = project.tasks.findByName(ARTIFACTORY_PUBLISH_TASK_NAME)
         if (artifactoryTask == null) {
-            log.info("Configuring ${ARTIFACTORY_PUBLISH_TASK_NAME} task for project ${project.path}: is root? ${isRootProject(project)}")
-            log.info("Configuring ${ARTIFACTORY_PUBLISH_TASK_NAME} task for project ${project.path}: is root? ${isRootProject(project)}")
+            log.debug("Configuring ${ARTIFACTORY_PUBLISH_TASK_NAME} task for project ${project.path}: is root? ${isRootProject(project)}")
             artifactoryTask = createArtifactoryPublishTask(project)
             artifactoryTask.setGroup(PUBLISH_TASK_GROUP)
         }
@@ -101,7 +100,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
     private DistributeBuildTask addDistributeBuildTask(Project project) {
         DistributeBuildTask distributeBuildTask = project.tasks.findByName(DISTRIBUTE_TASK_NAME)
         if (distributeBuildTask == null) {
-            log.info("Configuring ${DISTRIBUTE_TASK_NAME} task for project ${project.path}: is root? ${isRootProject(project)}")
+            log.debug("Configuring ${DISTRIBUTE_TASK_NAME} task for project ${project.path}: is root? ${isRootProject(project)}")
             distributeBuildTask = createArtifactoryDistributeBuildTask(project)
             distributeBuildTask.setGroup(PUBLISH_TASK_GROUP)
         }
@@ -113,7 +112,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
         Project project = artifactoryTask.project
         ExtractModuleTask extractModuleTask = project.tasks.findByName(EXTRACT_MODULE_TASK_NAME)
         if (extractModuleTask == null) {
-            log.info("Configuring extractModuleInfo task for project ${project.path}")
+            log.debug("Configuring extractModuleInfo task for project ${project.path}")
             extractModuleTask = createExtractModuleTask(project)
         }
         extractModuleTask.outputs.upToDateWhen { false }
@@ -130,7 +129,7 @@ abstract class ArtifactoryPluginBase implements Plugin<Project> {
     private DeployTask addDeployTask(Project project) {
         DeployTask deployTask = project.tasks.findByName(DEPLOY_TASK_NAME)
         if (deployTask == null) {
-            log.info("Configuring deployTask task for project ${project.path}")
+            log.debug("Configuring deployTask task for project ${project.path}")
             deployTask = createArtifactoryDeployTask(project)
             deployTask.setGroup(PUBLISH_TASK_GROUP)
         }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -130,7 +130,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
     }
 
     private void evaluate(ArtifactoryTask artifactoryTask) {
-        log.debug("evaluating buildBaseTask {}", artifactoryTask)
+        log.info("evaluating buildBaseTask: {} for project: {}", artifactoryTask, artifactoryTask.project)
         ArtifactoryPluginConvention convention =
                 ArtifactoryPluginUtil.getArtifactoryConvention(artifactoryTask.project)
 
@@ -146,9 +146,13 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
             if (artifactoryTask.isCiServerBuild()) {
                 PublishingExtension publishingExtension = (PublishingExtension) artifactoryTask.project.extensions.findByName("publishing")
                 String publicationsNames = clientConfig.publisher.getPublications()
+                log.info("publishing extension is: {} and publication name: {}", publishingExtension, publicationsNames)
                 if (publishingExtension != null && StringUtils.isNotBlank(publicationsNames)) {
+                    log.info("publishing extension is present and publication name: {}", publicationsNames)
                     addPublications(artifactoryTask, publishingExtension, publicationsNames)
-                } else if (projectHasOneOfComponents(artifactoryTask.project, "java", "javaPlatform")) {
+                }// we need to add default publications for android here because, id("org.jetbrains.kotlin.jvm")  // Creates "java" component
+                else if (projectHasOneOfComponents(artifactoryTask.project, "java", "javaPlatform")) {
+                    log.info("adding default configuration for java project: {}", publicationsNames)
                     addDefaultPublicationsOrConfigurations(artifactoryTask, publishingExtension);
                 }
             }

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -130,7 +130,7 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
     }
 
     private void evaluate(ArtifactoryTask artifactoryTask) {
-        log.info("evaluating buildBaseTask: {} for project: {}", artifactoryTask, artifactoryTask.project)
+        log.debug("evaluating buildBaseTask: {} for project: {}", artifactoryTask, artifactoryTask.project)
         ArtifactoryPluginConvention convention =
                 ArtifactoryPluginUtil.getArtifactoryConvention(artifactoryTask.project)
 

--- a/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
+++ b/build-info-extractor-gradle/src/main/groovy/org/jfrog/gradle/plugin/artifactory/extractor/listener/ProjectsEvaluatedBuildListener.groovy
@@ -130,7 +130,8 @@ public class ProjectsEvaluatedBuildListener extends BuildAdapter implements Proj
     }
 
     private void evaluate(ArtifactoryTask artifactoryTask) {
-        log.debug("evaluating buildBaseTask: {} for project: {}", artifactoryTask, artifactoryTask.project)
+        log.info("evaluating artifactoryTask for project: {}", artifactoryTask.project)
+        log.debug("evaluating buildBaseTask {}", artifactoryTask)
         ArtifactoryPluginConvention convention =
                 ArtifactoryPluginUtil.getArtifactoryConvention(artifactoryTask.project)
 

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -93,13 +93,13 @@ public abstract class BuildInfoExtractorUtils {
         String propsFilePath = getAdditionalPropertiesFile(existingProps, log);
 
         if (StringUtils.isBlank(propsFilePath)) {
-            log.debug("[buildinfo] BuildInfo properties file path is not found.");
+            log.info("[buildinfo] BuildInfo properties file path is not found.");
             return props;
         }
 
         File propertiesFile = new File(propsFilePath);
         if (!propertiesFile.exists()) {
-            log.debug("[buildinfo] BuildInfo properties file is not exists.");
+            log.info("[buildinfo] BuildInfo properties file is not exists.");
             return props;
         }
 
@@ -299,9 +299,9 @@ public abstract class BuildInfoExtractorUtils {
         }
         if (log != null) {
             if (StringUtils.isBlank(filePath)) {
-                log.debug("[buildinfo] Not using buildInfo properties file for this build.");
+                log.info("[buildinfo] Not using buildInfo properties file for this build.");
             } else {
-                log.debug("[buildinfo] Properties file '" + filePath + "' retrieved from '" + propFoundPath + "'");
+                log.info("[buildinfo] Properties file '" + filePath + "' retrieved from '" + propFoundPath + "'");
             }
         }
         return filePath;

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -93,13 +93,13 @@ public abstract class BuildInfoExtractorUtils {
         String propsFilePath = getAdditionalPropertiesFile(existingProps, log);
 
         if (StringUtils.isBlank(propsFilePath)) {
-            log.info("[buildinfo] BuildInfo properties file path is not found.");
+            log.debug("[buildinfo] BuildInfo properties file path is not found.");
             return props;
         }
 
         File propertiesFile = new File(propsFilePath);
         if (!propertiesFile.exists()) {
-            log.info("[buildinfo] BuildInfo properties file is not exists.");
+            log.debug("[buildinfo] BuildInfo properties file is not exists.");
             return props;
         }
 
@@ -299,9 +299,9 @@ public abstract class BuildInfoExtractorUtils {
         }
         if (log != null) {
             if (StringUtils.isBlank(filePath)) {
-                log.info("[buildinfo] Not using buildInfo properties file for this build.");
+                log.debug("[buildinfo] Not using buildInfo properties file for this build.");
             } else {
-                log.info("[buildinfo] Properties file '" + filePath + "' retrieved from '" + propFoundPath + "'");
+                log.debug("[buildinfo] Properties file '" + filePath + "' retrieved from '" + propFoundPath + "'");
             }
         }
         return filePath;


### PR DESCRIPTION
Problem-
A user is experiencing an issue where the dependencies of their Android project are not being captured in the build-info.json file when using the JFrog CLI following command. 

1- jf gradle "assembleDebug" --build-name=android-gradle --build-number=1
2- jf rt u "app/build/outputs/apk/debug/app-debug.apk" "demo-gradle-dev/android-sample-app/app-debug.apk" --build-name=android-gradle --build-number=1
3- Jf rt bp android-gradle 1

While this isn't preventing the build from completing, it creates a feeling that the project isn't being built properly.

"assembleDebug" is a gradle build task which lets you build the apk for the staging environment. This task does not enable the module-extractor task which helps to collect the dependencies.

Solution-
by adding artifactoryPublish in the command with assembleDebug. this will register the artifactoryTask in the gradle project which internally register the extract-module task for the project that collects the dependencies for the modules.
jf gradle "assembleDebug" atrifactoryPublish --build-name=android-gradle --build-number=1

Also, I have changed the hasModules() this function just not only check for the publication but also do check for the 
modules present or not for the module now. It helps us to collect the dependencies for the modules that do no have any publication configured just like the android project.