### PR TITLE
Fix for maven conditional upload scenarios

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -470,8 +470,15 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     private void addArtifactsToCurrentModule(MavenProject project, ModuleBuilder module) {
         addDefaultPublisherAttributes(conf, project.getName(), "Maven", project.getVersion());
         
-        // Check if artifact collection is disabled for build info
-        if (!conf.publisher.isPublishArtifacts()) {
+        // Check if artifact metadata is explicitly requested for scanning/detailed summary
+        boolean artifactMetadataRequested = conf.publisher.shouldAddDeployableArtifacts();
+        boolean publishArtifacts = conf.publisher.isPublishArtifacts();
+        
+        // Skip artifact collection only if BOTH conditions are true:
+        // 1. Publishing is disabled (publish.artifacts=false) AND
+        // 2. Artifact metadata is NOT explicitly requested (no deployable.artifacts.map)
+        // This preserves the mvn verify fix while supporting conditional upload scenarios
+        if (!publishArtifacts && !artifactMetadataRequested) {
             logger.info("Artifact publishing is disabled - skipping artifact collection for build info");
             return;
         }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
Fixes regression in Maven extractor 2.43.1 where artifact metadata was not collected for conditional upload scenarios (XRay scan before deploy).

**Problem:**
- `mvn verify` fix (skipping artifacts when `publish.artifacts=false`) was too aggressive
- Broke conditional upload feature which needs artifact metadata for XRay scanning

**Solution:**
- Check BOTH `isPublishArtifacts()` AND `shouldAddDeployableArtifacts()`
- Skip artifacts only when publishing is disabled AND metadata is NOT explicitly requested
- Preserves mvn verify fix while supporting conditional upload