### PR TITLE
Fix comments that had issue with JavaDocs

### DIFF
--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java
@@ -108,7 +108,7 @@ public final class WslUtils {
 
     /**
      * Extracts the WSL distribution name from a WSL UNC path.
-     * Example: {@code "\\wsl.localhost\Ubuntu\home\\user"} → {@code "Ubuntu"}.
+     * Example: {@code "\\wsl.localhost\Ubuntu\home\\user"} -> {@code "Ubuntu"}.
      *
      * @return the distribution name, or {@code null} if the path is not a WSL UNC path.
      */
@@ -126,7 +126,7 @@ public final class WslUtils {
 
     /**
      * Converts a Linux absolute path back to a Windows WSL UNC path using a known distribution.
-     * Example: {@code "/home/user/project"} + {@code "Ubuntu"} → {@code \\wsl.localhost\\Ubuntu\\home\\user\\project}.
+     * Example: {@code "/home/user/project"} + {@code "Ubuntu"} -> {@code \\wsl.localhost\\Ubuntu\\home\\user\\project}.
      */
     public static String linuxPathToWslWindowsPath(String linuxPath, String distro) {
         return WSL_LOCALHOST_PREFIX + distro + linuxPath.replace('/', '\\');
@@ -134,7 +134,7 @@ public final class WslUtils {
 
     /**
      * Linux path suitable for {@code wsl.exe --cd} for the given working directory.
-     * WSL UNC → {@link #toLinuxPath}; Windows drive path → {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
+     * WSL UNC -> {@link #toLinuxPath}; Windows drive path -> {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
      */
     public static String toWslLinuxCdPath(File workingDirectory) {
         if (workingDirectory == null) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/build-info/actions/workflows/integrationTests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
-----

fixing the following:

```
> Task :build-info-extractor:javadoc FAILED
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:111: error: unmappable character for encoding ASCII
     * Example: {@code "\\wsl.localhost\Ubuntu\home\\user"} ??? {@code "Ubuntu"}.
                                                            ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:111: error: unmappable character for encoding ASCII
     * Example: {@code "\\wsl.localhost\Ubuntu\home\\user"} ??? {@code "Ubuntu"}.
                                                             ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:111: error: unmappable character for encoding ASCII
     * Example: {@code "\\wsl.localhost\Ubuntu\home\\user"} ??? {@code "Ubuntu"}.
                                                              ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:129: error: unmappable character for encoding ASCII
     * Example: {@code "/home/user/project"} + {@code "Ubuntu"} ??? {@code \\wsl.localhost\\Ubuntu\\home\\user\\project}.
                                                                ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:129: error: unmappable character for encoding ASCII
     * Example: {@code "/home/user/project"} + {@code "Ubuntu"} ??? {@code \\wsl.localhost\\Ubuntu\\home\\user\\project}.
                                                                 ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:129: error: unmappable character for encoding ASCII
     * Example: {@code "/home/user/project"} + {@code "Ubuntu"} ??? {@code \\wsl.localhost\\Ubuntu\\home\\user\\project}.
                                                                  ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:137: error: unmappable character for encoding ASCII
     * WSL UNC ??? {@link #toLinuxPath}; Windows drive path ??? {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
               ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:137: error: unmappable character for encoding ASCII
     * WSL UNC ??? {@link #toLinuxPath}; Windows drive path ??? {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
                ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:137: error: unmappable character for encoding ASCII
     * WSL UNC ??? {@link #toLinuxPath}; Windows drive path ??? {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
                 ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:137: error: unmappable character for encoding ASCII
     * WSL UNC ??? {@link #toLinuxPath}; Windows drive path ??? {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
                                                            ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:137: error: unmappable character for encoding ASCII
     * WSL UNC ??? {@link #toLinuxPath}; Windows drive path ??? {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
                                                             ^
/var/opt/jfrog/pipelines/data/release_build_info/runs/6554578/steps/Release/47989156/dependencyState/resources/biReleaseGit/build-info-extractor/src/main/java/org/jfrog/build/extractor/WslUtils.java:137: error: unmappable character for encoding ASCII
     * WSL UNC ??? {@link #toLinuxPath}; Windows drive path ??? {@link #windowsLocalPathToWslMount}; otherwise forward slashes.
```