### PR TITLE
Fix Maven verify goal including undeployed artifacts in build info

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -469,6 +469,13 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
 
     private void addArtifactsToCurrentModule(MavenProject project, ModuleBuilder module) {
         addDefaultPublisherAttributes(conf, project.getName(), "Maven", project.getVersion());
+        
+        // Check if artifact collection is disabled for build info
+        if (!conf.publisher.isPublishArtifacts()) {
+            logger.info("Artifact publishing is disabled - skipping artifact collection for build info");
+            return;
+        }
+        
         Set<Artifact> moduleArtifacts = currentModuleArtifacts.get();
         if (moduleArtifacts == null) {
             logger.warn("Skipping Artifactory Build-Info module artifact addition: Null current module artifact list.");


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
# Fix Maven verify goal including undeployed artifacts in build info

## Problem
Maven `verify` goal was incorrectly including built artifacts in the build info even though these artifacts were never deployed to Artifactory. This caused issues when creating Release Bundles, as they referenced non-existent artifacts.

## Solution
Added a check in `BuildInfoRecorder.addArtifactsToCurrentModule()` to respect the `publish.artifacts` configuration property. When artifact publishing is disabled, the extractor now skips artifact collection entirely.

## Changes
- **File**: `build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java`
- **Change**: Added `!conf.publisher.isPublishArtifacts()` check before collecting artifacts
- **Behavior**: 
  - `mvn verify`: ✅ Dependencies collected, ❌ No artifacts in build info
  - `mvn deploy`: ✅ Dependencies collected, ✅ Artifacts collected and deployed

## Testing
- Verified `verify` goal produces build info with 0 artifacts and dependencies intact
- Verified `deploy` goal continues to work normally with artifacts included
- No breaking changes to existing functionality

## Impact
Fixes Release Bundle creation failures caused by referencing undeployed artifacts from `verify` builds.