### PR TITLE
Fix missing <type>pom</type> for groovy-all dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -483,7 +483,7 @@ project('build-info-extractor-maven3') {
 
     dependencies {
         implementation "org.jdom:jdom2:$jdomVersion",
-                "org.codehaus.groovy:groovy-all:$groovyAllVersion",
+                "org.codehaus.groovy:groovy-all:$groovyAllVersion@pom",
                 "org.codehaus.plexus:plexus-container-default:$plexusContainerVersion",
                 "org.eclipse.aether:aether-api:$eclipseAetherVersion",
                 "org.eclipse.aether:aether-util:$eclipseAetherVersion",


### PR DESCRIPTION
### Fix missing `<type>pom</type>` for `groovy-all` dependency

**Context:**
The `build-info-extractor-maven3` package declares a dependency on `org.codehaus.groovy:groovy-all:3.0.13`. Starting from version `3.0.0`, the `groovy-all` package discontinued publishing the actual `.jar` artifact and was refactored into a `pom` packaging type (aggregator).

**Bug:**
Because the dependency definition in `build.gradle` omits the artifact extension, the generated `pom.xml` defaults to a `jar` type. This causes downstream users in strict or offline environments (e.g., using `dependency:copy-dependencies`) to suffer fatal `--fail-at-end` build crashes:
`Could not resolve dependencies [...] org.codehaus.groovy:groovy-all:jar:3.0.13 was not found`

**Fix:**
This PR simply appends `@pom` to the dependency declaration in `build.gradle` so that the `maven-publish` plugin accurately generates the required `<type>pom</type>` in the resulting POM file, effectively resolving the dependency tree resolution failure.