### PR TITLE
Fix --insecure-tls to actually cover Maven's own artifact resolution

### DIFF
--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/ArtifactoryProjectBuilder.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/ArtifactoryProjectBuilder.java
@@ -12,7 +12,13 @@ import org.jfrog.build.extractor.maven.resolver.ArtifactoryPluginResolution;
 import org.jfrog.build.extractor.maven.resolver.ResolutionHelper;
 
 import javax.inject.Named;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.File;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -26,6 +32,11 @@ public class ArtifactoryProjectBuilder extends DefaultProjectBuilder {
     @Requirement
     private ResolutionHelper resolutionHelper;
 
+    // Guards installIfNeeded() so the permissive SSLContext/HostnameVerifier
+    // below is installed at most once per JVM, regardless of how many times
+    // build() runs (e.g. a multi-module reactor calls it once per module).
+    private static volatile boolean insecureTlsInstalled = false;
+
     @Override
     public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive, ProjectBuildingRequest request) throws ProjectBuildingException {
         if (Boolean.parseBoolean(System.getProperties().getProperty(PROP_ARTIFACTORY_RESOLUTION_ENABLED))
@@ -36,6 +47,7 @@ public class ArtifactoryProjectBuilder extends DefaultProjectBuilder {
                 allMavenProps.putAll(request.getUserProperties());
                 resolutionHelper.init(allMavenProps);
             }
+            installInsecureTlsIfNeeded();
 
             // We're setting the resolver repositories to the list of repositories.
             // This repository replaces the central repository.
@@ -45,6 +57,52 @@ public class ArtifactoryProjectBuilder extends DefaultProjectBuilder {
             request.setPluginArtifactRepositories(repositories);
         }
         return super.build(pomFiles, recursive, request);
+    }
+
+    // --insecure-tls previously only applied to jfrog-cli's own build-info
+    // upload client (ArtifactoryManagerBuilder#resolveInsecureTls) - it never
+    // affected Maven's OWN artifact resolution, so plugins/dependencies
+    // resolved through the artifactory-release/artifactory-snapshot
+    // repositories above still failed PKIX validation against a self-signed
+    // or otherwise untrusted cert even with the flag set. Maven's resolver
+    // has no per-repository "skip TLS validation" hook in its public API, so
+    // this installs a permissive default SSLContext/HostnameVerifier for the
+    // whole JVM instead - blunt, but --insecure-tls is itself a deliberate,
+    // opt-in "trust everything" escape hatch, and this is version-agnostic
+    // across whichever HTTP transport a given Maven version bundles (legacy
+    // wagon-http or the newer maven-resolver-transport implementations all
+    // ultimately go through the JDK's javax.net.ssl default context).
+    private void installInsecureTlsIfNeeded() {
+        if (insecureTlsInstalled || !resolutionHelper.isInsecureTls()) {
+            return;
+        }
+        synchronized (ArtifactoryProjectBuilder.class) {
+            if (insecureTlsInstalled) {
+                return;
+            }
+            try {
+                TrustManager[] trustAllCerts = new TrustManager[]{
+                        new X509TrustManager() {
+                            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                            }
+
+                            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                            }
+
+                            public X509Certificate[] getAcceptedIssuers() {
+                                return new X509Certificate[0];
+                            }
+                        }
+                };
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, trustAllCerts, new SecureRandom());
+                HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+                HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
+                insecureTlsInstalled = true;
+            } catch (Exception e) {
+                resolutionHelper.getLogger().warn("Failed to install insecure TLS context for Maven artifact resolution: " + e.getMessage());
+            }
+        }
     }
 
     private List<ArtifactRepository> getRepositories() {

--- a/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ResolutionHelper.java
+++ b/build-info-extractor-maven3/src/main/java/org/jfrog/build/extractor/maven/resolver/ResolutionHelper.java
@@ -38,6 +38,10 @@ public class ResolutionHelper {
         return initialized;
     }
 
+    public boolean isInsecureTls() {
+        return internalConfiguration.getInsecureTls();
+    }
+
     /**
      * Determines a deployed artifact's scope (either "project" or "build") according to the maven's request context sent as an argument.
      * @param requestContext    The deployed artifact's request context.


### PR DESCRIPTION
## Summary
`--insecure-tls` in jfrog-cli only ever configured jfrog-cli's own build-info upload client (`ArtifactoryManagerBuilder#resolveInsecureTls`) to skip TLS validation. It never affected Maven's own artifact resolution transport - the repositories `ArtifactoryProjectBuilder` injects for plugin/dependency resolution (`artifactory-release`/`artifactory-snapshot`) were always constructed with default (strict) TLS validation, regardless of the flag.

## Risk assessment - why this should not affect existing customers
This is a behavior change gated entirely behind an opt-in flag most customers never set. Specifically:

- `installInsecureTlsIfNeeded()`'s very first line is `if (insecureTlsInstalled || !resolutionHelper.isInsecureTls()) return;`. For any build that does **not** pass `--insecure-tls` - which is the default, and almost certainly the overwhelming majority of real usage, since this flag exists specifically to disable TLS validation for testing/self-signed-cert scenarios - this method executes **zero new code, allocates nothing, and touches no global JVM state**. The existing, secure-by-default path is completely unmodified.
- For the subset of builds that **do** pass `--insecure-tls` today: this doesn't remove or weaken anything that previously worked. It makes the flag's own already-documented, already-tested intent (see `TestInsecureTlsMavenBuild`, which asserts the whole `mvn` invocation should succeed with the flag) actually hold true for Maven's own resolution, not just the build-info upload client. There's no plausible existing workflow that depends on Maven's resolution *still* rejecting certs while `--insecure-tls` is set.
- If `SSLContext.getInstance("TLS")`/`.init(...)` were ever to throw (not expected - "TLS" is a guaranteed-available algorithm per the Java spec on any real JVM), the exception is caught and logged as a warning, not propagated - the build falls back to the prior strict behavior rather than failing in a new way.
- The installed state (`insecureTlsInstalled`) is a static flag scoped to the JVM process running one `mvn` invocation. Standard Maven CLI usage is non-daemon (unlike Gradle) - each invocation is its own fresh JVM - so this cannot leak across builds or between customers.

## Root cause
Traced this from real jfrog-cli CI logs, not assumption: `TestInsecureTlsMavenBuild` runs a Maven build behind a self-signed-cert reverse proxy with `--insecure-tls` and expects success on the second run. It still fails - Maven's own plugin resolution (fetching `maven-clean-plugin` etc.) rejects the cert with a PKIX validation error even though the flag is set. This is a real, current cause of a large chunk of jfrog-cli's maven-3.9.x compatibility failures.

## Fix
Maven's resolver API has no per-repository "skip TLS validation" hook, and the affected HTTP transport differs across Maven versions (legacy wagon-http vs newer maven-resolver-transport implementations). So this installs a permissive default `SSLContext`/`HostnameVerifier` for the whole JVM instead - blunt, but `--insecure-tls` is itself a deliberate, opt-in "trust everything" escape hatch, and a JVM-wide default is version-agnostic since every HTTP transport ultimately goes through the JDK's `javax.net.ssl` default context.

Installed once per JVM (`volatile` + `synchronized` guard against multi-module reactor builds calling `build()` repeatedly), only when `--insecure-tls` is actually set, at the same lifecycle point (`ArtifactoryProjectBuilder.build()`) that already customizes Maven's resolution behavior.

## Compatibility impact
No exported API changed. `ResolutionHelper` gains one new method (`isInsecureTls()`); `ArtifactoryProjectBuilder` gains one new private method. Nothing changes when `--insecure-tls` isn't set.

## Verification
- Reproduced the exact failure and the exact fix in a standalone Java program: a real self-signed cert + local `HttpsServer`, confirmed the connection fails with `PKIX path building failed / SunCertPathBuilderException` (matching the real CI failure verbatim) without the override, and succeeds with it.
- Every API used (`X509TrustManager`, `HostnameVerifier`, `HttpsURLConnection` static setters, `Logger.warn(String)`, `ArtifactoryClientConfiguration.getInsecureTls()`) verified against decompiled/fetched real sources - not assumed from memory.
- **Honest limitation**: could not get a full module compile in my environment - a network policy here blocks Gradle's direct Maven Central resolution. A targeted `javac` compile of these two files plus their direct dependencies reported **zero errors against this code** - every error surfaced was in unrelated, untouched code (e.g. `ArtifactoryClientConfiguration`'s NPM/build-info-handler imports) needing external jars this environment can't fetch, not in the actual diff.
- Real end-to-end confirmation should come from a maintainer running this module's own test suite plus `TestInsecureTlsMavenBuild` in jfrog-cli-workflows' CI before merging.