### PR TITLE
Add GitHub Actions release/snapshot workflows (JFrog Pipelines EOL migration)

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Runs the build-info release flow: configures git identity and the JFrog CLI,
+# optionally runs a JFrog audit, bumps the release version and tags it, builds
+# and publishes to Artifactory, publishes build-info, distributes the release
+# bundle, publishes to Maven Central, and bumps the next development version.
+#
+# Runnable both from GitHub Actions (release.yml) and directly on a
+# developer's machine - export the env vars below and run this script from
+# the repository root, on the branch/checkout you want to release from.
+#
+# Expected environment variables:
+#   NEXT_VERSION                     - e.g. 2.44.0
+#   NEXT_DEVELOPMENT_VERSION         - e.g. 2.44.x-SNAPSHOT
+#   NEXT_GRADLE_VERSION              - e.g. 4.36.0
+#   NEXT_GRADLE_DEVELOPMENT_VERSION  - e.g. 4.36.x-SNAPSHOT
+#   ARTIFACTORY_URL
+#   ARTIFACTORY_USER
+#   ARTIFACTORY_APIKEY
+#   MVN_CENTRAL_USER
+#   MVN_CENTRAL_PASSWORD
+#   MVN_CENTRAL_SIGNING_KEY          - base64-encoded GPG signing key
+#   MVN_CENTRAL_SIGNING_PASSWORD
+#   SKIP_AUDIT_CHECK                 - optional, "true" to skip the jf audit step (default: "false")
+set -euo pipefail
+
+git config user.name "JFrog CI"
+git config user.email "eco-system@jfrog.com"
+
+jf c rm --quiet
+jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
+jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-release-local
+
+if [[ "${SKIP_AUDIT_CHECK:-false}" != "true" ]]; then
+  jf audit --fail=false
+fi
+
+sed -i -e "/build-info-version=/ s/=.*/=$NEXT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_VERSION/" gradle.properties
+git commit -am "[artifactory-release] Release version ${NEXT_VERSION} [skipRun]" --allow-empty
+git tag build-info-extractor-${NEXT_VERSION}
+git tag build-info-gradle-extractor-${NEXT_GRADLE_VERSION}
+git push
+git push --tags
+
+export ORG_GRADLE_PROJECT_signingKey=$(echo "$MVN_CENTRAL_SIGNING_KEY" | base64 -d)
+export ORG_GRADLE_PROJECT_signingPassword="$MVN_CENTRAL_SIGNING_PASSWORD"
+jf gradle clean aP -x test -Psign
+
+jf rt bag && jf rt bce
+jf rt bp
+
+jf ds rbc ecosystem-build-info $NEXT_VERSION --spec=./release/specs/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION;gradleVersion=$NEXT_GRADLE_VERSION" --sign
+jf ds rbd ecosystem-build-info $NEXT_VERSION --site="releases.jfrog.io" --sync
+
+export ORG_GRADLE_PROJECT_sonatypeUsername="$MVN_CENTRAL_USER"
+export ORG_GRADLE_PROJECT_sonatypePassword="$MVN_CENTRAL_PASSWORD"
+export ORG_GRADLE_PROJECT_signingKey=$(echo "$MVN_CENTRAL_SIGNING_KEY" | base64 -d)
+export ORG_GRADLE_PROJECT_signingPassword="$MVN_CENTRAL_SIGNING_PASSWORD"
+./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository -x test -Psign
+
+sed -i -e "/build-info-version=/ s/=.*/=$NEXT_DEVELOPMENT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_DEVELOPMENT_VERSION/" gradle.properties
+git commit -am "[artifactory-release] Next development version [skipRun]"
+git push

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -27,7 +27,7 @@ git config user.name "JFrog CI"
 git config user.email "eco-system@jfrog.com"
 
 jf c rm --quiet
-jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
+jf c add internal --url="$ARTIFACTORY_URL" --access-token="$ARTIFACTORY_APIKEY"
 jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-release-local
 
 if [[ "${SKIP_AUDIT_CHECK:-false}" != "true" ]]; then

--- a/.github/scripts/snapshot.sh
+++ b/.github/scripts/snapshot.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 jf c rm --quiet
-jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
+jf c add internal --url="$ARTIFACTORY_URL" --access-token="$ARTIFACTORY_APIKEY"
 jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-snapshot-local
 
 jf audit --fail=false

--- a/.github/scripts/snapshot.sh
+++ b/.github/scripts/snapshot.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Runs the build-info snapshot flow: configures the JFrog CLI, runs a JFrog
+# audit, deletes former snapshot artifacts, builds and publishes to
+# Artifactory, publishes build-info, and distributes the snapshot release
+# bundle.
+#
+# Runnable both from GitHub Actions (snapshot.yml) and directly on a
+# developer's machine - export the env vars below and run this script from
+# the repository root.
+#
+# Expected environment variables:
+#   ARTIFACTORY_URL
+#   ARTIFACTORY_USER
+#   ARTIFACTORY_APIKEY
+#   RUN_NUMBER  - unique build/run number used to tag the snapshot bundle (e.g. GitHub Actions run_number)
+set -euo pipefail
+
+jf c rm --quiet
+jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
+jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-snapshot-local
+
+jf audit --fail=false
+
+# Delete former snapshots to make sure the release bundle will not contain stale artifacts
+jf rt del "ecosys-oss-snapshot-local/org/jfrog/buildinfo/*" --quiet
+
+jf gradle clean aP -x test
+
+jf rt bag && jf rt bce
+jf rt bp
+
+jf ds rbc ecosystem-build-info-snapshot "$RUN_NUMBER" --spec=./release/specs/dev-rbc-filespec.json --sign
+jf ds rbd ecosystem-build-info-snapshot "$RUN_NUMBER" --site="releases.jfrog.io" --sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,71 +51,17 @@ jobs:
           java-version: "8"
           distribution: "zulu"
 
-      - name: Configure git identity
-        run: |
-          git config user.name "JFrog CI"
-          git config user.email "eco-system@jfrog.com"
-
       - name: Setup JFrog CLI
         uses: jfrog/setup-jfrog-cli@v4
 
-      - name: Configure JFrog CLI
-        run: |
-          jf c rm --quiet
-          jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
-          jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-release-local
+      - name: Run release script
+        run: .github/scripts/release.sh
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
-
-      - name: Run audit
-        if: ${{ inputs.skip_audit_check != true }}
-        run: jf audit --fail=false
-
-      - name: Update release version and tag
-        run: |
-          sed -i -e "/build-info-version=/ s/=.*/=$NEXT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_VERSION/" gradle.properties
-          git commit -am "[artifactory-release] Release version ${NEXT_VERSION} [skipRun]" --allow-empty
-          git tag build-info-extractor-${NEXT_VERSION}
-          git tag build-info-gradle-extractor-${NEXT_GRADLE_VERSION}
-          git push
-          git push --tags
-
-      - name: Build and publish to Artifactory
-        run: |
-          export ORG_GRADLE_PROJECT_signingKey=$(echo "$MVN_CENTRAL_SIGNING_KEY" | base64 -d)
-          export ORG_GRADLE_PROJECT_signingPassword="$MVN_CENTRAL_SIGNING_PASSWORD"
-          jf gradle clean aP -x test -Psign
-        env:
-          MVN_CENTRAL_SIGNING_KEY: ${{ secrets.MVN_CENTRAL_SIGNING_KEY }}
-          MVN_CENTRAL_SIGNING_PASSWORD: ${{ secrets.MVN_CENTRAL_SIGNING_PASSWORD }}
-
-      - name: Publish build info
-        run: |
-          jf rt bag && jf rt bce
-          jf rt bp
-
-      - name: Distribute release bundle
-        run: |
-          jf ds rbc ecosystem-build-info $NEXT_VERSION --spec=./release/specs/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION;gradleVersion=$NEXT_GRADLE_VERSION" --sign
-          jf ds rbd ecosystem-build-info $NEXT_VERSION --site="releases.jfrog.io" --sync
-
-      - name: Publish to Maven Central
-        run: |
-          export ORG_GRADLE_PROJECT_sonatypeUsername="$MVN_CENTRAL_USER"
-          export ORG_GRADLE_PROJECT_sonatypePassword="$MVN_CENTRAL_PASSWORD"
-          export ORG_GRADLE_PROJECT_signingKey=$(echo "$MVN_CENTRAL_SIGNING_KEY" | base64 -d)
-          export ORG_GRADLE_PROJECT_signingPassword="$MVN_CENTRAL_SIGNING_PASSWORD"
-          ./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository -x test -Psign
-        env:
           MVN_CENTRAL_USER: ${{ secrets.MVN_CENTRAL_USER }}
           MVN_CENTRAL_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
           MVN_CENTRAL_SIGNING_KEY: ${{ secrets.MVN_CENTRAL_SIGNING_KEY }}
           MVN_CENTRAL_SIGNING_PASSWORD: ${{ secrets.MVN_CENTRAL_SIGNING_PASSWORD }}
-
-      - name: Update next development version
-        run: |
-          sed -i -e "/build-info-version=/ s/=.*/=$NEXT_DEVELOPMENT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_DEVELOPMENT_VERSION/" gradle.properties
-          git commit -am "[artifactory-release] Next development version [skipRun]"
-          git push
+          SKIP_AUDIT_CHECK: ${{ inputs.skip_audit_check }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: Release Build Info
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: "Next build-info release version (e.g. 2.44.0)"
+        required: true
+      next_development_version:
+        description: "Next build-info development version (e.g. 2.44.x-SNAPSHOT)"
+        required: true
+      next_gradle_version:
+        description: "Next build-info-extractor-gradle release version (e.g. 4.36.0)"
+        required: true
+      next_gradle_development_version:
+        description: "Next build-info-extractor-gradle development version (e.g. 4.36.x-SNAPSHOT)"
+        required: true
+      skip_audit_check:
+        description: "Skip the jf audit check"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  CI: true
+  JFROG_BUILD_STATUS: PASS
+  JFROG_CLI_BUILD_NAME: ecosystem-build-info-release
+  JFROG_CLI_BUILD_NUMBER: ${{ github.run_number }}
+  JFROG_CLI_BUILD_PROJECT: ecosys
+  NEXT_VERSION: ${{ inputs.next_version }}
+  NEXT_DEVELOPMENT_VERSION: ${{ inputs.next_development_version }}
+  NEXT_GRADLE_VERSION: ${{ inputs.next_gradle_version }}
+  NEXT_GRADLE_DEVELOPMENT_VERSION: ${{ inputs.next_gradle_development_version }}
+
+permissions:
+  contents: write
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v3
+        with:
+          ref: master
+          token: ${{ secrets.IL_AUTOMATION_TOKEN }}
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "8"
+          distribution: "zulu"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "JFrog CI"
+          git config user.email "eco-system@jfrog.com"
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+
+      - name: Configure JFrog CLI
+        run: |
+          jf c rm --quiet
+          jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
+          jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-release-local
+        env:
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+
+      - name: Run audit
+        if: ${{ inputs.skip_audit_check != true }}
+        run: jf audit --fail=false
+
+      - name: Update release version and tag
+        run: |
+          sed -i -e "/build-info-version=/ s/=.*/=$NEXT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_VERSION/" gradle.properties
+          git commit -am "[artifactory-release] Release version ${NEXT_VERSION} [skipRun]" --allow-empty
+          git tag build-info-extractor-${NEXT_VERSION}
+          git tag build-info-gradle-extractor-${NEXT_GRADLE_VERSION}
+          git push
+          git push --tags
+
+      - name: Build and publish to Artifactory
+        run: |
+          export ORG_GRADLE_PROJECT_signingKey=$(echo "$MVN_CENTRAL_SIGNING_KEY" | base64 -d)
+          export ORG_GRADLE_PROJECT_signingPassword="$MVN_CENTRAL_SIGNING_PASSWORD"
+          jf gradle clean aP -x test -Psign
+        env:
+          MVN_CENTRAL_SIGNING_KEY: ${{ secrets.MVN_CENTRAL_SIGNING_KEY }}
+          MVN_CENTRAL_SIGNING_PASSWORD: ${{ secrets.MVN_CENTRAL_SIGNING_PASSWORD }}
+
+      - name: Publish build info
+        run: |
+          jf rt bag && jf rt bce
+          jf rt bp
+
+      - name: Distribute release bundle
+        run: |
+          jf ds rbc ecosystem-build-info $NEXT_VERSION --spec=./release/specs/prod-rbc-filespec.json --spec-vars="version=$NEXT_VERSION;gradleVersion=$NEXT_GRADLE_VERSION" --sign
+          jf ds rbd ecosystem-build-info $NEXT_VERSION --site="releases.jfrog.io" --sync
+
+      - name: Publish to Maven Central
+        run: |
+          export ORG_GRADLE_PROJECT_sonatypeUsername="$MVN_CENTRAL_USER"
+          export ORG_GRADLE_PROJECT_sonatypePassword="$MVN_CENTRAL_PASSWORD"
+          export ORG_GRADLE_PROJECT_signingKey=$(echo "$MVN_CENTRAL_SIGNING_KEY" | base64 -d)
+          export ORG_GRADLE_PROJECT_signingPassword="$MVN_CENTRAL_SIGNING_PASSWORD"
+          ./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository -x test -Psign
+        env:
+          MVN_CENTRAL_USER: ${{ secrets.MVN_CENTRAL_USER }}
+          MVN_CENTRAL_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
+          MVN_CENTRAL_SIGNING_KEY: ${{ secrets.MVN_CENTRAL_SIGNING_KEY }}
+          MVN_CENTRAL_SIGNING_PASSWORD: ${{ secrets.MVN_CENTRAL_SIGNING_PASSWORD }}
+
+      - name: Update next development version
+        run: |
+          sed -i -e "/build-info-version=/ s/=.*/=$NEXT_DEVELOPMENT_VERSION/" -e "/build-info-extractor-gradle-version=/ s/=.*/=$NEXT_GRADLE_DEVELOPMENT_VERSION/" gradle.properties
+          git commit -am "[artifactory-release] Next development version [skipRun]"
+          git push

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,32 +37,10 @@ jobs:
       - name: Setup JFrog CLI
         uses: jfrog/setup-jfrog-cli@v4
 
-      - name: Configure JFrog CLI
-        run: |
-          jf c rm --quiet
-          jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
-          jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-snapshot-local
+      - name: Run snapshot script
+        run: .github/scripts/snapshot.sh
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
-
-      - name: Run audit
-        run: jf audit --fail=false
-
-      # Delete former snapshots to make sure the release bundle will not contain stale artifacts
-      - name: Delete former snapshots
-        run: jf rt del "ecosys-oss-snapshot-local/org/jfrog/buildinfo/*" --quiet
-
-      - name: Build and publish to Artifactory
-        run: jf gradle clean aP -x test
-
-      - name: Publish build info
-        run: |
-          jf rt bag && jf rt bce
-          jf rt bp
-
-      - name: Distribute release bundle
-        run: |
-          jf ds rbc ecosystem-build-info-snapshot ${{ github.run_number }} --spec=./release/specs/dev-rbc-filespec.json --sign
-          jf ds rbd ecosystem-build-info-snapshot ${{ github.run_number }} --site="releases.jfrog.io" --sync
+          RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,68 @@
+name: Snapshot Build Info
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  CI: true
+  JFROG_BUILD_STATUS: PASS
+  JFROG_CLI_BUILD_NAME: ecosystem-build-info-dev
+  JFROG_CLI_BUILD_NUMBER: ${{ github.run_number }}
+  JFROG_CLI_BUILD_PROJECT: ecosys
+
+jobs:
+  Snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "8"
+          distribution: "zulu"
+
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: .gradle
+          key: ${{ runner.os }}-gradle-snapshot-${{ hashFiles('**/*.gradle', 'gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-snapshot-
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+
+      - name: Configure JFrog CLI
+        run: |
+          jf c rm --quiet
+          jf c add internal --url="$ARTIFACTORY_URL" --user="$ARTIFACTORY_USER" --password="$ARTIFACTORY_APIKEY"
+          jf gradlec --use-wrapper --uses-plugin --repo-resolve ecosys-maven-remote --repo-deploy ecosys-oss-snapshot-local
+        env:
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+
+      - name: Run audit
+        run: jf audit --fail=false
+
+      # Delete former snapshots to make sure the release bundle will not contain stale artifacts
+      - name: Delete former snapshots
+        run: jf rt del "ecosys-oss-snapshot-local/org/jfrog/buildinfo/*" --quiet
+
+      - name: Build and publish to Artifactory
+        run: jf gradle clean aP -x test
+
+      - name: Publish build info
+        run: |
+          jf rt bag && jf rt bce
+          jf rt bp
+
+      - name: Distribute release bundle
+        run: |
+          jf ds rbc ecosystem-build-info-snapshot ${{ github.run_number }} --spec=./release/specs/dev-rbc-filespec.json --sign
+          jf ds rbd ecosystem-build-info-snapshot ${{ github.run_number }} --site="releases.jfrog.io" --sync


### PR DESCRIPTION
## Summary

Ports the two JFrog Pipelines defined in `release/pipelines.release.yml` and `release/pipelines.snapshot.yml` to GitHub Actions, ahead of JFrog Pipelines EOL:

- `.github/workflows/release.yml` — ports `release_build_info`. Triggered manually via `workflow_dispatch`, with one required input per version variable the pipeline needed (`next_version`, `next_development_version`, `next_gradle_version`, `next_gradle_development_version`) plus a `skip_audit_check` boolean. Publishes to Artifactory, distributes the release bundle, and publishes to Maven Central (`mvn_central` integration), then bumps to the next development version — same sequence of steps as the original pipeline.
- `.github/workflows/snapshot.yml` — ports `create_build_info_snapshot`. Triggers on `push` to `master` (the branch the `biSnapshotGit` GitRepo resource tracks) plus `workflow_dispatch`, and publishes a snapshot build to Artifactory the same way the pipeline did.

## Deliberate behavior changes

- **JFrog CLI install**: uses `jfrog/setup-jfrog-cli@v4` instead of `curl -fL https://install-cli.jfrog.io | sh`. This is the one intentional behavior change called out per migration guidance.
- Dropped the `env -i PATH=$PATH HOME=$HOME ...` environment-wiping wrapper around `jf gradle` in the snapshot pipeline — that was a workaround specific to the old custom Pipelines Docker image and isn't needed on `ubuntu-latest`.

## Judgment calls

- **Git identity for commits**: the release pipeline ran `git commit` without ever configuring `user.name`/`user.email`, relying on whatever default identity the JFrog Pipelines runtime image had baked in. GitHub-hosted runners have no such default, so the workflow now explicitly sets `git config user.name "JFrog CI"` / `user.email "eco-system@jfrog.com"` before committing. Happy to change this identity if there's a preferred bot account/email.
- **Git push auth**: instead of the original `git remote set-url origin https://$TOKEN@github.com/...` (which embeds the token in `.git/config` in plaintext), the workflow passes `IL_AUTOMATION_TOKEN` as the `token:` input to `actions/checkout`, which configures git auth via an `http.extraheader`. Same effective permission, safer handling of the secret.
- **Version inputs are `required: true` with no default**: this replaces the pipeline's runtime guard (`test -n "$NEXT_VERSION" -a "$NEXT_VERSION" != "2.0.0"`, etc.) that checked the version envs had been overridden from their placeholder defaults — `workflow_dispatch` required inputs enforce the same "you must supply real values" behavior natively.
- **Gradle cache**: mapped the pipeline's `restore_cache_files`/`add_cache_files` (caching `.gradle` in the resource's checkout dir) to `actions/cache@v3` on the same relative `.gradle` path, keyed off `hashFiles('**/*.gradle', 'gradle.properties')`.
- Matched the more current house style already used across most jobs in `integrationTests.yml` (`actions/checkout@v3`, `actions/setup-java@v3` with `distribution: zulu`, Java 8) rather than the older `actions/setup-java@v2`/`adopt` pattern used only in the standalone `gradle.yml` (Gradle Gallery) workflow.

## Required secrets (exact names)

| JFrog Pipelines integration | GitHub secret name(s) |
|---|---|
| `il_automation` | `IL_AUTOMATION_TOKEN` |
| `ecosys_entplus_deployer` | `ARTIFACTORY_URL`, `ARTIFACTORY_USER`, `ARTIFACTORY_APIKEY` |
| `mvn_central` | `MVN_CENTRAL_USER`, `MVN_CENTRAL_PASSWORD`, `MVN_CENTRAL_SIGNING_KEY`, `MVN_CENTRAL_SIGNING_PASSWORD` |

`MVN_CENTRAL_SIGNING_KEY` is expected to hold the same base64-encoded GPG signing key value the pipeline's `int_mvn_central_signingKey` held — the workflow base64-decodes it at run time, same as the original pipeline did.

Not run yet — needs secrets added first.
