### PR TITLE
Improve Maven compatibility test: add Develocity scenario, boundary versions 3.9.11/3.9.12, and PR branch extractor injection

### DIFF
--- a/.github/workflows/maven-compatibility-test.yml
+++ b/.github/workflows/maven-compatibility-test.yml
@@ -3,17 +3,29 @@ name: Maven Compatibility Test
 # This workflow proactively tests build-info-extractor-maven3 compatibility with multiple Maven versions
 # to catch breaking changes early (e.g., new required fields in DefaultMavenPluginManager).
 #
+# Two scenarios are tested for each Maven version:
+#   1. Plain JFrog CLI (no Develocity) — catches NPE / components.xml issues
+#   2. JFrog CLI + Develocity extension  — catches reflection-based issues (getDeclaredMethod)
+#
+# The workflow builds the extractor from the current branch and injects it into the
+# jf CLI dependency cache so the PR changes are tested, not the published release.
+#
 # When a compatibility issue is detected:
-# 1. Check error logs for NullPointerException, NoSuchMethodError, etc.
-# 2. Compare Maven's DefaultMavenPluginManager with our components.xml
-# 3. Add missing field declarations to components.xml
-# 4. See CHECK-MAVEN-FIELDS.sh for a helper script to identify missing fields
+# 1. Check error logs for NullPointerException, NoSuchMethodError, NoSuchMethodException etc.
+# 2. Compare Maven's DefaultMavenPluginManager with our ArtifactoryEclipsePluginManager
+# 3. Add missing overrides or field declarations as needed
 
 on:
   # Run nightly to catch new Maven releases
   schedule:
     - cron: '0 2 * * *'  # Every night at 2 AM UTC
-  
+
+  # Run on PRs that touch the maven3 extractor
+  pull_request:
+    paths:
+      - 'build-info-extractor-maven3/**'
+      - 'build.gradle'
+
   # Allow manual trigger for testing
   workflow_dispatch:
 
@@ -23,93 +35,120 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       maven-versions: ${{ steps.set-versions.outputs.maven-versions }}
-    
+
     steps:
       - name: Get latest Maven versions from Maven Central
         id: maven-versions
         run: |
           echo "Fetching latest Maven versions from Maven Central..."
-          
+
           # Fetch Maven metadata
           curl -s https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/maven-metadata.xml > maven-metadata.xml
-          
+
           # Extract all stable versions (exclude alpha/beta/RC)
           VERSIONS=$(grep -oP '(?<=<version>)[^<]+' maven-metadata.xml | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
-          
+
           echo "Available Maven versions:"
           echo "$VERSIONS"
-          
+
           # Get latest versions for each major.minor series
           LATEST_3_8=$(echo "$VERSIONS" | grep '^3\.8\.' | tail -1)
           LATEST_3_9=$(echo "$VERSIONS" | grep '^3\.9\.' | tail -1)
           LATEST_4_0=$(echo "$VERSIONS" | grep '^4\.0\.' | tail -1)
-          
+
           echo ""
           echo "Latest versions by series:"
           echo "  3.8.x: $LATEST_3_8"
           echo "  3.9.x: $LATEST_3_9"
           echo "  4.0.x: ${LATEST_4_0:-not released yet}"
-          
-          # Export for next step
+
           echo "LATEST_3_8=$LATEST_3_8" >> $GITHUB_ENV
           echo "LATEST_3_9=$LATEST_3_9" >> $GITHUB_ENV
           echo "LATEST_4_0=$LATEST_4_0" >> $GITHUB_ENV
-      
+
       - name: Build version matrix
         id: set-versions
         run: |
-          # Build JSON array of versions to test
-          # Include: first 3.9, some mid versions, and all latest versions
-          
-          VERSIONS='["3.9.0"'  # First 3.9.x
-          
+          # Fixed boundary versions around the checkPrerequisites change:
+          #   3.9.11 = last version WITHOUT checkPrerequisites on DefaultMavenPluginManager
+          #   3.9.12 = first version WITH  checkPrerequisites on DefaultMavenPluginManager
+          # These must always be tested regardless of what the "latest" is.
+          VERSIONS='["3.9.0", "3.9.11", "3.9.12"'
+
           # Add latest 3.8.x
           if [ -n "$LATEST_3_8" ]; then
             VERSIONS+=', "'$LATEST_3_8'"'
           fi
-          
-          # Add latest 3.9.x
-          if [ -n "$LATEST_3_9" ]; then
+
+          # Add latest 3.9.x (skip if it is already one of the fixed versions above)
+          if [ -n "$LATEST_3_9" ] && [ "$LATEST_3_9" != "3.9.11" ] && [ "$LATEST_3_9" != "3.9.12" ]; then
             VERSIONS+=', "'$LATEST_3_9'"'
           fi
-          
-          # Add latest 4.0.x if it exists
+
+          # Add latest 4.0.x if released
           if [ -n "$LATEST_4_0" ]; then
             VERSIONS+=', "'$LATEST_4_0'"'
-          else
-            # Fallback to beta if no stable 4.0 yet
-            VERSIONS+=', "4.0.0-beta-4"'
           fi
-          
+
           VERSIONS+=']'
-          
+
           echo "Maven versions to test: $VERSIONS"
           echo "maven-versions=$VERSIONS" >> $GITHUB_OUTPUT
 
-  test-maven-compatibility:
-    name: Test with Maven ${{ matrix.maven-version }}
+  build-extractor:
+    name: Build extractor from source
     runs-on: ubuntu-latest
-    needs: check-latest-maven-versions
-    
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11 for build
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Build uber-jar from source
+        run: ./gradlew :build-info-extractor-maven3:uberJar --no-daemon
+
+      - name: Locate built jar and capture version
+        id: jar-info
+        run: |
+          JAR=$(find build-info-extractor-maven3/build/libs -name "*-uber.jar" | head -1)
+          echo "Built jar: $JAR"
+          echo "jar-path=$JAR" >> $GITHUB_OUTPUT
+
+      - name: Upload uber-jar as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extractor-uber-jar
+          path: ${{ steps.jar-info.outputs.jar-path }}
+          retention-days: 1
+
+  test-maven-compatibility:
+    name: Maven ${{ matrix.maven-version }} / Java ${{ matrix.java-version }} / ${{ matrix.develocity && 'with Develocity' || 'plain' }}
+    runs-on: ubuntu-latest
+    needs: [check-latest-maven-versions, build-extractor]
+
     strategy:
-      fail-fast: false  # Test all versions even if one fails
+      fail-fast: false
       matrix:
-        # Dynamically fetched versions from previous job
         maven-version: ${{ fromJSON(needs.check-latest-maven-versions.outputs.maven-versions) }}
         java-version:
-          - '8'
           - '11'
           - '17'
           - '21'
+        develocity:
+          - false
+          - true
         exclude:
           # Maven 4 requires Java 17+
-          - maven-version: '4.0.0-beta-4'
-            java-version: '8'
-          - maven-version: '4.0.0-beta-4'
+          - maven-version: '3.9.0'
             java-version: '11'
 
     steps:
-      - name: Set up test JDK ${{ matrix.java-version }}
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -121,9 +160,7 @@ jobs:
           maven-version: ${{ matrix.maven-version }}
 
       - name: Verify Maven version
-        run: |
-          mvn --version
-          echo "M2_HOME=$M2_HOME"
+        run: mvn --version
 
       - name: Set up JFrog CLI
         uses: jfrog/setup-jfrog-cli@v4
@@ -133,181 +170,171 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.PLATFORM_ADMIN_TOKEN }}
         with:
           version: latest
-        # JFrog CLI will automatically download the latest released build-info extractor
-        # This tests the version users actually use in production
 
-      - name: Create test Maven project
+      - name: Download built extractor jar
+        uses: actions/download-artifact@v4
+        with:
+          name: extractor-uber-jar
+          path: /tmp/extractor
+
+      - name: Inject built extractor into jf CLI dependency cache
         run: |
-          # Create project structure in testdata/ (excluded from builds like Go testdata/)
-          mkdir -p ${{ github.workspace }}/testdata/maven-compatibility-test/src/main/java/com/test
-          cd ${{ github.workspace }}/testdata/maven-compatibility-test
-          
-          cat > pom.xml << 'EOF'
+          # Trigger jf to download the published extractor + classworlds.conf
+          # (we only need classworlds.conf from this; we replace the jar below)
+          jf config add dummy-server \
+            --url=http://localhost:8081/artifactory \
+            --access-token=dummy \
+            --interactive=false --overwrite=true || true
+
+          mkdir -p /tmp/dummy-project/.jfrog/projects
+          cat > /tmp/dummy-project/.jfrog/projects/maven.yaml << 'EOF'
+          version: 1
+          type: maven
+          resolver:
+            serverID: dummy-server
+            releaseRepo: libs-release
+            snapshotRepo: libs-snapshot
+          deployer:
+            serverID: dummy-server
+            releaseRepo: libs-release
+            snapshotRepo: libs-snapshot
+          EOF
+
+          mkdir -p /tmp/dummy-project
+          cat > /tmp/dummy-project/pom.xml << 'EOF'
           <?xml version="1.0" encoding="UTF-8"?>
           <project xmlns="http://maven.apache.org/POM/4.0.0"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
-                   http://maven.apache.org/xsd/maven-4.0.0.xsd">
-              <modelVersion>4.0.0</modelVersion>
-              
-              <groupId>com.jfrog.test</groupId>
-              <artifactId>maven-compatibility-test</artifactId>
-              <version>1.0.0-SNAPSHOT</version>
-              <packaging>jar</packaging>
-              
-              <properties>
-                  <maven.compiler.source>8</maven.compiler.source>
-                  <maven.compiler.target>8</maven.compiler.target>
-                  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-              </properties>
-              
-              <!-- Use Maven Central as fallback to ensure plugins can be downloaded -->
-              <repositories>
-                  <repository>
-                      <id>central</id>
-                      <url>https://repo.maven.apache.org/maven2</url>
-                      <releases><enabled>true</enabled></releases>
-                  </repository>
-              </repositories>
-              
-              <pluginRepositories>
-                  <pluginRepository>
-                      <id>central</id>
-                      <url>https://repo.maven.apache.org/maven2</url>
-                      <releases><enabled>true</enabled></releases>
-                  </pluginRepository>
-              </pluginRepositories>
-              
-              <dependencies>
-                  <dependency>
-                      <groupId>org.apache.commons</groupId>
-                      <artifactId>commons-lang3</artifactId>
-                      <version>3.14.0</version>
-                  </dependency>
-              </dependencies>
+                   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>dummy</groupId>
+            <artifactId>dummy</artifactId>
+            <version>1.0</version>
           </project>
           EOF
-          
-          cat > src/main/java/com/test/App.java << 'EOF'
+
+          cd /tmp/dummy-project
+          jf mvn --version 2>/dev/null || true  # triggers extractor download, ignore build failure
+
+          # Find the downloaded extractor directory
+          EXTRACTOR_DIR=$(find ~/.jfrog/dependencies/maven -maxdepth 1 -mindepth 1 -type d | head -1)
+          EXTRACTOR_VERSION=$(basename "$EXTRACTOR_DIR")
+          echo "Extractor version expected by jf CLI: $EXTRACTOR_VERSION"
+          echo "EXTRACTOR_VERSION=$EXTRACTOR_VERSION" >> $GITHUB_ENV
+          echo "EXTRACTOR_DIR=$EXTRACTOR_DIR" >> $GITHUB_ENV
+
+          # Replace the published jar with our built jar
+          rm -f "$EXTRACTOR_DIR"/build-info-extractor-maven3-*.jar
+          BUILT_JAR=$(find /tmp/extractor -name "*-uber.jar" | head -1)
+          cp "$BUILT_JAR" "$EXTRACTOR_DIR/build-info-extractor-maven3-${EXTRACTOR_VERSION}-uber.jar"
+
+          echo "Injected: $(ls -lh $EXTRACTOR_DIR)"
+
+      - name: Create test Maven project
+        run: |
+          mkdir -p /tmp/test-project/src/main/java/com/test
+          mkdir -p /tmp/test-project/.jfrog/projects
+
+          cat > /tmp/test-project/pom.xml << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <project xmlns="http://maven.apache.org/POM/4.0.0"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>com.jfrog.test</groupId>
+            <artifactId>maven-compat-test</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <properties>
+              <maven.compiler.source>11</maven.compiler.source>
+              <maven.compiler.target>11</maven.compiler.target>
+            </properties>
+          </project>
+          EOF
+
+          cat > /tmp/test-project/src/main/java/com/test/App.java << 'EOF'
           package com.test;
-          
-          import org.apache.commons.lang3.StringUtils;
-          
           public class App {
               public static void main(String[] args) {
-                  System.out.println("Maven version test: " + 
-                      StringUtils.capitalize("success"));
+                  System.out.println("ok");
               }
           }
           EOF
-          
-          # Verify project was created
-          echo ""
-          echo "Test project structure:"
-          ls -la ${{ github.workspace }}/testdata/maven-compatibility-test/
-          echo ""
-          echo "✅ Test project created successfully"
 
-      - name: Configure Maven with JFrog
-        working-directory: ${{ github.workspace }}/testdata/maven-compatibility-test
-        env:
-          PLATFORM_URL: ${{ secrets.PLATFORM_URL }}
+          cat > /tmp/test-project/.jfrog/projects/maven.yaml << 'EOF'
+          version: 1
+          type: maven
+          resolver:
+            serverID: setup-jfrog-cli-server
+            releaseRepo: maven-virtual
+            snapshotRepo: maven-virtual
+          deployer:
+            serverID: setup-jfrog-cli-server
+            releaseRepo: maven-local
+            snapshotRepo: maven-local
+          EOF
+
+      - name: Add Develocity extension
+        if: ${{ matrix.develocity }}
         run: |
-          echo "Configuring Maven for JFrog CLI..."
-          
-          # Ensure we have a valid server config (required by jf mvn)
-          if [ -z "$PLATFORM_URL" ]; then
-            echo "⚠️  No Artifactory secrets - creating dummy server for testing"
-            jf config add test-server \
-              --url=http://localhost:8081/artifactory \
-              --access-token=dummy \
-              --interactive=false --overwrite=true
-            SERVER_ID="test-server"
-          else
-            echo "✅ Using real Artifactory from secrets"
-            SERVER_ID="setup-jfrog-cli-server"
-          fi
-          
-          # Create Maven config (required by jf mvn, even for compatibility testing)
-          # Configure deployment only to avoid overriding resolution (Maven Central stays default)
-          jf mvn-config \
-            --server-id-deploy=$SERVER_ID \
-            --repo-deploy-releases=maven-local \
-            --repo-deploy-snapshots=maven-local
-          
-          echo "✅ Maven config created"
-          echo "Note: Resolution NOT configured - Maven will use Maven Central from pom.xml"
+          mkdir -p /tmp/test-project/.mvn
+          cat > /tmp/test-project/.mvn/extensions.xml << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <extensions>
+            <extension>
+              <groupId>com.gradle</groupId>
+              <artifactId>develocity-maven-extension</artifactId>
+              <version>2.4.0</version>
+            </extension>
+          </extensions>
+          EOF
+          echo "Develocity extension added"
 
-      - name: Test Maven with build-info extractor
+      - name: Run jf mvn
         id: maven_test
-        working-directory: ${{ github.workspace }}/testdata/maven-compatibility-test
+        working-directory: /tmp/test-project
         run: |
-          set -o pipefail  # Ensure pipeline fails if jf mvn fails
-          
-          echo "Testing Maven ${{ matrix.maven-version }} with build-info extractor"
-          echo ""
-          
-          # Run jf mvn - this will:
-          # 1. Download the build-info extractor (if not cached)
-          # 2. Load it as a Maven extension  
-          # 3. If Maven incompatibility exists, NullPointerException happens immediately
-          # 4. Otherwise, will build successfully
-          jf mvn clean compile 2>&1 | tee maven-output.log
-          
-          echo ""
-          echo "Build complete - no compatibility issues detected!"
+          set -o pipefail
+          echo "=== Scenario: Maven ${{ matrix.maven-version }} / Java ${{ matrix.java-version }} / Develocity=${{ matrix.develocity }} ==="
+          jf mvn clean compile -B 2>&1 | tee maven-output.log
+          echo "✅ Build succeeded"
 
-      - name: Analyze build failure (if any)
+      - name: Analyze failure
         if: failure()
-        continue-on-error: true
-        working-directory: ${{ github.workspace }}/testdata/maven-compatibility-test
+        working-directory: /tmp/test-project
         run: |
-          echo "============================================"
+          echo "=========================================="
           echo "Build Failure Analysis"
-          echo "============================================"
-          echo ""
-          
-          if [ ! -f maven-output.log ]; then
-            echo "❌ No maven-output.log found - build may have failed before Maven ran"
-            exit 0
-          fi
-          
-          echo "Checking for compatibility errors..."
-          echo ""
-          
-          # Check for Maven version compatibility issues
-          if grep -q "NullPointerException" maven-output.log; then
-            echo "❌ COMPATIBILITY ERROR: NullPointerException detected!"
-            echo ""
-            echo "Maven ${{ matrix.maven-version }} is INCOMPATIBLE with build-info extractor"
-            echo "This likely indicates missing field declarations in components.xml"
-            echo ""
-            echo "Error context:"
-            grep -B5 -A10 "NullPointerException" maven-output.log | head -30
-            
+          echo "Maven: ${{ matrix.maven-version }} | Java: ${{ matrix.java-version }} | Develocity: ${{ matrix.develocity }}"
+          echo "=========================================="
+
+          if grep -q "NoSuchMethodException.*checkPrerequisites" maven-output.log; then
+            echo "❌ Develocity reflection issue: getDeclaredMethod could not find checkPrerequisites"
+            echo "   Fix: add explicit @Override of checkPrerequisites in ArtifactoryEclipsePluginManager"
+            grep -A5 "NoSuchMethodException" maven-output.log | head -20
+
+          elif grep -q "NoSuchMethodError.*checkPrerequisites" maven-output.log; then
+            echo "❌ Runtime NoSuchMethodError: super.checkPrerequisites() called on Maven < 3.9.12"
+            echo "   Fix: guard the super call so it is only invoked when the parent method exists"
+            grep -A5 "NoSuchMethodError" maven-output.log | head -20
+
+          elif grep -q "NullPointerException.*prerequisitesCheckers" maven-output.log; then
+            echo "❌ NPE: prerequisitesCheckers is null — missing Plexus requirement in components.xml"
+            grep -A5 "NullPointerException" maven-output.log | head -20
+
           elif grep -q "NoSuchMethodError\|NoClassDefFoundError\|IncompatibleClassChangeError" maven-output.log; then
-            echo "❌ COMPATIBILITY ERROR: Class/method compatibility issue!"
-            echo ""
-            echo "Error context:"
-            grep -B5 -A10 "NoSuchMethodError\|NoClassDefFoundError\|IncompatibleClassChangeError" maven-output.log | head -30
-            
+            echo "❌ Class/method compatibility error"
+            grep -A5 "NoSuchMethodError\|NoClassDefFoundError\|IncompatibleClassChangeError" maven-output.log | head -20
+
           else
-            echo "ℹ️  No obvious Maven compatibility errors detected"
-            echo ""
-            echo "Last 50 lines of output:"
+            echo "ℹ️  Unknown failure — last 50 lines:"
             tail -50 maven-output.log
           fi
-          
-          echo ""
-          echo "Full logs available in artifacts"
 
-      - name: Upload logs (on failure)
+      - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failure-logs-maven-${{ matrix.maven-version }}-java-${{ matrix.java-version }}
-          path: |
-            ${{ github.workspace }}/test-project/maven-output.log
-            ${{ github.workspace }}/test-project/config-output.log
-          retention-days: 30
+          name: failure-logs-maven${{ matrix.maven-version }}-java${{ matrix.java-version }}-develocity${{ matrix.develocity }}
+          path: /tmp/test-project/maven-output.log
+          retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Add `3.9.11` and `3.9.12` as fixed boundary versions (3.9.11 = last without `checkPrerequisites`, 3.9.12 = first with it)
- Add Develocity as a matrix dimension to catch `getDeclaredMethod` reflection failures (issue #841 variant 2)
- Add checkout + build step so the PR branch extractor is tested, not the published release
- Trigger workflow on PRs touching `build-info-extractor-maven3/**` or `build.gradle`
- Improve failure analysis to identify specific error type with actionable fix hints
---
- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----
