### PR TITLE
Fix Security Violation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ buildscript {
         httpClientVersion = '4.5.14'
         httpCoreVersion = '4.4.16'
         ivyVersion = '2.5.2'
-        // Updated to 2.17.3 for security fixes - compatible with Java 8+
-        jacksonVersion = '2.17.3'
+        // Updated to 2.18.6 for security fixes (CVE-2025-52999, GHSA-h46c-h94j-95f3) - compatible with Java 8+
+        jacksonVersion = '2.18.6'
         jdomVersion = '2.0.6.1'
         jsrVersion = '3.0.2'
         mavenVersion = '3.8.6'
@@ -128,7 +128,7 @@ subprojects {
             force 'org.xmlunit:xmlunit-core:2.10.0'
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'io.netty') {
-                    details.useVersion('4.1.125.Final')
+                    details.useVersion('4.1.130.Final')
                 }
             }
         }
@@ -143,7 +143,7 @@ subprojects {
     configurations.all {
         resolutionStrategy.eachDependency { details ->
             if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
-                details.useVersion '4.1.125.Final'
+                details.useVersion '4.1.130.Final'
             }
             if (details.requested.group == 'org.bouncycastle' &&
                     (details.requested.name == 'bcprov-jdk18on' || details.requested.name == 'bcpkix-jdk18on')) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
**Title:** Fix security audit violations - upgrade jackson and netty

**Description:**
Upgrade vulnerable dependencies to resolve `jf audit` security violations.

- jackson (core/databind/annotations): 2.17.3 → 2.18.6
- netty (all modules): 4.1.125.Final → 4.1.130.Final (CVE-2025-67735)

**Note on Jackson version:** 2.18.6 is the stable LTS branch. The nesting depth fix from 2.15.0 (CVE-2025-52999/GHSA-h46c-h94j-95f3 from Issue #405) is included in 2.18.6 since it comes after 2.15.0. We cannot use 2.21.1 because it's an incomplete release - only jackson-core 2.21.1 exists on Maven Central, while jackson-annotations and jackson-databind are stuck at 2.21.0, causing build failures. Using 2.18.6 avoids this issue and provides all necessary security fixes.
