### PR TITLE
RTECO-1424: Default to Maven Unique Snapshot Timestamp in the Extractor Flow

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/BuildInfoRecorder.java
@@ -62,6 +62,11 @@ import static org.jfrog.build.extractor.clientConfiguration.ClientConfigurationF
 @Component(role = BuildInfoRecorder.class)
 public class BuildInfoRecorder extends AbstractExecutionListener implements BuildInfoExtractor<ExecutionEvent> {
 
+    /**
+     * maven-deploy-plugin's own flag for choosing between unique and non-unique snapshots.
+     */
+    private static final String UNIQUE_VERSION_USER_PROPERTY = "uniqueVersion";
+
     @Requirement
     private BuildInfoModelPropertyResolver buildInfoModelPropertyResolver;
 
@@ -70,6 +75,9 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
 
     @Requirement
     private ResolutionHelper resolutionHelper;
+
+    @Requirement
+    private SnapshotVersionResolver snapshotVersionResolver;
 
     @Requirement
     private Logger logger;
@@ -141,6 +149,7 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             buildInfoBuilder = buildInfoModelPropertyResolver.resolveProperties(event, conf);
             deployableArtifactBuilderMap = new ConcurrentHashMap<>();
             setDeploymentPolicy(event);
+            setSnapshotVersionPolicy(event);
 
             if (wrappedListener != null) {
                 wrappedListener.sessionStarted(event);
@@ -511,15 +520,16 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             }
 
             if (artifactFile != null && artifactFile.isFile()) {
-                String artifactName = getArtifactName(artifactId, artifactVersion, artifactClassifier, artifactExtension);
+                String deployedVersion = snapshotVersionResolver.getDeployedVersion(groupId, artifactId, artifactVersion);
+                String artifactName = getArtifactName(artifactId, deployedVersion, artifactClassifier, artifactExtension);
                 org.jfrog.build.extractor.ci.Artifact artifact = new ArtifactBuilder(artifactName)
                         .remotePath(getRemotePath(groupId, artifactId, artifactVersion))
                         .type(type).build();
-                String deploymentPath = getDeploymentPath(groupId, artifactId, artifactVersion, artifactClassifier, artifactExtension);
+                String deploymentPath = getDeploymentPath(groupId, artifactId, artifactVersion, deployedVersion, artifactClassifier, artifactExtension);
                 boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
                 addArtifactToBuildInfo(artifact, pathConflicts, excludeArtifactsFromBuild, module);
                 if (conf.publisher.shouldAddDeployableArtifacts()) {
-                    addDeployableArtifact(artifact, artifactFile, pathConflicts, groupId, artifactId, artifactVersion, artifactClassifier, artifactExtension);
+                    addDeployableArtifact(artifact, artifactFile, pathConflicts, groupId, artifactId, artifactVersion, deployedVersion, artifactClassifier, artifactExtension);
                 }
             }
         }
@@ -537,17 +547,19 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             return;
         }
         Artifact projectArtifact = project.getArtifact();
-        String artifactName = getArtifactName(projectArtifact.getArtifactId(), projectArtifact.getBaseVersion(), projectArtifact.getClassifier(), "pom");
+        String baseVersion = projectArtifact.getBaseVersion();
+        String deployedVersion = snapshotVersionResolver.getDeployedVersion(projectArtifact.getGroupId(), projectArtifact.getArtifactId(), baseVersion);
+        String artifactName = getArtifactName(projectArtifact.getArtifactId(), deployedVersion, projectArtifact.getClassifier(), "pom");
         org.jfrog.build.extractor.ci.Artifact pomArtifact = new ArtifactBuilder(artifactName)
-                .remotePath(getRemotePath(projectArtifact.getGroupId(), projectArtifact.getArtifactId(), projectArtifact.getBaseVersion()))
+                .remotePath(getRemotePath(projectArtifact.getGroupId(), projectArtifact.getArtifactId(), baseVersion))
                 .type("pom")
                 .build();
 
-        String deploymentPath = getDeploymentPath(projectArtifact.getGroupId(), projectArtifact.getArtifactId(), projectArtifact.getVersion(), projectArtifact.getClassifier(), "pom");
+        String deploymentPath = getDeploymentPath(projectArtifact.getGroupId(), projectArtifact.getArtifactId(), baseVersion, deployedVersion, projectArtifact.getClassifier(), "pom");
         boolean pathConflicts = PatternMatcher.pathConflicts(deploymentPath, patterns);
         addArtifactToBuildInfo(pomArtifact, pathConflicts, excludeArtifactsFromBuild, module);
         if (conf.publisher.shouldAddDeployableArtifacts()) {
-            addDeployableArtifact(pomArtifact, pomFile, pathConflicts, projectArtifact.getGroupId(), projectArtifact.getArtifactId(), projectArtifact.getVersion(), projectArtifact.getClassifier(), "pom");
+            addDeployableArtifact(pomArtifact, pomFile, pathConflicts, projectArtifact.getGroupId(), projectArtifact.getArtifactId(), baseVersion, deployedVersion, projectArtifact.getClassifier(), "pom");
         }
     }
 
@@ -573,12 +585,13 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
     }
 
     private void addDeployableArtifact(org.jfrog.build.extractor.ci.Artifact artifact, File artifactFile, boolean pathConflicts,
-                                       String groupId, String artifactId, String version, String classifier, String fileExtension) {
+                                       String groupId, String artifactId, String version, String deployedVersion,
+                                       String classifier, String fileExtension) {
         if (pathConflicts) {
             logger.info("'" + artifact.getName() + "' will not be deployed due to the defined include-exclude patterns.");
             return;
         }
-        String deploymentPath = getDeploymentPath(groupId, artifactId, version, classifier, fileExtension);
+        String deploymentPath = getDeploymentPath(groupId, artifactId, version, deployedVersion, classifier, fileExtension);
         // deploy to snapshots or releases repository based on the deploy version
         String targetRepository = getTargetRepository(deploymentPath);
 
@@ -609,9 +622,14 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
         return groupId.replace(".", "/") + "/" + artifactId + "/" + version;
     }
 
-    private String getDeploymentPath(String groupId, String artifactId, String version, String classifier,
-                                     String fileExtension) {
-        return getRemotePath(groupId, artifactId, version) + "/" + getArtifactName(artifactId, version, classifier, fileExtension);
+    /**
+     * Maven's layout keeps unique snapshots in the directory of their -SNAPSHOT version, so only the file name
+     * carries the timestamped version. The directory is what {@link #getTargetRepository} reads to route
+     * snapshots to the snapshot repository.
+     */
+    private String getDeploymentPath(String groupId, String artifactId, String version, String deployedVersion,
+                                     String classifier, String fileExtension) {
+        return getRemotePath(groupId, artifactId, version) + "/" + getArtifactName(artifactId, deployedVersion, classifier, fileExtension);
     }
 
     private void addDependenciesToCurrentModule(ModuleBuilder module) {
@@ -736,5 +754,22 @@ public class BuildInfoRecorder extends AbstractExecutionListener implements Buil
             conf.publisher.setLegacyBooleanValue(PUBLISH_ARTIFACTS, false);
             conf.publisher.setLegacyBooleanValue(PUBLISH_BUILD_INFO, false);
         }
+    }
+
+    /**
+     * Maven 3 knows only unique snapshots, and setDeploymentPolicy hands deployment to the extractor before
+     * maven-deploy-plugin gets to apply them, so the extractor defaults to unique snapshots too. Users opt out
+     * with the plugin's own -DuniqueVersion=false, or with the publisher configuration when there is no command
+     * line to put it on.
+     */
+    private void setSnapshotVersionPolicy(ExecutionEvent event) {
+        String uniqueVersion = event.getSession().getUserProperties().getProperty(UNIQUE_VERSION_USER_PROPERTY);
+        boolean uniqueSnapshots = StringUtils.isNotBlank(uniqueVersion)
+                ? Boolean.parseBoolean(uniqueVersion)
+                : conf.publisher.isUniqueSnapshots();
+        if (!uniqueSnapshots) {
+            logger.info("Artifactory Build Info Recorder: unique snapshots are disabled, snapshots will be deployed without a timestamp.");
+        }
+        snapshotVersionResolver.newSession(conf, event.getSession().getRequest().getStartTime(), uniqueSnapshots);
     }
 }

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/SnapshotVersionResolver.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/SnapshotVersionResolver.java
@@ -1,0 +1,126 @@
+package org.jfrog.build.extractor.maven;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
+
+import java.io.FileNotFoundException;
+import java.io.StringReader;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Builds the unique snapshot versions - "1.0-20240101.101112-3" - that Maven 3 puts in deployed snapshot file
+ * names. The recorder takes deployment away from maven-deploy-plugin, which means the version transformation
+ * the plugin would normally apply never runs, so the extractor has to reproduce it here.
+ *
+ * @see BuildInfoRecorder
+ */
+@Component(role = SnapshotVersionResolver.class)
+public class SnapshotVersionResolver {
+
+    public static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+
+    private static final DateTimeFormatter TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyyMMdd.HHmmss").withZone(ZoneOffset.UTC);
+
+    @Requirement
+    private Logger logger;
+
+    @Requirement
+    private ArtifactoryManagerBuilder artifactoryManagerBuilder;
+
+    /**
+     * groupId:artifactId:baseVersion to unique version, so that every artifact of a module - the jar, the pom
+     * and any attached artifact - is deployed under one version.
+     */
+    private final Map<String, String> uniqueVersions = new ConcurrentHashMap<>();
+    private ArtifactoryClientConfiguration conf;
+    /**
+     * The whole session shares one timestamp, as maven-deploy-plugin does. Null turns unique snapshots off.
+     */
+    private String timestamp;
+    /**
+     * Turned off after the first time Artifactory could not be reached, so that an unreachable or misconfigured
+     * publisher costs one failed request per build rather than one per module.
+     */
+    private boolean metadataReadable;
+
+    public void newSession(ArtifactoryClientConfiguration conf, Date sessionStart, boolean uniqueSnapshots) {
+        this.conf = conf;
+        this.timestamp = uniqueSnapshots
+                ? TIMESTAMP_FORMAT.format((sessionStart == null ? new Date() : sessionStart).toInstant())
+                : null;
+        this.metadataReadable = uniqueSnapshots;
+        uniqueVersions.clear();
+    }
+
+    public static boolean isSnapshot(String version) {
+        return StringUtils.endsWith(version, SNAPSHOT_SUFFIX);
+    }
+
+    /**
+     * @return the version to write into the deployed file name. Snapshots get a timestamp and a build number
+     * appended in place of the -SNAPSHOT suffix; every other version is returned untouched.
+     */
+    public String getDeployedVersion(String groupId, String artifactId, String version) {
+        if (timestamp == null || !isSnapshot(version)) {
+            return version;
+        }
+        String key = groupId + ":" + artifactId + ":" + version;
+        String cached = uniqueVersions.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        String uniqueVersion = StringUtils.removeEnd(version, SNAPSHOT_SUFFIX) + "-" + timestamp + "-"
+                + resolveBuildNumber(groupId, artifactId, version);
+        String published = uniqueVersions.putIfAbsent(key, uniqueVersion);
+        return published == null ? uniqueVersion : published;
+    }
+
+    /**
+     * Maven derives the build number from the snapshot metadata already sitting in the repository. Metadata we
+     * cannot read means we cannot tell how many builds came before, and deploying as the first one keeps the
+     * timestamp - and with it the traceability the unique version exists for - intact.
+     */
+    private int resolveBuildNumber(String groupId, String artifactId, String baseVersion) {
+        if (!metadataReadable) {
+            return 1;
+        }
+        String repoKey = StringUtils.defaultIfBlank(conf.publisher.getSnapshotRepoKey(), conf.publisher.getRepoKey());
+        if (StringUtils.isBlank(repoKey)) {
+            return 1;
+        }
+        String metadataPath = repoKey + "/" + groupId.replace('.', '/') + "/" + artifactId + "/" + baseVersion
+                + "/maven-metadata.xml";
+        try (ArtifactoryManager artifactoryManager = artifactoryManagerBuilder.resolveProperties(conf)) {
+            String metadata = artifactoryManager.download(metadataPath).getContent();
+            return readBuildNumber(metadata) + 1;
+        } catch (FileNotFoundException e) {
+            // Nothing deployed under this version yet, which is the normal case for a first snapshot deployment.
+            logger.debug("Artifactory Build Info Recorder: no snapshot metadata at '" + metadataPath + "'.");
+        } catch (Exception e) {
+            metadataReadable = false;
+            logger.warn("Artifactory Build Info Recorder: failed reading snapshot metadata from '" + metadataPath
+                    + "', snapshots of this build will be deployed with build number 1: " + e.getMessage());
+        }
+        return 1;
+    }
+
+    private int readBuildNumber(String metadataXml) throws Exception {
+        Metadata metadata = new MetadataXpp3Reader().read(new StringReader(metadataXml), false);
+        Versioning versioning = metadata.getVersioning();
+        Snapshot snapshot = versioning == null ? null : versioning.getSnapshot();
+        return snapshot == null ? 0 : snapshot.getBuildNumber();
+    }
+}

--- a/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
+++ b/build-info-extractor-maven3/src/main/resources/META-INF/plexus/components.xml
@@ -375,6 +375,30 @@
                     <role-hint>default</role-hint>
                     <field-name>resolutionHelper</field-name>
                 </requirement>
+                <requirement>
+                    <role>org.jfrog.build.extractor.maven.SnapshotVersionResolver</role>
+                    <role-hint>default</role-hint>
+                    <field-name>snapshotVersionResolver</field-name>
+                </requirement>
+            </requirements>
+        </component>
+        <!-- A class that names deployed snapshots the way Maven 3 does, with a timestamp and a build number -->
+        <component>
+            <role>org.jfrog.build.extractor.maven.SnapshotVersionResolver</role>
+            <implementation>org.jfrog.build.extractor.maven.SnapshotVersionResolver</implementation>
+            <role-hint>default</role-hint>
+            <isolated-realm>false</isolated-realm>
+            <requirements>
+                <requirement>
+                    <role>org.codehaus.plexus.logging.Logger</role>
+                    <role-hint>default</role-hint>
+                    <field-name>logger</field-name>
+                </requirement>
+                <requirement>
+                    <role>org.jfrog.build.extractor.maven.ArtifactoryManagerBuilder</role>
+                    <role-hint>default</role-hint>
+                    <field-name>artifactoryManagerBuilder</field-name>
+                </requirement>
             </requirements>
         </component>
         <component>

--- a/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/SnapshotVersionResolverTest.java
+++ b/build-info-extractor-maven3/src/test/java/org/jfrog/build/extractor/maven/SnapshotVersionResolverTest.java
@@ -1,0 +1,153 @@
+package org.jfrog.build.extractor.maven;
+
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.easymock.EasyMock;
+import org.jfrog.build.api.util.NullLog;
+import org.jfrog.build.client.DownloadResponse;
+import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfiguration;
+import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.FileNotFoundException;
+import java.lang.reflect.Field;
+import java.util.Date;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author naveenku
+ */
+public class SnapshotVersionResolverTest {
+
+    private static final String GROUP_ID = "org.example";
+    private static final String ARTIFACT_ID = "my-app";
+    private static final String SNAPSHOT_VERSION = "1.0-SNAPSHOT";
+    private static final String SNAPSHOT_REPO = "libs-snapshot-local";
+    // new Date(0) is 1970-01-01T00:00:00Z, so the session timestamp is deterministic.
+    private static final Date EPOCH = new Date(0);
+    private static final String EPOCH_TIMESTAMP = "19700101.000000";
+    private static final String EXPECTED_METADATA_PATH =
+            SNAPSHOT_REPO + "/org/example/my-app/1.0-SNAPSHOT/maven-metadata.xml";
+
+    private SnapshotVersionResolver resolver;
+    private ArtifactoryManagerBuilder managerBuilder;
+    private ArtifactoryManager artifactoryManager;
+    private ArtifactoryClientConfiguration conf;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        resolver = new SnapshotVersionResolver();
+        managerBuilder = EasyMock.createMock(ArtifactoryManagerBuilder.class);
+        artifactoryManager = EasyMock.createMock(ArtifactoryManager.class);
+        inject(resolver, "logger", new ConsoleLogger(ConsoleLogger.LEVEL_DISABLED, "test"));
+        inject(resolver, "artifactoryManagerBuilder", managerBuilder);
+
+        conf = new ArtifactoryClientConfiguration(new NullLog());
+        conf.publisher.setSnapshotRepoKey(SNAPSHOT_REPO);
+    }
+
+    @Test
+    public void isSnapshotTest() {
+        assertTrue(SnapshotVersionResolver.isSnapshot("1.0-SNAPSHOT"));
+        assertFalse(SnapshotVersionResolver.isSnapshot("1.0"));
+        assertFalse(SnapshotVersionResolver.isSnapshot(null));
+    }
+
+    /**
+     * Releases are never rewritten, and no metadata lookup is made for them.
+     */
+    @Test
+    public void releaseVersionUnchangedTest() {
+        EasyMock.replay(managerBuilder, artifactoryManager);
+        resolver.newSession(conf, EPOCH, true);
+        assertEquals(resolver.getDeployedVersion(GROUP_ID, ARTIFACT_ID, "1.0"), "1.0");
+        EasyMock.verify(managerBuilder, artifactoryManager);
+    }
+
+    /**
+     * -DuniqueVersion=false is honored: the snapshot keeps its -SNAPSHOT name and nothing is looked up.
+     */
+    @Test
+    public void uniqueSnapshotsDisabledTest() {
+        EasyMock.replay(managerBuilder, artifactoryManager);
+        resolver.newSession(conf, EPOCH, false);
+        assertEquals(resolver.getDeployedVersion(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION), SNAPSHOT_VERSION);
+        EasyMock.verify(managerBuilder, artifactoryManager);
+    }
+
+    /**
+     * A first snapshot deployment - no metadata yet - is deployed as build number 1.
+     */
+    @Test
+    public void firstSnapshotDeploymentTest() throws Exception {
+        expectMetadataDownload();
+        EasyMock.expect(artifactoryManager.download(EXPECTED_METADATA_PATH)).andThrow(new FileNotFoundException());
+        EasyMock.replay(managerBuilder, artifactoryManager);
+
+        resolver.newSession(conf, EPOCH, true);
+        assertEquals(resolver.getDeployedVersion(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION),
+                "1.0-" + EPOCH_TIMESTAMP + "-1");
+        EasyMock.verify(managerBuilder, artifactoryManager);
+    }
+
+    /**
+     * The build number is derived from the snapshot metadata already in the repository.
+     */
+    @Test
+    public void buildNumberFromMetadataTest() throws Exception {
+        expectMetadataDownload();
+        EasyMock.expect(artifactoryManager.download(EXPECTED_METADATA_PATH))
+                .andReturn(new DownloadResponse(snapshotMetadata(4), null));
+        EasyMock.replay(managerBuilder, artifactoryManager);
+
+        resolver.newSession(conf, EPOCH, true);
+        assertEquals(resolver.getDeployedVersion(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION),
+                "1.0-" + EPOCH_TIMESTAMP + "-5");
+        EasyMock.verify(managerBuilder, artifactoryManager);
+    }
+
+    /**
+     * Every artifact of a module - jar, pom, sources - must share one unique version, so the metadata is read
+     * only once per group:artifact:version and the result is reused.
+     */
+    @Test
+    public void sameVersionForRepeatedGavTest() throws Exception {
+        expectMetadataDownload();
+        EasyMock.expect(artifactoryManager.download(EXPECTED_METADATA_PATH)).andThrow(new FileNotFoundException());
+        EasyMock.replay(managerBuilder, artifactoryManager);
+
+        resolver.newSession(conf, EPOCH, true);
+        String first = resolver.getDeployedVersion(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION);
+        String second = resolver.getDeployedVersion(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION);
+        assertEquals(second, first);
+        // download expected exactly once - verify() fails if it was called again.
+        EasyMock.verify(managerBuilder, artifactoryManager);
+    }
+
+    private void expectMetadataDownload() {
+        EasyMock.expect(managerBuilder.resolveProperties(conf)).andReturn(artifactoryManager);
+        artifactoryManager.close();
+        EasyMock.expectLastCall();
+    }
+
+    private static String snapshotMetadata(int buildNumber) {
+        return "<metadata>"
+                + "<groupId>" + GROUP_ID + "</groupId>"
+                + "<artifactId>" + ARTIFACT_ID + "</artifactId>"
+                + "<version>" + SNAPSHOT_VERSION + "</version>"
+                + "<versioning><snapshot>"
+                + "<timestamp>20240101.101112</timestamp>"
+                + "<buildNumber>" + buildNumber + "</buildNumber>"
+                + "</snapshot><lastUpdated>20240101101112</lastUpdated></versioning>"
+                + "</metadata>";
+    }
+
+    private static void inject(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ArtifactoryClientConfiguration.java
@@ -379,6 +379,17 @@ public class ArtifactoryClientConfiguration {
             setStringValue(SNAPSHOT_REPO_KEY, repoKey);
         }
 
+        /**
+         * Maven 3 has no non-unique snapshots, so unique snapshots are the default here as well.
+         */
+        public Boolean isUniqueSnapshots() {
+            return getBooleanValue(UNIQUE_SNAPSHOTS, true);
+        }
+
+        public void setUniqueSnapshots(Boolean enabled) {
+            setBooleanValue(UNIQUE_SNAPSHOTS, enabled);
+        }
+
         public String getReleaseRepoKey() {
             return getStringValue(RELEASE_REPO_KEY);
         }

--- a/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
+++ b/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/ClientConfigurationFields.java
@@ -39,6 +39,7 @@ public interface ClientConfigurationFields {
     String PUBLISH_FORK_COUNT = "forkCount";
     String RECORD_ALL_DEPENDENCIES = "record.all.dependencies";
     String SNAPSHOT_REPO_KEY = "snapshot.repoKey";
+    String UNIQUE_SNAPSHOTS = "snapshot.unique";
     String RELEASE_REPO_KEY = "release.repoKey";
     String MATRIX = "matrix";
     String ARTIFACT_SPECS = "artifactSpecs";


### PR DESCRIPTION
### Problem
`jf mvn deploy` runs through the Build Info Extractor, which sets `maven.deploy.skip=true` and uploads artifacts itself at session end. Because `maven-deploy-plugin` never runs, its snapshot-version transformation never fires — so SNAPSHOT artifacts were deployed under the non-unique base name (`my-app-1.0-SNAPSHOT.jar`), regardless of `-DuniqueVersion` or the repository's *Maven Snapshot Version Behavior*. This diverges from native Maven 3, which only produces unique timestamped snapshots. Customers forced onto the extractor flow (e.g. a `maven.yaml` present, which pins the extractor even with `JFROG_RUN_NATIVE=true`) could not get timestamped snapshots without workarounds.

### Fix
Reproduce Maven 3's snapshot naming from inside the extractor:

- **`SnapshotVersionResolver`** builds `<base>-<yyyyMMdd.HHmmss>-<buildNumber>` from one session-wide UTC timestamp, with the build number read from the repository's snapshot `maven-metadata.xml` (falls back to `1` when unreadable, keeping the timestamp). The result is cached per `group:artifactId:version`, so a module's jar / pom / attached artifacts all share one version.
- **`BuildInfoRecorder`** resolves the deployed version when collecting artifacts and threads it through the artifact name and deployment path. The directory stays at the `-SNAPSHOT` path, so snapshot-repo routing is unchanged; only the file name carries the timestamp.
- **Defaults to unique** (matching Maven 3). Honors the deploy plugin's own `-DuniqueVersion=false` to opt out, or the publisher's new `snapshot.unique` configuration when there is no command line to set it on.
- Adds the `snapshot.unique` client-configuration field (default `true`).

### Tests
`SnapshotVersionResolverTest` covers release passthrough, the `uniqueVersion=false` opt-out, first deployment, build-number-from-metadata, and one shared version across a module. `:build-info-extractor-maven3:test` is green.

### Verification
Verified end-to-end through the real `jf mvn` CLI against Artifactory, using a snapshot repo in **Deployer** mode:

| Scenario | Deployed name |
|---|---|
| Released `2.43.9` jar (before) | `my-app-1.0-SNAPSHOT.jar` |
| Fixed jar, default | `my-app-1.0-20260906.073650-1.jar` |
| Fixed jar, `-DuniqueVersion=false` | `my-app-1.0-SNAPSHOT.jar` |

### Downstream follow-up
After this is released, bump `MavenExtractorDependencyVersion` in `build-info-go` (`build/maven.go`) so `jf mvn` downloads the fixed extractor.
