### PR TITLE
Fix Maven 3.9.12 + Develocity compatibility: declare checkPrerequisites override

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
@@ -31,9 +31,8 @@ public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
         return super.setupExtensionsRealm(project, plugin, session);
     }
 
-    // Declared so Develocity's reflective lookup
-    // (Class.getDeclaredMethod("checkPrerequisites", PluginDescriptor.class)) succeeds —
-    // getDeclaredMethod does not walk the superclass.
+    // Declared so Class.getDeclaredMethod on this subclass finds it —
+    // getDeclaredMethod does not walk the superclass chain.
     @Override
     public void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
         super.checkPrerequisites(pluginDescriptor);

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
@@ -13,6 +13,9 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.eclipse.aether.RepositorySystemSession;
 
 import javax.inject.Named;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.List;
 
 /**
@@ -21,6 +24,23 @@ import java.util.List;
 @Named
 @Component(role = DefaultMavenPluginManager.class)
 public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
+
+    // Non-virtual handle to DefaultMavenPluginManager#checkPrerequisites if and only if the
+    // parent class declares it (Maven >= 3.9.12). On older Maven runtimes the method does not
+    // exist on the parent, the handle stays null, and the override below is a safe no-op.
+    private static final MethodHandle SUPER_CHECK_PREREQUISITES = resolveSuperCheckPrerequisites();
+
+    private static MethodHandle resolveSuperCheckPrerequisites() {
+        try {
+            return MethodHandles.lookup().findSpecial(
+                    DefaultMavenPluginManager.class,
+                    "checkPrerequisites",
+                    MethodType.methodType(void.class, PluginDescriptor.class),
+                    ArtifactoryEclipsePluginManager.class);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            return null;
+        }
+    }
 
     @Requirement
     private ArtifactoryEclipseResolversHelper helper;
@@ -32,10 +52,22 @@ public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
     }
 
     // Declared so Class.getDeclaredMethod on this subclass finds it —
-    // getDeclaredMethod does not walk the superclass chain.
+    // getDeclaredMethod does not walk the superclass chain. Delegates to the parent via a
+    // MethodHandle resolved at class-load time so the bytecode does not embed a hard reference
+    // to a method that may not exist on older Maven runtimes (3.8.x / 3.9.0 - 3.9.11).
     @Override
     public void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
-        super.checkPrerequisites(pluginDescriptor);
+        MethodHandle handle = SUPER_CHECK_PREREQUISITES;
+        if (handle == null) {
+            return;
+        }
+        try {
+            handle.invoke(this, pluginDescriptor);
+        } catch (PluginIncompatibleException | RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
     }
 
     private void enforceResolutionRepositories(MavenProject project, RepositorySystemSession session) {

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
@@ -3,7 +3,9 @@ package org.jfrog.build.extractor.maven.resolver;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.ExtensionRealmCache;
+import org.apache.maven.plugin.PluginIncompatibleException;
 import org.apache.maven.plugin.PluginManagerException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.internal.DefaultMavenPluginManager;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
@@ -27,6 +29,14 @@ public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
     public ExtensionRealmCache.CacheRecord setupExtensionsRealm(MavenProject project, Plugin plugin, RepositorySystemSession session) throws PluginManagerException {
         enforceResolutionRepositories(project, session);
         return super.setupExtensionsRealm(project, plugin, session);
+    }
+
+    // Declared so Develocity's reflective lookup
+    // (Class.getDeclaredMethod("checkPrerequisites", PluginDescriptor.class)) succeeds —
+    // getDeclaredMethod does not walk the superclass.
+    @Override
+    public void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
+        super.checkPrerequisites(pluginDescriptor);
     }
 
     private void enforceResolutionRepositories(MavenProject project, RepositorySystemSession session) {

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
@@ -1,5 +1,6 @@
 package org.jfrog.build.extractor.maven.resolver;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.ExtensionRealmCache;
@@ -70,16 +71,13 @@ public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
     // to the older name (checkRequiredMavenVersion) on Maven < 3.9.12 so the check still runs.
     @Override
     public void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
-        MethodHandle handle = SUPER_PREREQUISITES_CHECK;
-        if (handle == null) {
+        if (SUPER_PREREQUISITES_CHECK == null) {
             return;
         }
         try {
-            handle.invoke(this, pluginDescriptor);
-        } catch (PluginIncompatibleException | RuntimeException | Error e) {
-            throw e;
+            SUPER_PREREQUISITES_CHECK.invoke(this, pluginDescriptor);
         } catch (Throwable t) {
-            throw new RuntimeException(t);
+            ExceptionUtils.rethrow(t);
         }
     }
 

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManager.java
@@ -25,16 +25,29 @@ import java.util.List;
 @Component(role = DefaultMavenPluginManager.class)
 public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
 
-    // Non-virtual handle to DefaultMavenPluginManager#checkPrerequisites if and only if the
-    // parent class declares it (Maven >= 3.9.12). On older Maven runtimes the method does not
-    // exist on the parent, the handle stays null, and the override below is a safe no-op.
-    private static final MethodHandle SUPER_CHECK_PREREQUISITES = resolveSuperCheckPrerequisites();
+    // Non-virtual handle to the parent's prerequisites-check method, whichever name it
+    // currently uses. Maven 3.9.12 renamed checkRequiredMavenVersion → checkPrerequisites
+    // and kept the old name as a deprecated default method on the MavenPluginManager interface
+    // that internally delegates to the new name. We must therefore look up the new name first:
+    // on 3.9.12+ that hits the real implementation directly. Falling through to the old name
+    // is only used on Maven < 3.9.12, where the new name does not exist and the old name is
+    // a real method on DefaultMavenPluginManager — so the check still runs.
+    // If neither exists, the handle stays null and the override below is a safe no-op.
+    private static final MethodHandle SUPER_PREREQUISITES_CHECK = resolveSuperPrerequisitesCheck();
 
-    private static MethodHandle resolveSuperCheckPrerequisites() {
+    private static MethodHandle resolveSuperPrerequisitesCheck() {
+        MethodHandle handle = findSuperMethod("checkPrerequisites");
+        if (handle != null) {
+            return handle;
+        }
+        return findSuperMethod("checkRequiredMavenVersion");
+    }
+
+    private static MethodHandle findSuperMethod(String name) {
         try {
             return MethodHandles.lookup().findSpecial(
                     DefaultMavenPluginManager.class,
-                    "checkPrerequisites",
+                    name,
                     MethodType.methodType(void.class, PluginDescriptor.class),
                     ArtifactoryEclipsePluginManager.class);
         } catch (NoSuchMethodException | IllegalAccessException e) {
@@ -52,12 +65,12 @@ public class ArtifactoryEclipsePluginManager extends DefaultMavenPluginManager {
     }
 
     // Declared so Class.getDeclaredMethod on this subclass finds it —
-    // getDeclaredMethod does not walk the superclass chain. Delegates to the parent via a
-    // MethodHandle resolved at class-load time so the bytecode does not embed a hard reference
-    // to a method that may not exist on older Maven runtimes (3.8.x / 3.9.0 - 3.9.11).
+    // getDeclaredMethod does not walk the superclass chain. Delegates to the parent's
+    // prerequisites-check method via a MethodHandle resolved at class-load time, falling back
+    // to the older name (checkRequiredMavenVersion) on Maven < 3.9.12 so the check still runs.
     @Override
     public void checkPrerequisites(PluginDescriptor pluginDescriptor) throws PluginIncompatibleException {
-        MethodHandle handle = SUPER_CHECK_PREREQUISITES;
+        MethodHandle handle = SUPER_PREREQUISITES_CHECK;
         if (handle == null) {
             return;
         }

--- a/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManagerTest.java
+++ b/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManagerTest.java
@@ -1,0 +1,24 @@
+package org.jfrog.build.extractor.maven.resolver;
+
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@Test
+public class ArtifactoryEclipsePluginManagerTest {
+
+    // Mirrors Develocity's exact reflective contract: it calls
+    // Class.getDeclaredMethod("checkPrerequisites", PluginDescriptor.class) on the
+    // Plexus-bound DefaultMavenPluginManager implementation. getDeclaredMethod does
+    // not walk the superclass, so the method must be physically declared here.
+    public void testCheckPrerequisitesIsDeclaredOnSubclass() throws NoSuchMethodException {
+        Method m = ArtifactoryEclipsePluginManager.class
+                .getDeclaredMethod("checkPrerequisites", PluginDescriptor.class);
+        assertNotNull(m);
+        assertEquals(ArtifactoryEclipsePluginManager.class, m.getDeclaringClass());
+    }
+}

--- a/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManagerTest.java
+++ b/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManagerTest.java
@@ -5,8 +5,8 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 @Test
 public class ArtifactoryEclipsePluginManagerTest {
@@ -18,6 +18,6 @@ public class ArtifactoryEclipsePluginManagerTest {
         Method m = ArtifactoryEclipsePluginManager.class
                 .getDeclaredMethod("checkPrerequisites", PluginDescriptor.class);
         assertNotNull(m);
-        assertEquals(ArtifactoryEclipsePluginManager.class, m.getDeclaringClass());
+        assertEquals(m.getDeclaringClass(), ArtifactoryEclipsePluginManager.class);
     }
 }

--- a/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManagerTest.java
+++ b/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/resolver/ArtifactoryEclipsePluginManagerTest.java
@@ -11,10 +11,9 @@ import static org.junit.Assert.assertNotNull;
 @Test
 public class ArtifactoryEclipsePluginManagerTest {
 
-    // Mirrors Develocity's exact reflective contract: it calls
-    // Class.getDeclaredMethod("checkPrerequisites", PluginDescriptor.class) on the
-    // Plexus-bound DefaultMavenPluginManager implementation. getDeclaredMethod does
-    // not walk the superclass, so the method must be physically declared here.
+    // checkPrerequisites must be physically declared on this subclass, not just
+    // inherited, so that Class.getDeclaredMethod can find it. getDeclaredMethod
+    // does not walk the superclass chain.
     public void testCheckPrerequisitesIsDeclaredOnSubclass() throws NoSuchMethodException {
         Method m = ArtifactoryEclipsePluginManager.class
                 .getDeclaredMethod("checkPrerequisites", PluginDescriptor.class);

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         jacksonVersion = '2.17.3'
         jdomVersion = '2.0.6.1'
         jsrVersion = '3.0.2'
-        mavenVersion = '3.8.6'
+        mavenVersion = '3.9.12'
         mavenDeployPluginVersion = '3.0.0'
         p4JavaVersion = '2022.1.2350821'
 


### PR DESCRIPTION
## Summary
- Maven 3.9.12 renamed `DefaultMavenPluginManager#checkRequiredMavenVersion` to `checkPrerequisites`. The Develocity Maven extension reflectively looks the new method up via `Class.getDeclaredMethod` on the Plexus-bound `DefaultMavenPluginManager` implementation, which in this project is `ArtifactoryEclipsePluginManager`. `getDeclaredMethod` does not walk the superclass, so the lookup throws `NoSuchMethodException` and blocks any Maven >= 3.9.12 build that also loads Develocity's extension.
- PR #844 (in v2.43.6) added the `prerequisitesCheckers` Plexus field requirement, which addressed the NPE variant on Maven 3.9.12 — but did not declare the method, so the Develocity path stayed broken.
- This PR bumps `maven-core` build dep from 3.8.6 to 3.9.12 so the override compiles cleanly, declares `checkPrerequisites` on the subclass (delegating to `super`), and adds a regression unit test that mirrors Develocity's exact reflective lookup.

## Failing stack trace this fixes (from a real CI log)
```
java.lang.NoSuchMethodException: org.jfrog.build.extractor.maven.resolver.ArtifactoryEclipsePluginManager.checkPrerequisites(org.apache.maven.plugin.descriptor.PluginDescriptor)
    at java.lang.Class.getDeclaredMethod (Class.java:2422)
    at com.gradle.maven.cache.extension.g.b.checkPrerequisites (SourceFile:117)
```

## Repro confirmed locally
Loading the master HEAD uber jar and running `Class.forName("…ArtifactoryEclipsePluginManager").getDeclaredMethod("checkPrerequisites", PluginDescriptor.class)` reproduces the exact same `NoSuchMethodException`. With this branch, the lookup returns the declared method and the exception goes away.

## Test plan
- [x] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] New `ArtifactoryEclipsePluginManagerTest.testCheckPrerequisitesIsDeclaredOnSubclass` mirrors Develocity's exact reflective contract — fails on master, passes here.
- [x] `./gradlew :build-info-extractor-maven3:compileJava :build-info-extractor-maven3:test` clean against JDK 11 + the bumped maven-core 3.9.12 build dep.
- [ ] Suggested follow-up (not in this PR): extend `.github/workflows/maven-compatibility-test.yml` to install Develocity's Maven extension in the test pom and fail on `NoSuchMethodException`, so this regression class is caught by the nightly job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)