### PR TITLE
Fix Maven 3.9.12 compatibility: Add prerequisitesCheckers requirement

### DIFF
--- a/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
+++ b/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
@@ -100,6 +100,10 @@
                     <role>org.apache.maven.plugin.PluginValidationManager</role>
                     <field-name>pluginValidationManager</field-name>
                 </requirement>
+                <requirement>
+                    <role>java.util.List</role>
+                    <field-name>prerequisitesCheckers</field-name>
+                </requirement>
             </requirements>
         </component>
         <!-- A class responssible for enforcing metadata resolution from Artifactory, for Maven 3.2.1 and above -->


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
