### PR TITLE
excluding ide-specific properties

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/BuildInfoExtractorUtils.java
@@ -102,7 +102,8 @@ public abstract class BuildInfoExtractorUtils {
                 "intellij.",
                 "eclipse.",
                 "netbeans.",
-                "vscode.")) {
+                "vscode.",
+                "studio.")) {
             return false;
         }
         // By default, include all other properties.


### PR DESCRIPTION
Problem- Customer are facing Gradle cache miss happening due to ide properties getting updated in the configuration phase. These properties does not concern the project build but still end up being the one for the cause of cache miss.

Solution- Not reading these properties in the configuration phase which exclude them from being an input in the cache.