### PR TITLE
RTDEV-61736 - Align GoZipBallStreamer with package handler impl's

### DIFF
--- a/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
+++ b/build-info-extractor-go/src/test/java/org/jfrog/build/extractor/go/extractor/GoExtractorTest.java
@@ -10,6 +10,7 @@ import org.jfrog.build.extractor.ci.*;
 import org.jfrog.build.extractor.clientConfiguration.ArtifactoryManagerBuilder;
 import org.jfrog.build.extractor.clientConfiguration.deploy.DeployDetails;
 import org.jfrog.build.extractor.executor.CommandExecutor;
+import org.jfrog.build.extractor.ci.Module;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

Decsription:
The purpose of this PR is to align build-info code with packages code.
we have the same class and there was 2 commits lately that wasn't align with build-info code
This is already runs in production in artifactory so we trust is and just need to merge here as well.
those are the commits:
[RTDEV-70709 - Fix for .zip downloading from GitLab + subgroups](https://github.jfrog.info/JFROG/packages/commit/2bfdb60efca3c76d147d8a9f1a4ff8b9fd254531#diff-8c3d6e8c8b1c16d16887306a577e72afc161e2be7b9ac68371ed6f2bcd34d38c)

[RTDEV-70121 - Fix resolve go nested submodule for compatible git tags (](https://github.jfrog.info/JFROG/packages/pull/982/commits/628212f2112abd42b55d3fd14b738563cb4c1584#diff-8c3d6e8c8b1c16d16887306a577e72afc161e2be7b9ac68371ed6f2bcd34d38c)[#980](https://github.jfrog.info/JFROG/packages/pull/980)[)](https://github.jfrog.info/JFROG/packages/pull/982/commits/628212f2112abd42b55d3fd14b738563cb4c1584)
