### PR TITLE
excluding ide-specific properties

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -77,8 +77,36 @@ public abstract class BuildInfoExtractorUtils {
     private static Properties addSystemProperties(Properties existingProps) {
         Properties props = new Properties();
         props.putAll(existingProps);
-        props.putAll(System.getProperties());
+        // Only add system properties that are relevant to the build
+        Properties systemProps = System.getProperties();
+        for (String propertyName : systemProps.stringPropertyNames()) {
+            // Include properties that are likely to be build-related
+            if (isRelevantSystemProperty(propertyName)) {
+                props.setProperty(propertyName, systemProps.getProperty(propertyName));
+            }
+        }
+        
         return props;
+    }
+    
+    /**
+     * This method filters out IDE-specific and other unrelated properties that could cause
+     * configuration cache invalidation in Gradle.
+     */
+    private static boolean isRelevantSystemProperty(String propertyName) {
+        if (StringUtils.isEmpty(propertyName)) {
+            return false;
+        }
+        if (StringUtils.startsWithAny(propertyName,
+                "idea.",
+                "intellij.",
+                "eclipse.",
+                "netbeans.",
+                "vscode.")) {
+            return false;
+        }
+        // By default, include all other properties.
+        return true;
     }
 
     /**


### PR DESCRIPTION
Problem- Customer are facing Gradle cache miss happening due to ide properties getting updated in the configuration phase. These properties does not concern the project build but still end up being the one for the cause of cache miss.

Solution- Not reading these properties in the configuration phase which exclude them from being an input in the cache.
